### PR TITLE
Add configurable decimal display for aura countdowns

### DIFF
--- a/DandersFrames_Auras.lua
+++ b/DandersFrames_Auras.lua
@@ -36,7 +36,7 @@ function DF:ApplyAuraLayout(frame)
 
     -- Parse "PRIMARY_SECONDARY" growth strings (e.g., "LEFT_DOWN")
     -- Added stackFont argument and countdown arguments
-    local function ApplyLayout(auraFrames, scale, alpha, anchor, growthString, limit, offX, offY, maxCount, clickThrough, stackScale, stackAnchor, stackX, stackY, stackOutline, stackFont, showCountdown, countdownScale, countdownFont, countdownOutline, countdownX, countdownY, hideSwipe)
+    local function ApplyLayout(auraFrames, scale, alpha, anchor, growthString, limit, offX, offY, maxCount, clickThrough, stackScale, stackAnchor, stackX, stackY, stackOutline, stackFont, showCountdown, countdownScale, countdownFont, countdownOutline, countdownX, countdownY, countdownDecimalMode, hideSwipe)
         if not auraFrames then return end
         
         -- Split growth direction string
@@ -143,7 +143,7 @@ function DF:ApplyAuraLayout(frame)
                                 -- Use our stored values instead of API calls
                                 if cd and cd:IsShown() and cd.dfStart and cd.dfDuration and cd.dfDuration > 0 then
                                     local remaining = (cd.dfStart + cd.dfDuration) - GetTime()
-                                    
+
                                     if remaining > 0.5 then
                                         if remaining >= 3600 then
                                             text:SetText(math.floor(remaining / 3600) .. "h")
@@ -154,7 +154,11 @@ function DF:ApplyAuraLayout(frame)
                                         elseif remaining >= 3 then
                                             text:SetFormattedText("%.0f", remaining)
                                         else
-                                            text:SetFormattedText("%.1f", remaining)
+                                            if countdownDecimalMode == "WHOLE" then
+                                                text:SetFormattedText("%.0f", remaining)
+                                            else
+                                                text:SetFormattedText("%.1f", remaining)
+                                            end
                                         end
                                         text:Show()
                                     else
@@ -261,6 +265,7 @@ function DF:ApplyAuraLayout(frame)
         db.raidBuffCountdownOutline,
         db.raidBuffCountdownX,
         db.raidBuffCountdownY,
+        db.raidBuffCountdownDecimalMode,
         db.raidBuffHideSwipe
     )
 
@@ -288,6 +293,7 @@ function DF:ApplyAuraLayout(frame)
         db.raidDebuffCountdownOutline,
         db.raidDebuffCountdownX,
         db.raidDebuffCountdownY,
+        db.raidDebuffCountdownDecimalMode,
         db.raidDebuffHideSwipe
     )
 end

--- a/DandersFrames_Config.lua
+++ b/DandersFrames_Config.lua
@@ -214,6 +214,7 @@ DF.PartyDefaults = {
     raidBuffCountdownOutline = "OUTLINE",
     raidBuffCountdownX = 0,
     raidBuffCountdownY = 0,
+    raidBuffCountdownDecimalMode = "TENTHS",
     raidBuffHideSwipe = false,
 
     -- Debuffs
@@ -239,6 +240,7 @@ DF.PartyDefaults = {
     raidDebuffCountdownOutline = "OUTLINE",
     raidDebuffCountdownX = 0,
     raidDebuffCountdownY = 0,
+    raidDebuffCountdownDecimalMode = "TENTHS",
     raidDebuffHideSwipe = false,
     
     -- Dispel Toggles
@@ -446,6 +448,7 @@ DF.RaidDefaults = {
     raidBuffCountdownOutline = "OUTLINE",
     raidBuffCountdownX = 0,
     raidBuffCountdownY = 0,
+    raidBuffCountdownDecimalMode = "TENTHS",
     raidBuffHideSwipe = false,
 
     -- Debuffs
@@ -471,6 +474,7 @@ DF.RaidDefaults = {
     raidDebuffCountdownOutline = "OUTLINE",
     raidDebuffCountdownX = 0,
     raidDebuffCountdownY = 0,
+    raidDebuffCountdownDecimalMode = "TENTHS",
     raidDebuffHideSwipe = false,
     
     -- Dispel Toggles

--- a/DandersFrames_Options.lua
+++ b/DandersFrames_Options.lua
@@ -341,6 +341,10 @@ function DF:SetupGUIPages(GUI, CreateTab, BuildPage)
         bCdHeader.hideOn = function(d) return not d.showAdvancedBuffOptions end
         local bCountdown = Add(GUI:CreateCheckbox(self, "Show Countdown", db, "raidBuffShowCountdown"), 30, 1)
         bCountdown.hideOn = function(d) return not d.showAdvancedBuffOptions end
+        local countdownFormats = {
+            ["TENTHS"] = "Tenths (<3s)",
+            ["WHOLE"] = "Whole Seconds",
+        }
         local bCdScale = Add(GUI:CreateSlider(self, "Countdown Scale", 0.5, 2.0, 0.1, db, "raidBuffCountdownScale"), 60, 1)
         bCdScale.hideOn = function(d) return not d.showAdvancedBuffOptions or not d.raidBuffShowCountdown end
         local bCdFont = Add(GUI:CreateDropdown(self, "Countdown Font", DF:GetFontList(), db, "raidBuffCountdownFont"), 60, 1)
@@ -353,6 +357,8 @@ function DF:SetupGUIPages(GUI, CreateTab, BuildPage)
         bCdOffX.hideOn = function(d) return not d.showAdvancedBuffOptions or not d.raidBuffShowCountdown end
         local bCdOffY = Add(GUI:CreateSlider(self, "Countdown Y", -20, 20, 1, db, "raidBuffCountdownY"), 60, 1)
         bCdOffY.hideOn = function(d) return not d.showAdvancedBuffOptions or not d.raidBuffShowCountdown end
+        local bCdFormat = Add(GUI:CreateDropdown(self, "Countdown Decimals", countdownFormats, db, "raidBuffCountdownDecimalMode"), 60, 1)
+        bCdFormat.hideOn = function(d) return not d.showAdvancedBuffOptions or not d.raidBuffShowCountdown end
         local bHideSwipe = Add(GUI:CreateCheckbox(self, "Hide Cooldown Swipe", db, "raidBuffHideSwipe"), 30, 1)
         bHideSwipe.hideOn = function(d) return not d.showAdvancedBuffOptions end
         
@@ -414,6 +420,8 @@ function DF:SetupGUIPages(GUI, CreateTab, BuildPage)
         dCdOffX.hideOn = function(d) return not d.showAdvancedDebuffOptions or not d.raidDebuffShowCountdown end
         local dCdOffY = Add(GUI:CreateSlider(self, "Countdown Y", -20, 20, 1, db, "raidDebuffCountdownY"), 60, 2)
         dCdOffY.hideOn = function(d) return not d.showAdvancedDebuffOptions or not d.raidDebuffShowCountdown end
+        local dCdFormat = Add(GUI:CreateDropdown(self, "Countdown Decimals", countdownFormats, db, "raidDebuffCountdownDecimalMode"), 60, 2)
+        dCdFormat.hideOn = function(d) return not d.showAdvancedDebuffOptions or not d.raidDebuffShowCountdown end
         local dHideSwipe = Add(GUI:CreateCheckbox(self, "Hide Cooldown Swipe", db, "raidDebuffHideSwipe"), 30, 2)
         dHideSwipe.hideOn = function(d) return not d.showAdvancedDebuffOptions end
     end)


### PR DESCRIPTION
## Summary
- add profile defaults for selecting aura countdown decimal formatting per buff and debuff
- update countdown rendering to honor whole-second or tenths display modes
- expose new dropdowns in the options UI for choosing countdown decimal behavior

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d75133d10833288623c5c0e2fe7e0)