### PR TITLE
feat: Health-based fading — fade frames above configurable health threshold

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -891,6 +891,25 @@ DF.PartyDefaults = {
     fadeDeadStatusText = 1,
     fadeDeadUseCustomColor = false,
 
+    -- Health threshold fading (fade when health above threshold)
+    healthFadeEnabled = false,
+    healthFadeAlpha = 0.5,
+    healthFadeThreshold = 100,
+    hfCancelOnDispel = true,
+    hfElementSpecific = false,
+    hfHealthBarAlpha = 0.3,
+    hfBackgroundAlpha = 0.3,
+    hfNameTextAlpha = 0.5,
+    hfHealthTextAlpha = 0.5,
+    hfAurasAlpha = 0.5,
+    hfIconsAlpha = 0.5,
+    hfDispelOverlayAlpha = 0.3,
+    hfMyBuffIndicatorAlpha = 0.5,
+    hfPowerBarAlpha = 0.3,
+    hfMissingBuffAlpha = 0.5,
+    hfDefensiveIconAlpha = 0.5,
+    hfTargetedSpellAlpha = 0.5,
+
     -- Debuff settings
     debuffAlpha = 1,
     debuffAnchor = "BOTTOMLEFT",
@@ -1947,6 +1966,25 @@ DF.RaidDefaults = {
     fadeDeadPowerBar = 0,
     fadeDeadStatusText = 1,
     fadeDeadUseCustomColor = false,
+
+    -- Health threshold fading (fade when health above threshold)
+    healthFadeEnabled = false,
+    healthFadeAlpha = 0.5,
+    healthFadeThreshold = 100,
+    hfCancelOnDispel = true,
+    hfElementSpecific = false,
+    hfHealthBarAlpha = 0.3,
+    hfBackgroundAlpha = 0.3,
+    hfNameTextAlpha = 0.5,
+    hfHealthTextAlpha = 0.5,
+    hfAurasAlpha = 0.5,
+    hfIconsAlpha = 0.5,
+    hfDispelOverlayAlpha = 0.3,
+    hfMyBuffIndicatorAlpha = 0.5,
+    hfPowerBarAlpha = 0.3,
+    hfMissingBuffAlpha = 0.5,
+    hfDefensiveIconAlpha = 0.5,
+    hfTargetedSpellAlpha = 0.5,
 
     -- Debuff settings
     debuffAlpha = 1,

--- a/DandersFrames.toc
+++ b/DandersFrames.toc
@@ -60,6 +60,7 @@ Features\PrivateAuras.lua
 Features\Highlights.lua
 Features\ElementAppearance.lua
 Features\Range.lua
+Features\HealthFade.lua
 Features\Sort.lua
 Features\SecureSort.lua
 Features\Dispel.lua

--- a/Debug/PerformanceTest.lua
+++ b/Debug/PerformanceTest.lua
@@ -15,6 +15,7 @@ DF.PerfTest = {
     enableDefensive = true,
     enableMissingBuff = true,
     enableRange = true,
+    enableHealthFade = true,
     enableHighlights = true,
     enableHealPrediction = true,
     enableAbsorbs = true,
@@ -130,6 +131,7 @@ local function CreatePerfTestFrame()
     CreateCheckbox(frame, "Defensive Icon", "enableDefensive", col1X, yStart + (i * yStep)); i = i + 1
     CreateCheckbox(frame, "Missing Buff Icon", "enableMissingBuff", col1X, yStart + (i * yStep)); i = i + 1
     CreateCheckbox(frame, "Range Checking", "enableRange", col1X, yStart + (i * yStep)); i = i + 1
+    CreateCheckbox(frame, "Health Threshold Fade", "enableHealthFade", col1X, yStart + (i * yStep)); i = i + 1
     CreateCheckbox(frame, "Highlights (Target/Mouse)", "enableHighlights", col1X, yStart + (i * yStep)); i = i + 1
     CreateCheckbox(frame, "Heal Prediction", "enableHealPrediction", col1X, yStart + (i * yStep)); i = i + 1
     CreateCheckbox(frame, "Absorb Shields", "enableAbsorbs", col1X, yStart + (i * yStep)); i = i + 1

--- a/ExportCategories.lua
+++ b/ExportCategories.lua
@@ -837,6 +837,25 @@ DF.ExportCategories = {
         "hoverHighlightMode",
         "hoverHighlightThickness",
         
+        -- Health Threshold Fading
+        "healthFadeEnabled",
+        "healthFadeAlpha",
+        "healthFadeThreshold",
+        "hfCancelOnDispel",
+        "hfElementSpecific",
+        "hfHealthBarAlpha",
+        "hfBackgroundAlpha",
+        "hfNameTextAlpha",
+        "hfHealthTextAlpha",
+        "hfAurasAlpha",
+        "hfIconsAlpha",
+        "hfDispelOverlayAlpha",
+        "hfMyBuffIndicatorAlpha",
+        "hfPowerBarAlpha",
+        "hfMissingBuffAlpha",
+        "hfDefensiveIconAlpha",
+        "hfTargetedSpellAlpha",
+
         -- Out of Range
         "oorEnabled",
         "rangeAlpha",

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -12,8 +12,9 @@ local addonName, DF = ...
 -- Priority Order for determining appearance:
 -- 1. Aggro Override (health bar only)
 -- 2. Dead/Offline State
--- 3. Out of Range (OOR) - element-specific or frame-level
--- 4. Normal Settings
+-- 3. Health Threshold Fading (above configurable health threshold)
+-- 4. Out of Range (OOR) - element-specific or frame-level
+-- 5. Normal Settings
 --
 -- Integration Points:
 -- - Range timer (Range.lua) calls UpdateRangeAppearance every 0.2s
@@ -118,6 +119,16 @@ local function IsOffline(frame)
     return not UnitIsConnected(unit)
 end
 
+-- Check if unit is above health threshold (for health threshold fading)
+local function IsHealthFaded(frame)
+    return frame.dfIsHealthFaded == true
+end
+
+-- Check if health threshold fade is enabled
+local function IsHealthFadeEnabled(db)
+    return db and db.healthFadeEnabled
+end
+
 -- Get class color for a unit
 local function GetClassColor(frame)
     local unit = frame.unit
@@ -168,6 +179,8 @@ function DF:UpdateHealthBarAppearance(frame)
     
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadHealthBar or 1
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "healthBar")
     end
     
     -- ========================================
@@ -319,9 +332,10 @@ function DF:UpdateBackgroundAppearance(frame)
     -- ========================================
     local finalAlpha = baseAlpha
     
-    -- Dead fade ALWAYS affects alpha when enabled
     if deadOrOffline and db.fadeDeadFrames then
         finalAlpha = db.fadeDeadBackground or 1
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        finalAlpha = DF:GetHealthFadeAlpha(frame, "background")
     end
     
     -- ========================================
@@ -402,6 +416,8 @@ function DF:UpdateNameTextAppearance(frame)
     
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadName or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "nameText")
     end
     
     -- ========================================
@@ -458,6 +474,8 @@ function DF:UpdateHealthTextAppearance(frame)
     
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadHealthBar or 1  -- Health text follows health bar alpha
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "healthText")
     end
     
     -- ========================================
@@ -493,10 +511,11 @@ function DF:UpdateStatusTextAppearance(frame)
     local c = db.statusTextColor or DEFAULT_COLOR_WHITE
     local r, g, b = c.r, c.g, c.b
     
-    -- Alpha based on dead fade settings
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadStatusText or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "healthText")  -- status text uses same key as health text for health fade
     end
     
     frame.statusText:SetTextColor(r, g, b, alpha)
@@ -526,6 +545,8 @@ function DF:UpdatePowerBarAppearance(frame)
     
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadPowerBar or 0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "powerBar")
     end
     
     if db.oorEnabled then
@@ -556,6 +577,8 @@ function DF:UpdateBuffIconsAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadAuras or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "auras")
     end
     
     if db.oorEnabled then
@@ -595,6 +618,8 @@ function DF:UpdateDebuffIconsAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadAuras or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "auras")
     end
     
     if db.oorEnabled then
@@ -634,6 +659,8 @@ function DF:UpdateRoleIconAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadIcons or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "icons")
     end
     
     if db.oorEnabled then
@@ -659,6 +686,8 @@ function DF:UpdateLeaderIconAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadIcons or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "icons")
     end
     
     if db.oorEnabled then
@@ -684,6 +713,8 @@ function DF:UpdateRaidTargetIconAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadIcons or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "icons")
     end
     
     if db.oorEnabled then
@@ -709,6 +740,8 @@ function DF:UpdateReadyCheckIconAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadIcons or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "icons")
     end
     
     if db.oorEnabled then
@@ -734,6 +767,8 @@ function DF:UpdateCenterStatusIconAppearance(frame)
     local alpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
         alpha = db.fadeDeadIcons or 1.0
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "icons")
     end
     
     if db.oorEnabled then
@@ -757,27 +792,34 @@ function DF:UpdateDispelOverlayAppearance(frame)
     
     if DF.testMode or DF.raidTestMode then return end
     
+    local deadOrOffline = IsDeadOrOffline(frame)
     local inRange = GetInRange(frame)
+    local overlay = frame.dfDispelOverlay
+    local alpha = 1.0
+    if deadOrOffline and db.fadeDeadFrames then
+        alpha = db.fadeDeadBackground or 1
+    elseif IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not deadOrOffline and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "dispelOverlay")
+    end
     
     if db.oorEnabled then
         local oorAlpha = db.oorDispelOverlayAlpha or 0.2
-        
-        -- PERF: Apply to elements directly without creating a table
-        local overlay = frame.dfDispelOverlay
-        ApplyOORAlpha(overlay.gradient, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(overlay.borderTop, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(overlay.borderBottom, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(overlay.borderLeft, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(overlay.borderRight, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(overlay.icon, inRange, 1.0, oorAlpha)
-        
-        -- For EDGE style, delegate to the dedicated function that re-applies SetGradient
+        ApplyOORAlpha(overlay.gradient, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.borderTop, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.borderBottom, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.borderLeft, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.borderRight, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.icon, inRange, alpha, oorAlpha)
         if DF.ApplyDispelOverlayAppearance then
             DF:ApplyDispelOverlayAppearance(frame)
         end
     else
-        -- Frame-level mode - dispel overlay follows frame alpha
-        if frame.dfDispelOverlay.gradient then frame.dfDispelOverlay.gradient:SetAlpha(1.0) end
+        if overlay.gradient then overlay.gradient:SetAlpha(alpha) end
+        if overlay.borderTop then overlay.borderTop:SetAlpha(alpha) end
+        if overlay.borderBottom then overlay.borderBottom:SetAlpha(alpha) end
+        if overlay.borderLeft then overlay.borderLeft:SetAlpha(alpha) end
+        if overlay.borderRight then overlay.borderRight:SetAlpha(alpha) end
+        if overlay.icon then overlay.icon:SetAlpha(alpha) end
     end
 end
 
@@ -786,10 +828,15 @@ end
 -- ============================================================
 
 function DF:UpdateMyBuffIndicatorAppearance(frame)
-    -- Delegate to the dedicated appearance function in MyBuffIndicators.lua
-    -- This ensures there's only ONE place that sets colors/alpha
     if DF.ApplyMyBuffIndicatorAppearance then
         DF:ApplyMyBuffIndicatorAppearance(frame)
+    end
+    local db = GetDB(frame)
+    if not db then return end
+    if DF.testMode or DF.raidTestMode then return end
+    if not frame.dfMyBuffOverlay or not frame.dfMyBuffOverlay:IsShown() then return end
+    if not db.oorEnabled and IsHealthFadeEnabled(db) and IsHealthFaded(frame) and db.hfElementSpecific then
+        frame.dfMyBuffOverlay:SetAlpha(DF:GetHealthFadeAlpha(frame, "myBuffIndicator"))
     end
 end
 
@@ -811,14 +858,24 @@ function DF:UpdateMissingBuffAppearance(frame)
     
     local inRange = GetInRange(frame)
     
+    local alpha = 1.0
+    if IsHealthFadeEnabled(db) and IsHealthFaded(frame) and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "missingBuff")
+    end
+    
     if db.oorEnabled then
         local oorAlpha = db.oorMissingBuffAlpha or 0.5
-        
-        ApplyOORAlpha(frame.missingBuffIcon, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(frame.missingBuffBorderLeft, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(frame.missingBuffBorderRight, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(frame.missingBuffBorderTop, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(frame.missingBuffBorderBottom, inRange, 1.0, oorAlpha)
+        ApplyOORAlpha(frame.missingBuffIcon, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(frame.missingBuffBorderLeft, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(frame.missingBuffBorderRight, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(frame.missingBuffBorderTop, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(frame.missingBuffBorderBottom, inRange, alpha, oorAlpha)
+    else
+        frame.missingBuffIcon:SetAlpha(alpha)
+        if frame.missingBuffBorderLeft then frame.missingBuffBorderLeft:SetAlpha(alpha) end
+        if frame.missingBuffBorderRight then frame.missingBuffBorderRight:SetAlpha(alpha) end
+        if frame.missingBuffBorderTop then frame.missingBuffBorderTop:SetAlpha(alpha) end
+        if frame.missingBuffBorderBottom then frame.missingBuffBorderBottom:SetAlpha(alpha) end
     end
 end
 
@@ -911,17 +968,28 @@ function DF:UpdateDefensiveIconAppearance(frame)
     local inRange = GetInRange(frame)
     local icon = frame.defensiveIcon
     
+    local alpha = 1.0
+    if IsHealthFadeEnabled(db) and IsHealthFaded(frame) and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "defensiveIcon")
+    end
+    
     if db.oorEnabled then
         local oorAlpha = db.oorDefensiveIconAlpha or 0.5
-        
-        -- PERF: Apply to elements directly without creating a table
-        ApplyOORAlpha(icon.texture, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.borderLeft, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.borderRight, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.borderTop, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.borderBottom, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.cooldown, inRange, 1.0, oorAlpha)
-        ApplyOORAlpha(icon.count, inRange, 1.0, oorAlpha)
+        ApplyOORAlpha(icon.texture, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.borderLeft, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.borderRight, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.borderTop, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.borderBottom, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.cooldown, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(icon.count, inRange, alpha, oorAlpha)
+    else
+        if icon.texture then icon.texture:SetAlpha(alpha) end
+        if icon.borderLeft then icon.borderLeft:SetAlpha(alpha) end
+        if icon.borderRight then icon.borderRight:SetAlpha(alpha) end
+        if icon.borderTop then icon.borderTop:SetAlpha(alpha) end
+        if icon.borderBottom then icon.borderBottom:SetAlpha(alpha) end
+        if icon.cooldown then icon.cooldown:SetAlpha(alpha) end
+        if icon.count then icon.count:SetAlpha(alpha) end
     end
 end
 
@@ -943,11 +1011,16 @@ function DF:UpdateTargetedSpellAppearance(frame)
     
     local inRange = GetInRange(frame)
     
+    local alpha = 1.0
+    if IsHealthFadeEnabled(db) and IsHealthFaded(frame) and db.hfElementSpecific then
+        alpha = DF:GetHealthFadeAlpha(frame, "targetedSpell")
+    end
+    
     if db.oorEnabled then
         local oorAlpha = db.oorTargetedSpellAlpha or 0.5
-        ApplyOORAlpha(frame.targetedSpellContainer, inRange, 1.0, oorAlpha)
+        ApplyOORAlpha(frame.targetedSpellContainer, inRange, alpha, oorAlpha)
     else
-        frame.targetedSpellContainer:SetAlpha(1.0)
+        frame.targetedSpellContainer:SetAlpha(alpha)
     end
 end
 
@@ -963,15 +1036,18 @@ function DF:UpdateFrameAppearance(frame)
     
     if DF.testMode or DF.raidTestMode then return end
     
-    -- Only apply frame-level alpha when NOT using element-specific mode
     if db.oorEnabled then
-        -- In oorEnabled mode, frame stays at full alpha
         ApplyOORAlpha(frame, true, 1.0, 1.0)
     else
-        -- Frame-level OOR mode
         local inRange = GetInRange(frame)
-        local outOfRangeAlpha = db.rangeFadeAlpha or 0.4
-        ApplyOORAlpha(frame, inRange, 1.0, outOfRangeAlpha)
+        -- Frame-level: health-based fade (above threshold) or OOR
+        if IsHealthFadeEnabled(db) and IsHealthFaded(frame) and not db.hfElementSpecific then
+            local healthFadeAlpha = db.healthFadeAlpha or 0.5
+            frame:SetAlpha(healthFadeAlpha)
+        else
+            local outOfRangeAlpha = db.rangeFadeAlpha or 0.4
+            ApplyOORAlpha(frame, inRange, 1.0, outOfRangeAlpha)
+        end
     end
 end
 

--- a/Features/HealthFade.lua
+++ b/Features/HealthFade.lua
@@ -1,0 +1,158 @@
+local addonName, DF = ...
+
+-- ============================================================
+-- HEALTH THRESHOLD FADE SYSTEM
+-- Fades frames/elements when a unit's health is above a configurable
+-- threshold (e.g. 100% or 80%). Uses the same pattern as Range.lua.
+-- ============================================================
+
+-- Upvalue all frequently used globals for performance
+local UnitExists = UnitExists
+local UnitIsDeadOrGhost = UnitIsDeadOrGhost
+local UnitIsConnected = UnitIsConnected
+
+-- ============================================================
+-- CHECK IF UNIT IS ABOVE HEALTH THRESHOLD
+-- Returns true if unit health percent is >= configured threshold.
+-- We use frame.dfComputedAboveThreshold set by Core.lua's SetHealthBarValue
+-- via a StatusBar OnValueChanged callback (receives resolved values).
+-- ============================================================
+
+local function IsAboveHealthThresholdFromFrame(frame)
+    if not frame or not frame.unit then
+        return false
+    end
+
+    local unit = frame.unit
+
+    if not UnitExists(unit) then
+        return false
+    end
+
+    if UnitIsDeadOrGhost(unit) or not UnitIsConnected(unit) then
+        return false
+    end
+
+    return frame.dfComputedAboveThreshold == true
+end
+
+-- ============================================================
+-- UPDATE HEALTH FADE STATE FOR A FRAME
+-- ============================================================
+
+function DF:UpdateHealthFade(frame)
+    if not frame or not frame.unit then return end
+
+    if frame.isPetFrame then
+        DF:UpdatePetHealthFade(frame)
+        return
+    end
+
+    if DF.PerfTest and not DF.PerfTest.enableHealthFade then return end
+    if DF.testMode or DF.raidTestMode then return end
+
+    local db = frame.isRaidFrame and DF:GetRaidDB() or DF:GetDB()
+    if not db or not db.healthFadeEnabled then
+        if frame.dfIsHealthFaded then
+            frame.dfIsHealthFaded = false
+            if DF.UpdateAllElementAppearances then
+                DF:UpdateAllElementAppearances(frame)
+            end
+        end
+        return
+    end
+
+    local isAboveThreshold = IsAboveHealthThresholdFromFrame(frame)
+
+    if isAboveThreshold and db.hfCancelOnDispel then
+        if frame.dfDispelOverlay and frame.dfDispelOverlay:IsShown() then
+            isAboveThreshold = false
+        end
+    end
+
+    if frame.dfIsHealthFaded ~= isAboveThreshold then
+        frame.dfIsHealthFaded = isAboveThreshold
+
+        if DF.UpdateAllElementAppearances then
+            DF:UpdateAllElementAppearances(frame)
+        end
+    end
+end
+
+-- ============================================================
+-- UPDATE HEALTH FADE FOR PET FRAMES
+-- ============================================================
+
+function DF:UpdatePetHealthFade(frame)
+    if not frame or not frame.unit then return end
+
+    if not UnitExists(frame.unit) then return end
+
+    local db = frame.isRaidFrame and DF:GetRaidDB() or DF:GetDB()
+    if not db or not db.healthFadeEnabled then
+        frame.dfIsHealthFaded = false
+        return
+    end
+
+    local isAboveThreshold = IsAboveHealthThresholdFromFrame(frame)
+
+    if frame.dfIsHealthFaded ~= isAboveThreshold then
+        frame.dfIsHealthFaded = isAboveThreshold
+
+        local healthFadeAlpha = db.healthFadeAlpha or 0.5
+
+        if frame.SetAlpha then
+            frame:SetAlpha(isAboveThreshold and healthFadeAlpha or 1.0)
+        end
+        if frame.healthBar then
+            frame.healthBar:SetAlpha(isAboveThreshold and healthFadeAlpha or 1.0)
+        end
+    end
+end
+
+-- ============================================================
+-- HELPER: Check if a frame should be faded (above health threshold)
+-- Used by ElementAppearance.lua
+-- ============================================================
+
+function DF:IsHealthFaded(frame)
+    if not frame then return false end
+
+    local db = frame.isRaidFrame and DF:GetRaidDB() or DF:GetDB()
+    if not db or not db.healthFadeEnabled then
+        return false
+    end
+
+    return frame.dfIsHealthFaded == true
+end
+
+-- ============================================================
+-- HELPER: Get health fade alpha for an element
+-- Used by ElementAppearance.lua
+-- ============================================================
+
+function DF:GetHealthFadeAlpha(frame, elementKey)
+    if not frame then return 1.0 end
+
+    local db = frame.isRaidFrame and DF:GetRaidDB() or DF:GetDB()
+    if not db then return 1.0 end
+
+    local alphaMap = {
+        healthBar = "hfHealthBarAlpha",
+        background = "hfBackgroundAlpha",
+        nameText = "hfNameTextAlpha",
+        healthText = "hfHealthTextAlpha",
+        auras = "hfAurasAlpha",
+        icons = "hfIconsAlpha",
+        dispelOverlay = "hfDispelOverlayAlpha",
+        powerBar = "hfPowerBarAlpha",
+        missingBuff = "hfMissingBuffAlpha",
+        defensiveIcon = "hfDefensiveIconAlpha",
+        targetedSpell = "hfTargetedSpellAlpha",
+        myBuffIndicator = "hfMyBuffIndicatorAlpha",
+        frame = "healthFadeAlpha",
+    }
+
+    local dbKey = alphaMap[elementKey] or "healthFadeAlpha"
+    return db[dbKey] or 0.5
+end

--- a/Features/Range.lua
+++ b/Features/Range.lua
@@ -633,6 +633,9 @@ rangeAnimGroup:SetLooping("REPEAT")
 local function RangeCheckFrame(frame)
     if frame and frame:IsShown() then
         DF:UpdateRange(frame)
+        if DF.UpdateHealthFade then
+            DF:UpdateHealthFade(frame)
+        end
     end
 end
 
@@ -671,6 +674,9 @@ rangeAnimGroup:SetScript("OnLoop", function()
                 local frame = DF.raidPetFrames[i]
                 if frame and not frame.dfPetHidden then
                     DF:UpdatePetRange(frame)
+                    if DF.UpdatePetHealthFade then
+                        DF:UpdatePetHealthFade(frame)
+                    end
                 end
             end
         end
@@ -697,6 +703,9 @@ rangeAnimGroup:SetScript("OnLoop", function()
             local petFrame = DF.petFrames.player
             if not petFrame.dfPetHidden then
                 DF:UpdatePetRange(petFrame)
+                if DF.UpdatePetHealthFade then
+                    DF:UpdatePetHealthFade(petFrame)
+                end
             end
         end
         
@@ -705,6 +714,9 @@ rangeAnimGroup:SetScript("OnLoop", function()
                 local frame = DF.partyPetFrames[i]
                 if frame and not frame.dfPetHidden then
                     DF:UpdatePetRange(frame)
+                    if DF.UpdatePetHealthFade then
+                        DF:UpdatePetHealthFade(frame)
+                    end
                 end
             end
         end


### PR DESCRIPTION
## Summary

Adds a **Health Threshold Fading** option: frames or elements can be faded when a unit's health is **above** a configurable threshold (e.g. 100% or 80%). This helps highlight damaged units and reduce visual clutter from full-health ones.

## Main changes

### New module `Features/HealthFade.lua`

- Detects "above threshold" via a hidden health bar whose `OnValueChanged` receives the resolved value (safe with secret health).
- `UpdateHealthFade` / `UpdatePetHealthFade` to update fade state.
- `DF:GetHealthFadeAlpha(frame, elementKey)` for per-element alpha, used by `ElementAppearance.lua`.

### Integration in the appearance pipeline (`ElementAppearance.lua`)

- **Priority order:** Aggro → Dead/Offline → **Health Threshold Fade** → Out of Range → Normal.
- **Frame-level mode:** single alpha for the whole frame (`healthFadeAlpha`).
- **Element-specific mode** (`hfElementSpecific`): per-element alpha (health bar, background, name/health text, auras, icons, dispel overlay, power bar, missing buff, defensive icon, targeted spell, my buff indicator).

### Options (`Config.lua`, `Options.lua`)

- Enable, threshold (50–100%), "Cancel Fade on Dispellable Debuff" (`hfCancelOnDispel`).
- Frame alpha and per-element alpha sliders.
- Fading page copy button extended to health-fade settings (`healthFade`, `hf`).

### Core (`Frames/Core.lua`)

- In `SetHealthBarValue`, a hidden bar `dfHealthCheckBar` is created and receives the same percentage; its `OnValueChanged` updates `dfComputedAboveThreshold` and triggers `UpdateHealthFade`.

### Range (`Features/Range.lua`)

- Range check loop also calls `UpdateHealthFade` / `UpdatePetHealthFade` so fade state stays in sync with the range timer.

### Export / Debug / Test

- **ExportCategories.lua:** all health-fade fields added to export.
- **Debug/PerformanceTest.lua:** "Health Threshold Fade" checkbox to include/exclude the feature in perf tests.
- **TestMode/TestMode.lua:** health-based fading supported in test mode (`fullHealthFade*`, `fh*`) so frame-level and element-specific behaviour can be previewed.

## Files changed

| Area | Files |
|------|--------|
| Config / TOC / Export | `Config.lua`, `DandersFrames.toc`, `ExportCategories.lua` |
| Features | `Features/ElementAppearance.lua`, `Features/HealthFade.lua` **(new)**, `Features/Range.lua` |
| Frames | `Frames/Core.lua` |
| Options | `Options/Options.lua` |
| Debug / Test | `Debug/PerformanceTest.lua`, `TestMode/TestMode.lua` |
