### PR TITLE
Add CI/CD pipeline, in-game changelog and version display [skip ci]

### DIFF
--- a/.github/workflows/nightly-beta.yml
+++ b/.github/workflows/nightly-beta.yml
@@ -1,0 +1,59 @@
+name: Nightly Beta
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-beta:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes since last beta
+        id: check
+        run: |
+          LAST_BETA=$(git tag -l 'v*-beta*' --sort=-v:refname | head -n1)
+          LAST_RELEASE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' HEAD 2>/dev/null || echo "")
+          REF="${LAST_BETA:-${LAST_RELEASE}}"
+
+          if [ -n "$REF" ]; then
+            CHANGES=$(git log "${REF}..HEAD" --oneline --no-merges | grep -cv '\[skip ci\]' || true)
+          else
+            CHANGES=$(git log HEAD --oneline --no-merges | grep -cv '\[skip ci\]' || true)
+          fi
+
+          echo "changes=$CHANGES" >> $GITHUB_OUTPUT
+          echo "Changes since ${REF:-inception}: $CHANGES"
+
+      - name: Create beta tag and trigger release
+        if: steps.check.outputs.changes != '0'
+        run: |
+          BASE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' HEAD 2>/dev/null || echo "v0.1.0")
+          SHA=$(git rev-parse HEAD)
+
+          # Find next available beta number (API check handles ghost refs from deleted tags)
+          NUM=1
+          while gh api "repos/${{ github.repository }}/git/ref/tags/${BASE}-beta.${NUM}" --silent 2>/dev/null; do
+            NUM=$((NUM + 1))
+          done
+
+          # Create tag, retry with next number on conflict (ghost ref not visible via GET)
+          for i in $(seq 0 4); do
+            TAG="${BASE}-beta.$((NUM + i))"
+            if gh api "repos/${{ github.repository }}/git/refs" \
+                 -f ref="refs/tags/${TAG}" -f sha="${SHA}" 2>/dev/null; then
+              echo "Created tag: ${TAG}"
+              gh workflow run release.yml -f "tag=${TAG}"
+              echo "Triggered release build"
+              exit 0
+            fi
+          done
+          echo "::error::Could not create beta tag"
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Package and Release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v1.0.0-beta.1). Leave empty for alpha build.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Check if build is needed
+        id: guard
+        run: |
+          # Tags and workflow_dispatch always build
+          if [[ "$GITHUB_REF" == refs/tags/* ]] || [[ -n "${{ inputs.tag }}" ]] || [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Branch pushes: skip if only docs/CI files changed
+          DOMINATED=true
+          for f in $(git diff --name-only HEAD~1..HEAD 2>/dev/null); do
+            case "$f" in
+              *.md|*.sh|.github/*|.gitignore|.pkgmeta) ;;
+              *) DOMINATED=false; break ;;
+            esac
+          done
+          echo "skip=$DOMINATED" >> $GITHUB_OUTPUT
+
+      - name: Generate Changelog.lua
+        if: steps.guard.outputs.skip != 'true'
+        id: changelog
+        run: |
+          chmod +x generate_changelog.sh
+          if [[ "$GITHUB_REF" == refs/heads/* ]] && [[ -z "${{ inputs.tag }}" ]]; then
+            export FORCE_ALPHA=true
+          fi
+          ./generate_changelog.sh
+
+          VERSION=$(grep 'DF.ADDON_VERSION' Changelog.lua | sed 's/.*= "\(.*\)"/\1/')
+          CHANNEL=$(grep 'DF.RELEASE_CHANNEL' Changelog.lua | sed 's/.*= "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
+          NOTES=$(awk '/^## / { count++; if (count > 1) exit } count >= 1 { print }' CHANGELOG.md | head -c 1800 | sed -e :a -e '/^[[:space:]-]*$/{ $d; N; ba; }')
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Package and Release
+        if: steps.guard.outputs.skip != 'true'
+        uses: BigWigsMods/packager@v2
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify Discord
+        if: steps.guard.outputs.skip != 'true' && success()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ steps.changelog.outputs.version }}
+          CHANNEL: ${{ steps.changelog.outputs.channel }}
+          NOTES: ${{ steps.changelog.outputs.notes }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "No Discord webhook configured, skipping."
+            exit 0
+          fi
+
+          case "$CHANNEL" in
+            release)
+              COLOR=3066993
+              TITLE="DandersFrames ${VERSION} — New Release"
+              FOOTER="Available on CurseForge"
+              ;;
+            beta)
+              COLOR=16755200
+              TITLE="DandersFrames ${VERSION} — Beta"
+              FOOTER="Available on CurseForge (Beta channel)"
+              ;;
+            *)
+              COLOR=9474192
+              TITLE="DandersFrames ${VERSION} — Alpha"
+              FOOTER="Available on CurseForge (Alpha channel)"
+              ;;
+          esac
+
+          PAYLOAD=$(jq -n \
+            --arg title "$TITLE" \
+            --arg desc "$NOTES" \
+            --arg color "$COLOR" \
+            --arg footer "$FOOTER" \
+            --arg url "https://www.curseforge.com/wow/addons/danders-frames" \
+            '{
+              embeds: [{
+                title: $title,
+                description: $desc,
+                color: ($color | tonumber),
+                url: $url,
+                footer: { text: $footer }
+              }]
+            }')
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,13 @@
+package-as: DandersFrames
+enable-nolib-creation: no
+
+ignore:
+  - CHANGELOG.md
+  - README.md
+  - generate_changelog.sh
+  - .github
+  - .gitignore
+
+manual-changelog:
+  filename: CHANGELOG.md
+  markup-type: markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# DandersFrames Changelog
+
+## [4.0.5] - 2026-02-14
+
+### Bug Fixes
+* Raid frames misaligned / anchoring broken
+* Groups per row setting not working in live raids
+* Arena/BG frames showing wrong layout after reload
+* Arena health bars not updating after reload
+* Leader change causes frames to disappear or misalign
+* Menu bind ignores out-of-combat setting
+* Boss aura font size defaulting to 200% instead of 100%
+* Click casting profiles don't switch on spec change
+* Clique not working on pet frames
+* Absorb overlay doesn't fade when out of range
+* Heal absorb and heal prediction bars don't fade when out of range
+* Defensive icon flashes at wrong opacity when appearing
+* Name text stays full opacity on out-of-range players
+* Health text and status text stay full opacity on out-of-range players
+* Name alpha resets after exiting test mode
+* Glowy hand cursor after failed click cast spells
+* Macro editing window gets stuck open when reopened
+* Flat raid unlock mover sized incorrectly
+* Fonts broken on non-English client languages
+
+### New Features
+* Click casting spec default profile option
+* Group visibility options now available in flat raid mode
+* Slider edit boxes accept precise decimal values for fine-tuned positioning and scaling

--- a/Changelog.lua
+++ b/Changelog.lua
@@ -1,0 +1,5 @@
+local addonName, DF = ...
+DF.ADDON_VERSION = "dev"
+DF.BUILD_DATE = "0000-00-00T00:00:00Z"
+DF.RELEASE_CHANNEL = "alpha"
+DF.CHANGELOG_TEXT = "Development version"

--- a/DandersFrames.toc
+++ b/DandersFrames.toc
@@ -3,7 +3,8 @@
 ## Notes: Custom party/raid frames for WoW Midnight 12.0
 ## X-Credits: Some optimization patterns informed by studying Grid2 and other community addons.
 ## Author: Danders
-## Version: 4.0.5
+## Version: @project-version@
+## X-Curse-Project-ID: 1389690
 ## IconTexture: Interface\AddOns\DandersFrames\Media\DF_Icon
 ## SavedVariables: DandersFramesDB_v2, DandersFramesClickCastingDB
 ## SavedVariablesPerCharacter: DandersFramesCharDB
@@ -25,6 +26,7 @@ DandersFrames.xml
 
 # Core
 Config.lua
+Changelog.lua
 Profile.lua
 ExportCategories.lua
 Core.lua

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -4328,7 +4328,10 @@ function DF:CreateGUI()
     
     local title = titleBar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     title:SetPoint("LEFT", 12, 0)
-    title:SetText("DandersFrames v" .. (DF.VERSION or "?"))
+    local versionStr = DF.ADDON_VERSION or DF.VERSION or "?"
+    local channelTags = { alpha = " |cffff8800alpha|r", beta = " |cffff8800beta|r" }
+    local channelTag = channelTags[DF.RELEASE_CHANNEL] or ""
+    title:SetText("DandersFrames " .. versionStr .. channelTag)
     local c = GetThemeColor()
     title:SetTextColor(c.r, c.g, c.b)
     title.UpdateTheme = function()
@@ -4363,7 +4366,92 @@ function DF:CreateGUI()
         closeIcon:SetVertexColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
     end)
     closeBtn:SetScript("OnClick", function() frame:Hide() end)
-    
+
+    -- Info button (changelog)
+    local infoBtn = CreateFrame("Button", nil, frame, "BackdropTemplate")
+    infoBtn:SetSize(20, 20)
+    infoBtn:SetPoint("TOPRIGHT", -32, -5)
+    infoBtn:SetFrameStrata("FULLSCREEN_DIALOG")
+    infoBtn:SetFrameLevel(210)
+    infoBtn:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    infoBtn:SetBackdropColor(C_ELEMENT.r, C_ELEMENT.g, C_ELEMENT.b, 1)
+    infoBtn:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 0.5)
+    local infoIcon = infoBtn:CreateTexture(nil, "OVERLAY")
+    infoIcon:SetPoint("CENTER")
+    infoIcon:SetSize(12, 12)
+    infoIcon:SetTexture("Interface\\AddOns\\DandersFrames\\Media\\Icons\\info")
+    infoIcon:SetVertexColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+    infoBtn:SetScript("OnEnter", function(self)
+        local tc = GetThemeColor()
+        self:SetBackdropBorderColor(tc.r, tc.g, tc.b, 1)
+        infoIcon:SetVertexColor(tc.r, tc.g, tc.b)
+    end)
+    infoBtn:SetScript("OnLeave", function(self)
+        self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 0.5)
+        infoIcon:SetVertexColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+    end)
+
+    -- Changelog overlay
+    local changelogOverlay = CreateFrame("Frame", nil, frame, "BackdropTemplate")
+    changelogOverlay:SetPoint("TOPLEFT", frame, "TOPLEFT", 12, -34)
+    changelogOverlay:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -12, 36)
+    changelogOverlay:SetFrameStrata("FULLSCREEN_DIALOG")
+    changelogOverlay:SetFrameLevel(300)
+    CreatePanelBackdrop(changelogOverlay)
+    changelogOverlay:Hide()
+
+    local changelogTitle = changelogOverlay:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    changelogTitle:SetPoint("TOPLEFT", 12, -10)
+    changelogTitle:SetText("Changelog")
+    changelogTitle:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
+
+    local backBtn = CreateFrame("Button", nil, changelogOverlay, "BackdropTemplate")
+    backBtn:SetSize(60, 22)
+    backBtn:SetPoint("TOPRIGHT", -8, -6)
+    CreateElementBackdrop(backBtn)
+    local backText = backBtn:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    backText:SetPoint("CENTER")
+    backText:SetText("Back")
+    backText:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
+    backBtn:SetScript("OnEnter", function(self)
+        local tc = GetThemeColor()
+        self:SetBackdropBorderColor(tc.r, tc.g, tc.b, 1)
+    end)
+    backBtn:SetScript("OnLeave", function(self)
+        self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 0.5)
+    end)
+    backBtn:SetScript("OnClick", function() changelogOverlay:Hide() end)
+
+    local changelogScroll = CreateFrame("ScrollFrame", nil, changelogOverlay, "UIPanelScrollFrameTemplate")
+    changelogScroll:SetPoint("TOPLEFT", 8, -34)
+    changelogScroll:SetPoint("BOTTOMRIGHT", -26, 8)
+
+    local changelogEdit = CreateFrame("EditBox", nil, changelogScroll)
+    changelogEdit:SetMultiLine(true)
+    changelogEdit:SetAutoFocus(false)
+    changelogEdit:SetFontObject(GameFontHighlightSmall)
+    changelogEdit:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+    changelogEdit:SetWidth(changelogScroll:GetWidth() or 500)
+    changelogEdit:SetText(DF.CHANGELOG_TEXT or "No changelog available.")
+    changelogEdit:SetCursorPosition(0)
+    changelogEdit:EnableMouse(true)
+    changelogEdit:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    changelogEdit:SetScript("OnEditFocusGained", function(self) self:HighlightText(0, 0) end)
+    changelogScroll:SetScrollChild(changelogEdit)
+
+    infoBtn:SetScript("OnClick", function()
+        if changelogOverlay:IsShown() then
+            changelogOverlay:Hide()
+        else
+            changelogEdit:SetWidth(changelogScroll:GetWidth())
+            changelogOverlay:Show()
+        end
+    end)
+
     -- =========================================================================
     -- RESIZE HANDLE (bottom-right corner)
     -- =========================================================================
@@ -5051,7 +5139,7 @@ function DF:CreateGUI()
     -- Version on the right
     local versionText = footer:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     versionText:SetPoint("RIGHT", footer, "RIGHT", -2, 0)
-    versionText:SetText("v" .. (DF.VERSION or "?"))
+    versionText:SetText(versionStr .. channelTag)
     versionText:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b, 0.5)
     
     -- Create the click casting UI content

--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# generate_changelog.sh — Reads CHANGELOG.md and generates Changelog.lua
+# Called by GitHub Actions before packaging.
+
+set -euo pipefail
+
+CHANGELOG_FILE="CHANGELOG.md"
+OUTPUT_FILE="Changelog.lua"
+
+if [ ! -f "$CHANGELOG_FILE" ]; then
+    echo "Error: $CHANGELOG_FILE not found."
+    exit 1
+fi
+
+# Build date
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ============================================================
+# SEMVER HELPERS
+# ============================================================
+
+# Extract major.minor.patch from a version string (v1.2.3, v1.2.3-beta.1, etc.)
+parse_major() { echo "${1#v}" | cut -d. -f1; }
+parse_minor() { echo "${1#v}" | cut -d. -f2 | cut -d- -f1; }
+
+# Check if the version bump is minor or major
+is_minor_or_major_bump() {
+    local cur_major; cur_major=$(parse_major "$1")
+    local cur_minor; cur_minor=$(parse_minor "$1")
+    local prev_major; prev_major=$(parse_major "$2")
+    local prev_minor; prev_minor=$(parse_minor "$2")
+
+    [ "$cur_major" != "$prev_major" ] || [ "$cur_minor" != "$prev_minor" ]
+}
+
+# Extract only the header + first ## [x.y.z] section from CHANGELOG.md
+trim_to_first_section() {
+    echo "$1" | awk '/^## \[/ { count++; if (count > 1) exit } { print }'
+}
+
+# ============================================================
+# DETERMINE VERSION AND CHANGELOG CONTENT
+# ============================================================
+CURRENT_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || echo "")
+LAST_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "v0.0.0")
+
+# Branch pushes must always produce alpha builds, even if a tag exists on HEAD
+if [ "${FORCE_ALPHA:-}" = "true" ]; then
+    CURRENT_TAG=""
+fi
+
+if [ -n "$CURRENT_TAG" ]; then
+    # Tagged commit — determine channel from tag name
+    if echo "$CURRENT_TAG" | grep -qi "beta"; then
+        RELEASE_CHANNEL="beta"
+    elif echo "$CURRENT_TAG" | grep -qi "alpha"; then
+        RELEASE_CHANNEL="alpha"
+    else
+        RELEASE_CHANNEL="release"
+    fi
+    VERSION="$CURRENT_TAG"
+
+    # Find previous release tag (excluding current and pre-release tags)
+    PREV_RELEASE=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v '-' | grep -v "^${CURRENT_TAG}$" | head -n1 || echo "")
+
+    if [ -n "$PREV_RELEASE" ] && is_minor_or_major_bump "$CURRENT_TAG" "$PREV_RELEASE"; then
+        # Minor/major bump: only include the latest version section
+        CHANGELOG_CONTENT=$(trim_to_first_section "$(cat "$CHANGELOG_FILE")")
+        echo "Minor/major bump detected (${PREV_RELEASE} -> ${CURRENT_TAG}): trimmed changelog"
+    else
+        # Patch or first release: keep full changelog
+        CHANGELOG_CONTENT=$(cat "$CHANGELOG_FILE")
+    fi
+
+    # Beta builds: prepend unreleased commits since the base release
+    if [ "$RELEASE_CHANNEL" = "beta" ] && [ -n "$PREV_RELEASE" ]; then
+        UNRELEASED_COMMITS=$(git log "${PREV_RELEASE}..HEAD" --oneline --no-merges 2>/dev/null | grep -v '\[skip ci\]' || echo "")
+        if [ -n "$UNRELEASED_COMMITS" ]; then
+            UNRELEASED_SECTION="## Unreleased (${VERSION})
+
+$(echo "$UNRELEASED_COMMITS" | sed 's/^[a-f0-9]* /- /')
+
+---
+"
+            HEADER=$(echo "$CHANGELOG_CONTENT" | head -n 1)
+            BODY=$(echo "$CHANGELOG_CONTENT" | tail -n +2)
+            CHANGELOG_CONTENT="${HEADER}
+
+${UNRELEASED_SECTION}
+${BODY}"
+        fi
+    fi
+else
+    # Untagged commit — alpha build
+    RELEASE_CHANNEL="alpha"
+    COMMIT_COUNT=$(git rev-list "${LAST_TAG}..HEAD" --count 2>/dev/null || echo "0")
+    # Strip pre-release suffix (v1.0.0-beta.3 → v1.0.0) for clean alpha version
+    BASE_VERSION=$(echo "$LAST_TAG" | sed 's/-[a-zA-Z].*$//')
+    VERSION="${BASE_VERSION}-alpha.${COMMIT_COUNT}"
+
+    UNRELEASED_COMMITS=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges 2>/dev/null | grep -v '\[skip ci\]' || echo "")
+
+    if [ -n "$UNRELEASED_COMMITS" ]; then
+        UNRELEASED_SECTION="## Unreleased (${VERSION})
+
+$(echo "$UNRELEASED_COMMITS" | sed 's/^[a-f0-9]* /- /')
+
+---
+"
+        HEADER=$(head -n 1 "$CHANGELOG_FILE")
+        BODY=$(tail -n +2 "$CHANGELOG_FILE")
+        CHANGELOG_CONTENT="${HEADER}
+
+${UNRELEASED_SECTION}
+${BODY}"
+    else
+        CHANGELOG_CONTENT=$(cat "$CHANGELOG_FILE")
+    fi
+fi
+
+# Update CHANGELOG.md in working directory so the packager picks up changes
+echo "$CHANGELOG_CONTENT" > "$CHANGELOG_FILE"
+
+# Write Changelog.lua
+cat > "$OUTPUT_FILE" << LUAEOF
+local addonName, DF = ...
+DF.ADDON_VERSION = "${VERSION}"
+DF.BUILD_DATE = "${BUILD_DATE}"
+DF.RELEASE_CHANNEL = "${RELEASE_CHANNEL}"
+DF.CHANGELOG_TEXT = [===[
+${CHANGELOG_CONTENT}
+]===]
+LUAEOF
+
+# Pre-set TOC version for alpha builds so the packager uses our clean version
+# For tagged builds, the packager replaces @project-version@ with the tag name
+if [ "$RELEASE_CHANNEL" = "alpha" ]; then
+    sed -i "s/@project-version@/${VERSION}/" DandersFrames.toc
+    echo "Pre-set TOC version to ${VERSION}"
+fi
+
+echo "Generated ${OUTPUT_FILE}: version=${VERSION} channel=${RELEASE_CHANNEL} date=${BUILD_DATE}"


### PR DESCRIPTION
## Summary

This sets up the full CI/CD pipeline for DandersFrames — automated builds, CurseForge uploads, nightly betas, and an in-game changelog so players can actually see what changed.

## What's new

### CI/CD Pipeline (GitHub Actions)

Two workflows:

- **`release.yml`** — Triggers on pushes to `main` and version tags (`v*`). Packages the addon via [BigWigs Packager](https://github.com/BigWigsMods/packager), uploads to CurseForge, creates a GitHub Release, and optionally pings Discord.
- **`nightly-beta.yml`** — Runs every night at 3 AM UTC. If there are new commits since the last beta, it creates a beta tag and triggers the release workflow. Can also be triggered manually.

### In-Game Changelog

- New **info button** (ℹ) next to the close button in the settings window
- Opens a **changelog overlay** showing the full changelog text
- Title bar and footer now show the **version number + release channel** (e.g. `v4.0.6 alpha` or `v4.0.6 beta` in orange)

### Build Infrastructure

- `Changelog.lua` — **Auto-generated by CI** with version, build date, release channel, and changelog text. Ships as a dev stub locally. Do not edit this file.
- `generate_changelog.sh` — Reads `CHANGELOG.md`, determines version/channel from git tags, and writes `Changelog.lua`.
- `.pkgmeta` — BigWigs Packager config for CurseForge.
- `CHANGELOG.md` — Human-maintained changelog. This is what players see in-game.

## How releases work

### Automatic alpha builds

Every push to `main` automatically creates an **alpha** build on CurseForge. The version is derived from the last tag (e.g. `v4.0.5-alpha.3` = 3 commits after `v4.0.5`).

**Important:** If a commit should NOT produce an alpha build and/or should NOT appear in the changelog, add `[skip ci]` to the commit message. This is useful for things like README edits, workflow changes, or anything that isn't an actual addon change.

### Automatic beta builds (nightly)

Every night, the nightly workflow checks if there are new (non-`[skip ci]`) commits since the last beta. If yes, it automatically creates a beta tag (e.g. `v4.0.5-beta.1`) and triggers a build. You can also trigger it manually from the Actions tab whenever you want.

### What alpha and beta players see

Alpha and beta builds auto-generate a changelog from commit messages — each commit becomes one line in the "Unreleased" section. Commits tagged with `[skip ci]` are excluded automatically.

This auto-generated section is prepended to whatever is already in `CHANGELOG.md`, so players always see both the latest unreleased changes and the last stable release notes.

### Creating a stable release

When you're ready to ship a proper release:

1. **Edit `CHANGELOG.md`** — Add a new section at the top with the version number and date. Write the changes however you like — this is what players will see in-game. Keep the previous versions below so there's always a full history.

```markdown
## [4.0.6] - 2026-03-01

### Bug Fixes
* Fixed something that was broken
* Another fix

### New Features
* Cool new thing

## [4.0.5] - 2026-02-14
...older entries stay here...
```

2. **Commit and push** to `main`
3. **Tag the commit:** `git tag v4.0.6 && git push --tags`
4. The release workflow picks up the tag, packages everything, and uploads it as a **release** to both CurseForge and GitHub

That's it. The tag name determines the version and release channel. No manual beta tagging needed — that's handled by the nightly workflow.

### What happens to the changelog on major bumps?

You never need to manually clear `CHANGELOG.md` — keep the full history in the file. The build script is smart about it: on a minor or major version bump (e.g. `v4.0.x` → `v4.1.0` or `v5.0.0`), the in-game changelog automatically trims down to only the latest version's section. Players see a fresh start, but the full history stays in the repo for reference.

## Required GitHub Secrets

| Secret | Required | Purpose |
|--------|----------|---------|
| `CF_API_KEY` | Yes | CurseForge API token for uploads |
| `PAT_TOKEN` | Yes | GitHub PAT with `Contents: Read+Write` (for nightly beta tag creation) |
| `DISCORD_WEBHOOK_URL` | No | Discord webhook for release notifications (skipped if not set) |

### How to create the PAT_TOKEN

The nightly beta workflow needs a Personal Access Token to create tags and trigger the release workflow (the default `GITHUB_TOKEN` can't trigger other workflows).

1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
2. Click **"Generate new token"**
3. Set a name like `DandersFrames CI` and pick an expiration (or no expiration)
4. Under **Repository access**, select **"Only select repositories"** and pick the DandersFrames repo
5. Under **Permissions → Repository permissions**, set **Contents** to **Read and write** — that's the only permission needed
6. Click **Generate token** and copy it
7. Go to the DandersFrames repo → **Settings → Secrets and variables → Actions → New repository secret**
8. Name: `PAT_TOKEN`, Value: paste the token

Same process for `CF_API_KEY` (get it from [CurseForge → Account → API Tokens](https://legacy.curseforge.com/account/api-tokens)) and `DISCORD_WEBHOOK_URL` (Discord → Server Settings → Integrations → Webhooks).

## Testing

Please pull this branch and test it locally before merging — check that the addon loads, the info button works, and the changelog overlay shows up correctly in-game. Better safe than sorry! :D

## Files changed

- **New:** `.github/workflows/release.yml`, `.github/workflows/nightly-beta.yml`, `.pkgmeta`, `CHANGELOG.md`, `Changelog.lua`, `generate_changelog.sh`
- **Modified:** `DandersFrames.toc` (version placeholder + CurseForge project ID + Changelog.lua in load order), `GUI/GUI.lua` (version display + info button + changelog overlay)
