### PR TITLE
Fix leader icon not updating on first leader change

### DIFF
--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -7939,10 +7939,10 @@ headerChildEventFrame:SetScript("OnEvent", function(self, event, arg1)
             if newLeader ~= oldLeader then
                 unitLeaderCache = newLeader
                 
-                -- Update only the old and new leader frames (not all frames)
+                -- Update only the old and new leader frames, or all if cache was empty
                 local function updateIfLeader(frame)
                     if frame.dfIsHeaderChild and frame.unit then
-                        if frame.unit == oldLeader or frame.unit == newLeader then
+                        if not oldLeader or frame.unit == oldLeader or frame.unit == newLeader then
                             DF:UpdateLeaderIcon(frame)
                         end
                     end
@@ -7951,7 +7951,7 @@ headerChildEventFrame:SetScript("OnEvent", function(self, event, arg1)
                 DF:IterateRaidFrames(updateIfLeader)
                 -- Also update pinned frames showing old/new leader
                 IteratePinnedFrames(function(frame)
-                    if frame.unit == oldLeader or frame.unit == newLeader then
+                    if not oldLeader or frame.unit == oldLeader or frame.unit == newLeader then
                         DF:UpdateLeaderIcon(frame)
                     end
                 end)


### PR DESCRIPTION
### Problem

When creating a group (inviting someone) and then promoting them to leader, the crown icon stays stuck on the old leader's frame instead of moving to the new one.

### Root Cause

The centralized `PARTY_LEADER_CHANGED` handler in `Frames/Headers.lua` uses a `unitLeaderCache` variable to track the current leader and only update the affected frames (old + new leader). However, `unitLeaderCache` is initialized as `nil` and never populated until the first leader change occurs.

On the first leader change:
- `oldLeader = nil` (cache empty)
- The condition `frame.unit == oldLeader` never matches any frame
- The old leader's frame is never updated, so the crown remains visible

### Fix

Added a `not oldLeader` guard to the update condition. When the cache is empty (first leader change), all frames are updated to ensure the crown is correctly removed from the previous leader. Once the cache is populated, subsequent leader changes continue to use the optimized path (only updating the two affected frames).

This fixes: https://discord.com/channels/1443538945605636149/1470515656574370075
