### PR TITLE
Fix forbidden table iteration in FindHealthManaBars

### DIFF
--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -904,6 +904,7 @@ function CC:FindHealthManaBars(obj)
         if checked[current] then return end
         
         checked[current] = true
+        if not pcall(pairs, current) then return end
         for key, value in pairs(current) do
             if key == "HealthBar" or key == "healthBar" then
                 health = value


### PR DESCRIPTION
### Problem

When registering Blizzard frames for click-casting, the addon scans the frame hierarchy to find health/mana bars. Some Blizzard frames contain protected tables that throw `attempted to iterate a forbidden table` when `pairs()` is called on them.

```lua
1x attempted to iterate a forbidden table
[DandersFrames/ClickCasting/Frames.lua]:907: in function <DandersFrames/ClickCasting/Frames.lua:902>
[DandersFrames/ClickCasting/Frames.lua]:913: in function <DandersFrames/ClickCasting/Frames.lua:902>
[DandersFrames/ClickCasting/Frames.lua]:913: in function <DandersFrames/ClickCasting/Frames.lua:902>
[DandersFrames/ClickCasting/Frames.lua]:913: in function <DandersFrames/ClickCasting/Frames.lua:902>
[DandersFrames/ClickCasting/Frames.lua]:913: in function <DandersFrames/ClickCasting/Frames.lua:902>
[DandersFrames/ClickCasting/Frames.lua]:913: in function 'traverse'
[DandersFrames/ClickCasting/Frames.lua]:918: in function 'FindHealthManaBars'
[DandersFrames/ClickCasting/Frames.lua]:926: in function 'FixBlizzardFrameStatusBars'
[DandersFrames/ClickCasting/Frames.lua]:1007: in function 'registerBlizzardFrame'
[DandersFrames/ClickCasting/Frames.lua]:1013: in function 'RegisterBlizzardFrames'
[DandersFrames/ClickCasting/Events.lua]:88: in function <DandersFrames/ClickCasting/Events.lua:81>
```

### Fix

Added a `pcall(pairs, current)` guard before iterating each table in the recursive traversal. If a table is forbidden, that branch is silently skipped.