### PR TITLE
Add click-cast binding tooltip on unit frame hover

### DIFF
--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -904,7 +904,7 @@ function CC:FindHealthManaBars(obj)
         if checked[current] then return end
         
         checked[current] = true
-        if not pcall(pairs, current) then return end
+        if not pcall(next, current) then return end
         for key, value in pairs(current) do
             if key == "HealthBar" or key == "healthBar" then
                 health = value

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -2595,6 +2595,9 @@ function CC:RefreshSpellGrid(skipScrollReset)
     if self.quickBindCb then
         self.quickBindCb:SetChecked(self.db.options.quickBindEnabled)
     end
+    if self.bindTipCb then
+        self.bindTipCb:SetChecked(self.db.options.showBindingTooltip)
+    end
     if self.UpdateSmartResText then
         self.UpdateSmartResText()
     end

--- a/ClickCasting/UI/Main.lua
+++ b/ClickCasting/UI/Main.lua
@@ -433,10 +433,38 @@ function CC:CreateClickCastUI(parent)
     quickBindCb:SetScript("OnClick", function(self)
         CC.db.options.quickBindEnabled = self:GetChecked()
     end)
-    
+
+    -- Show Binding Tooltip toggle
+    local bindTipCb = CreateFrame("CheckButton", nil, row2, "BackdropTemplate")
+    bindTipCb:SetPoint("LEFT", quickBindLabel, "RIGHT", 15, 0)
+    bindTipCb:SetSize(14, 14)
+    bindTipCb:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    bindTipCb:SetBackdropColor(C_ELEMENT.r, C_ELEMENT.g, C_ELEMENT.b, 1)
+    bindTipCb:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 0.5)
+
+    local bindTipCheck = bindTipCb:CreateTexture(nil, "OVERLAY")
+    bindTipCheck:SetTexture("Interface\\Buttons\\WHITE8x8")
+    bindTipCheck:SetVertexColor(themeColor.r, themeColor.g, themeColor.b)
+    bindTipCheck:SetPoint("CENTER")
+    bindTipCheck:SetSize(8, 8)
+    bindTipCb:SetCheckedTexture(bindTipCheck)
+
+    local bindTipLabel = row2:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+    bindTipLabel:SetPoint("LEFT", bindTipCb, "RIGHT", 3, 0)
+    bindTipLabel:SetText("Show Tooltips")
+    bindTipLabel:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
+
+    bindTipCb:SetScript("OnClick", function(self)
+        CC.db.options.showBindingTooltip = self:GetChecked()
+    end)
+
     -- Smart Resurrection dropdown
     local smartResLabel = row2:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    smartResLabel:SetPoint("LEFT", quickBindLabel, "RIGHT", 15, 0)
+    smartResLabel:SetPoint("LEFT", bindTipLabel, "RIGHT", 15, 0)
     smartResLabel:SetText("Smart Res:")
     smartResLabel:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
     
@@ -632,6 +660,7 @@ function CC:CreateClickCastUI(parent)
     CC.enableCb = enableCb
     CC.downCb = downCb
     CC.quickBindCb = quickBindCb
+    CC.bindTipCb = bindTipCb
     
     -- =========================================================================
     -- MAIN CONTENT: Side-by-side layout

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -708,25 +708,28 @@ function DF:InitializeHeaderChild(frame)
     -- ========================================
     frame:HookScript("OnEnter", function(self)
         local frameDb = self.isRaidFrame and DF:GetRaidDB() or DF:GetDB()
-        
+
         -- Set hover state and update highlights
         self.dfIsHovered = true
         if DF.UpdateHighlights then
             DF:UpdateHighlights(self)
         end
-        
+
+        -- Binding tooltip (independent of unit tooltip settings)
+        if DF.ShowBindingTooltip then DF:ShowBindingTooltip(self) end
+
         -- Check if we're actually hovering a child element (aura) with SetPropagateMouseMotion
         local focus = GetMouseFocus and GetMouseFocus() or GetMouseFoci and GetMouseFoci()[1]
         if focus and focus ~= self and focus.unitFrame == self then
             return
         end
-        
+
         -- Check if tooltips are enabled
         if not frameDb.tooltipFrameEnabled then return end
-        
+
         -- Check if tooltips disabled in combat
         if frameDb.tooltipFrameDisableInCombat and InCombatLockdown() then return end
-        
+
         -- Show tooltip
         if self.unit and UnitExists(self.unit) then
             local anchorType = frameDb.tooltipFrameAnchor or "CURSOR"
@@ -759,8 +762,9 @@ function DF:InitializeHeaderChild(frame)
             return
         end
         GameTooltip:Hide()
+        if DFBindingTooltip and focus ~= self then DFBindingTooltip:Hide(); DFBindingTooltip.anchorFrame = nil end
     end)
-    
+
     -- Apply layout (this configures all the visual elements properly)
     if DF.ApplyFrameLayout then
         DF:ApplyFrameLayout(frame)

--- a/TestMode/TestFramePool.lua
+++ b/TestMode/TestFramePool.lua
@@ -96,9 +96,17 @@ local function CreateTestFrame(index, isRaid)
         DF:ApplyAuraLayout(frame, "DEBUFF")
     end
     
+    -- Binding tooltip on hover
+    frame:SetScript("OnEnter", function(self)
+        if DF.ShowBindingTooltip then DF:ShowBindingTooltip(self) end
+    end)
+    frame:SetScript("OnLeave", function(self)
+        if DFBindingTooltip then DFBindingTooltip:Hide(); DFBindingTooltip.anchorFrame = nil end
+    end)
+
     -- Hide by default
     frame:Hide()
-    
+
     return frame
 end
 


### PR DESCRIPTION
out of combat:

<img width="450" height="148" alt="2026-02-19 23_15_03" src="https://github.com/user-attachments/assets/796285f4-ce39-494d-b4cc-c40548ea1ac4" /> 

infight:

<img width="455" height="185" alt="2026-02-19 23_16_34" src="https://github.com/user-attachments/assets/61022b5b-6c53-459b-9a26-ee5085147bbe" />

### Problem

There's no way to see which spells are bound to which mouse buttons/keys without opening the click-casting UI.

### Solution

Adds a separate tooltip that appears next to unit frames when hovering over party/raid members, showing all active click-cast bindings.

- Spell names colored green (usable) or red (not usable)
- Shows only matching bindings when holding Shift/Ctrl/Alt
- Fixed sort order: Left, Middle, Right, Mouse 4+, keyboard
- "Show Tooltips" checkbox in the Binds menu to toggle
- Smart Res compatible (only show Res Spell when applicable)

Due to secret values spell usability and cooldown status are only displayed out of combat.

### Bug fix

Fixed attempted to iterate a forbidden table error in click-casting Blizzard frame registration. The recursive frame traversal in FindHealthManaBars now correctly guards against forbidden tables using pcall(next) instead of pcall(pairs).
Reproducible by entering Rookery, engaging combat, and running out of the instance.
#11 didnt fix it sadly.

Also see: https://discord.com/channels/1443538945605636149/1465084670592024607