### PR TITLE
Remove dead 'Only Dispellable Debuffs' Blizzard CVar setting

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -747,7 +747,6 @@ DF.GlobalDefaults = {
 DF.PartyDefaults = {
     -- Internal migration flags
     _blizzDispelIndicator = 1,
-    _blizzOnlyDispellable = false,
     _defensiveBarMigrated = true,
     _defensiveIconMigrated = true,
 
@@ -2059,7 +2058,6 @@ DF.PartyDefaults = {
 DF.RaidDefaults = {
     -- Internal migration flags
     _blizzDispelIndicator = 1,
-    _blizzOnlyDispellable = false,
     _defensiveBarMigrated = true,
     _defensiveIconMigrated = true,
 

--- a/Core.lua
+++ b/Core.lua
@@ -2888,16 +2888,9 @@ function DF:ApplySavedCVarSettings()
     end
     SetCVar("raidFramesDispelIndicatorType", dispelIndicator)
     
-    -- Apply only dispellable debuffs setting
-    local onlyDispellable = db._blizzOnlyDispellable
-    if onlyDispellable ~= nil then
-        SetCVar("raidFramesDisplayOnlyDispellableDebuffs", onlyDispellable and 1 or 0)
-    end
-    
     if DF.debugEnabled then
         print("|cff00ff00DandersFrames:|r Applied CVar settings:")
         print("  raidFramesDispelIndicatorType =", dispelIndicator)
-        print("  raidFramesDisplayOnlyDispellableDebuffs =", onlyDispellable and 1 or 0)
     end
 end
 

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -1994,20 +1994,15 @@ local function ApplyBlizzardFrameSettings()
     local db = DF.db.party
     
     local dispelIndicator = db._blizzDispelIndicator
-    local onlyDispellable = db._blizzOnlyDispellable
-    
+
     -- Force dispel indicator to be at least 1 (never disabled)
     if dispelIndicator == nil or dispelIndicator == 0 then
         dispelIndicator = 1
         db._blizzDispelIndicator = 1
     end
-    
+
     -- Set via CVar only - do NOT modify optionTable
     SetCVar("raidFramesDispelIndicatorType", dispelIndicator)
-    
-    if onlyDispellable ~= nil then
-        SetCVar("raidFramesDisplayOnlyDispellableDebuffs", onlyDispellable and 1 or 0)
-    end
 end
 
 -- Export for use elsewhere

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -470,7 +470,6 @@ L["Container"] = true
 L["Content type filters configured in Party tab."] = true
 L["Content Types"] = true
 L["Content:"] = true
-L["Controls Blizzard's debuff filtering (affects our display too)."] = true
 L["Controls how multiple defensive icons are arranged when using Direct aura mode."] = true
 L["Copied %d settings from %s to %s."] = true
 L["Copied settings from %s to %s."] = true
@@ -983,7 +982,6 @@ L["Covers both normal debuffs and boss debuffs (private auras). Limited customis
 L["DandersFrames for normal dispels, Blizzard for boss debuffs (private auras). Recommended."] = true
 L["Oldest First"] = true
 L["Only changed settings will be saved"] = true
-L["Only Dispellable Debuffs"] = true
 L["Only My Buffs"] = true
 L["Only show buffs that you cast. Applies to all buff filters."] = true
 L["Only show casts from enemies that are in combat. Filters out idle mobs casting nearby."] = true

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4909,16 +4909,6 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         debuffPaddingY.disableOn = function(d) return not d.showDebuffs end
         AddToSection(gridGroup, nil, 1)
         
-        -- Blizzard Settings Group (col2)
-        local blizzGroup = GUI:CreateSettingsGroup(self.child, 260)
-        blizzGroup:AddWidget(GUI:CreateHeader(self.child, L["Blizzard Frame Settings"]), 40)
-        blizzGroup:AddWidget(GUI:CreateLabel(self.child, L["Controls Blizzard's debuff filtering (affects our display too)."], 230), 35)
-        local partyDb = DF.db.party
-        blizzGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Only Dispellable Debuffs"], partyDb, "_blizzOnlyDispellable", function()
-            local newValue = partyDb._blizzOnlyDispellable
-            SetCVar("raidFramesDisplayOnlyDispellableDebuffs", newValue and 1 or 0)
-        end), 30)
-        AddToSection(blizzGroup, nil, 2)
         
         currentSection = nil
         AddSpace(10, "both")


### PR DESCRIPTION
## Problem

The **Only Dispellable Debuffs** checkbox in the Debuffs page under **Blizzard Frame Settings** set the aidFramesDisplayOnlyDispellableDebuffs CVar. This was meaningful when DF read aura data from Blizzard's compact frames (Blizzard source mode) — the CVar controlled what those frames exposed, and DF read from them.

Since 12.0.5 removed addon access to Blizzard's compact frame data, DF uses Direct API mode exclusively. The CVar now only affects Blizzard's own frames, which DF hides. The checkbox had no effect on DF's display, and the tooltip description *'affects our display too'* was no longer accurate.

## Changes

- **Options/Options.lua** — remove the entire Blizzard Frame Settings group (header, description label, checkbox) from the Debuffs page
- **Config.lua** — remove _blizzOnlyDispellable from PartyDefaults and RaidDefaults
- **Features/Auras.lua** — remove onlyDispellable read and SetCVar call from ApplyBlizzardFrameSettings
- **Core.lua** — remove the same from the duplicate ApplyBlizzardFrameSettings block there
- **Locales/enUS.lua** — remove the two now-unused locale strings

The debug commands in Dispel.lua that list CVars for diagnostic purposes are left untouched.