### PR TITLE
Fix Aura Designer settings not applying to live frames without /reload

### DIFF
--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -750,6 +750,21 @@ end
 -- Called from proxy __newindex so every setting change updates the preview in real-time
 local RefreshPreviewLightweight
 
+-- Throttled live-frame refresh: bumps adConfigVersion and re-runs UpdateFrame on all
+-- visible AD-enabled frames. Debounced so rapid slider drags only trigger one refresh.
+local pendingLiveRefresh = false
+local function RefreshLiveFramesThrottled()
+    if pendingLiveRefresh then return end
+    pendingLiveRefresh = true
+    C_Timer.After(0.1, function()
+        pendingLiveRefresh = false
+        local engine = DF.AuraDesigner and DF.AuraDesigner.Engine
+        if engine and engine.ForceRefreshAllFrames then
+            engine:ForceRefreshAllFrames()
+        end
+    end)
+end
+
 -- Global-default key mapping: which global default keys apply to placed types
 local GLOBAL_DEFAULT_MAP = {
     icon   = {
@@ -825,6 +840,7 @@ local function CreateInstanceProxy(auraName, indicatorID)
             if not inst then return end
             inst[k] = v
             if RefreshPreviewLightweight then RefreshPreviewLightweight() end
+            RefreshLiveFramesThrottled()
         end,
     })
 end
@@ -856,6 +872,7 @@ local function CreateProxy(auraName, typeKey)
             local typeCfg = EnsureTypeConfig(auraName, typeKey)
             typeCfg[k] = v
             if RefreshPreviewLightweight then RefreshPreviewLightweight() end
+            RefreshLiveFramesThrottled()
         end,
     })
 end
@@ -872,6 +889,7 @@ local function CreateAuraProxy(auraName)
             local auraCfg = EnsureAuraConfig(auraName)
             auraCfg[k] = v
             if RefreshPreviewLightweight then RefreshPreviewLightweight() end
+            RefreshLiveFramesThrottled()
         end,
     })
 end


### PR DESCRIPTION
## Problem

Multiple Aura Designer settings work correctly in the preview window but have no effect on live party/raid frames until the UI is reloaded:

- Fill color
- Border on/off, border thickness, border color
- Color Bar by Duration (expiring)
- Show Duration Text
- Hide Duration Above Threshold
- Color Duration by Time

## Root Cause

Every Aura Designer setting is written via a proxy table. All three proxy \__newindex\ handlers (CreateInstanceProxy, CreateProxy, CreateAuraProxy) save the value to the DB and call \RefreshPreviewLightweight()\ — which only updates the mock preview frame. Live unit frames were never notified of the change, so they kept running with stale config until the next \/reload\.

The various explicit \Engine:ForceRefreshAllFrames()\ calls scattered through Options.lua only cover a handful of specific controls (e.g. toggling AD on/off, changing aura source). All the per-indicator settings go through the proxy path and were missing the live-frame refresh entirely.

## Fix

Add \RefreshLiveFramesThrottled()\ — a 100ms debounced wrapper around \Engine:ForceRefreshAllFrames()\ — and call it from all three proxy \__newindex\ handlers alongside the existing \RefreshPreviewLightweight()\ call.

The 100ms debounce prevents slider drag ticks from spamming \ForceRefreshAllFrames()\ on every pixel of movement, while still applying the final value promptly when the user stops dragging.