### PR TITLE
Fix bar colour-by-time and expiring override resetting after first cast

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -3411,7 +3411,11 @@ function Indicators:HideUnusedBars(frame, activeMap)
             bar.dfAD_unit = nil
             bar.dfAD_duration = 0
             bar.dfAD_expirationTime = 0
-            bar.dfAD_colorCurve = nil
+            -- dfAD_colorCurve intentionally NOT cleared — it is static config set by
+            -- ConfigureBar and reused across aura applications. Clearing it here caused
+            -- colour-by-time and expiring colour overrides to stop working after the
+            -- first cast because ConfigureBar doesn't re-run when adConfigVersion is
+            -- unchanged. dfAD_auraInstanceID = nil is sufficient to guard the OnUpdate.
             bar.dfAD_usedTimerDuration = false
             if bar.durationCooldown then
                 bar.durationCooldown:Hide()


### PR DESCRIPTION
## Problem

Since 4.1.9, Aura Designer bars using **Colour bar by duration** or **Expiring Colour Override** (e.g. Rejuv, Germination, Lifebloom) would display correctly on the first cast, then revert to a grey/static colour on every subsequent cast until a `/reload`.

## Root Cause

`HideUnusedBars` clears `bar.dfAD_colorCurve = nil` when hiding a bar after its aura expires. When the aura is recast, `UpdateBar` runs but finds `dfAD_colorCurve` is nil and falls straight through to the static fill colour. Because `adConfigVersion` hasn't changed, `ConfigureBar` does not re-run and the curve is never rebuilt.

The curve is **static configuration** — it is built once by `ConfigureBar` from the indicator's settings (gradient stops, expiring threshold, expiring colour) and is valid for any cast of that aura. It does not contain per-instance data.

The original intent of that clear was to prevent the bar's `OnUpdate` from calling `C_UnitAuras.GetAuraDuration` with a stale `auraInstanceID`. However, `dfAD_auraInstanceID = nil` (set on the same line above) is already sufficient — the `OnUpdate` guards `if unit and auraInstanceID` before touching the curve. The `dfAD_colorCurve = nil` was redundant and caused the regression.

## Fix

Remove `bar.dfAD_colorCurve = nil` from `HideUnusedBars`. Added an explanatory comment so the reasoning is clear for future readers.

## Test plan
- [ ] Set up a bar indicator for Rejuv, Germination, or Lifebloom with **Colour bar by duration** enabled
- [ ] Cast the spell, confirm the bar shows the correct gradient colour
- [ ] Let the aura expire, recast, confirm the gradient colour still works on the second and subsequent casts
- [ ] Repeat with **Expiring Colour Override** enabled instead
- [ ] Confirm bars with no colour-by-time settings are unaffected