### PR TITLE
Fix AD health bar type animating fill on aura application

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1039,11 +1039,14 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
     local overlay = GetOrCreateTintOverlay(frame)
     if overlay then
         overlay:SetStatusBarColor(r, g, b, blend)
-        overlay:Show()
-        -- Sync fill with current health
+        -- Snap fill to current health before showing so the bar doesn't animate
+        -- from near-empty to the correct position (ExponentialEaseOut + the
+        -- min/max changing from the creation default of 0-1 to 0-maxHealth
+        -- makes the stored value of 1 render as ~0% until the smooth completes).
         if DF.UpdateADTintHealth then
-            DF:UpdateADTintHealth(frame)
+            DF:UpdateADTintHealth(frame, true)  -- true = skip smooth interpolation
         end
+        overlay:Show()
     end
 
     -- ========================================
@@ -1116,11 +1119,13 @@ end
 -- Update tint overlay fill to match current health.
 -- Called from UpdateUnitFrame and UpdateHealthFast (same pattern as
 -- DF:UpdateDispelGradientHealth and DF:UpdateMyBuffGradientHealth).
-function DF:UpdateADTintHealth(frame)
+function DF:UpdateADTintHealth(frame, skipSmooth)
     if not frame or not frame.dfAD then return end
 
     local overlay = frame.dfAD.tintOverlay
-    if not overlay or not overlay:IsShown() then return end
+    -- Allow being called before Show() (skipSmooth path from ApplyHealthBar)
+    if not overlay then return end
+    if not skipSmooth and not overlay:IsShown() then return end
 
     local unit = frame.unit
     if not unit or not UnitExists(unit) then return end
@@ -1149,7 +1154,9 @@ function DF:UpdateADTintHealth(frame)
 
     overlay:SetMinMaxValues(0, maxHealth)
 
-    local smoothEnabled = db and db.smoothBars
+    -- skipSmooth: always snap when called from ApplyHealthBar before Show()
+    -- so the bar doesn't animate from its default position to actual health.
+    local smoothEnabled = (not skipSmooth) and db and db.smoothBars
     if smoothEnabled and Enum and Enum.StatusBarInterpolation and Enum.StatusBarInterpolation.ExponentialEaseOut then
         overlay:SetValue(currentHealth, Enum.StatusBarInterpolation.ExponentialEaseOut)
     else


### PR DESCRIPTION
## Problem

When **Smooth Bars** is enabled, the Aura Designer health bar type would sometimes animate a left-to-right fill instead of immediately showing the correct colour tint.

## Root Cause

The tint overlay is created with `SetMinMaxValues(0, 1)` and `SetValue(1)` as defaults. When an aura is applied, `ApplyHealthBar` was showing the overlay first, then calling `UpdateADTintHealth` to sync the fill to actual health. With smooth bars enabled, `UpdateADTintHealth` calls `SetValue(currentHealth, ExponentialEaseOut)` after changing the range to `(0, maxHealth)` — but the overlay's stored value of `1` in the new `maxHealth` range renders as nearly 0% full, so the smooth interpolation visibly animates from empty to the player's actual health.

## Fix

Call `UpdateADTintHealth` with a `skipSmooth` flag **before** `Show()`, so the overlay snaps to the correct health position while still hidden. The bar appears already at the right fill level with no animation. Subsequent health changes during the aura's duration continue to use smooth interpolation normally.

## Test plan
- [ ] Set up an Aura Designer health bar indicator with **Smooth Bars** enabled
- [ ] Trigger the aura and confirm the health bar immediately shows the correct colour tint with no fill animation
- [ ] Take damage while the aura is active and confirm smooth health updates still work
- [ ] Confirm behaviour is unchanged when Smooth Bars is disabled