### PR TITLE
Fix bar fill colour alpha having no effect in Aura Designer

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -2797,7 +2797,7 @@ local function CreateADBar(frame, auraName)
                         end
                     end
                 end
-                self:SetStatusBarColor(barR, barG, barB, 1)
+                self:SetStatusBarColor(barR, barG, barB, self.dfAD_fillA or 1)
             end
         end
     end)
@@ -2865,6 +2865,7 @@ function Indicators:ConfigureBar(frame, config, defaults, auraName, priority)
     local fillR = fillColor and (fillColor[1] or fillColor.r) or 1
     local fillG = fillColor and (fillColor[2] or fillColor.g) or 1
     local fillB = fillColor and (fillColor[3] or fillColor.b) or 1
+    local fillA = fillColor and (fillColor[4] or fillColor.a) or 1
 
     local bgColor = config.bgColor
     if bgColor and bar.bg then
@@ -2888,6 +2889,7 @@ function Indicators:ConfigureBar(frame, config, defaults, auraName, priority)
     bar.dfAD_fillR = fillR
     bar.dfAD_fillG = fillG
     bar.dfAD_fillB = fillB
+    bar.dfAD_fillA = fillA
 
     -- Hide Icon flag (bars don't have icons but stored for consistency)
     local hideIcon = config.hideIcon; if hideIcon == nil then hideIcon = defaults and defaults.hideIcon end
@@ -3214,6 +3216,7 @@ function Indicators:UpdateBar(frame, config, auraData, defaults, auraName, prior
     local fillR = bar.dfAD_fillR or 1
     local fillG = bar.dfAD_fillG or 1
     local fillB = bar.dfAD_fillB or 1
+    local fillA = bar.dfAD_fillA or 1
 
     if bar.dfAD_colorCurve and frame.unit and auraData.auraInstanceID
        and C_UnitAuras and C_UnitAuras.GetAuraDuration then
@@ -3228,13 +3231,13 @@ function Indicators:UpdateBar(frame, config, auraData, defaults, auraName, prior
             if result and result.r then
                 bar:SetStatusBarColor(result.r, result.g, result.b)
             else
-                bar:SetStatusBarColor(fillR, fillG, fillB, 1)
+                bar:SetStatusBarColor(fillR, fillG, fillB, fillA)
             end
         else
-            bar:SetStatusBarColor(fillR, fillG, fillB, 1)
+            bar:SetStatusBarColor(fillR, fillG, fillB, fillA)
         end
     else
-        bar:SetStatusBarColor(fillR, fillG, fillB, 1)
+        bar:SetStatusBarColor(fillR, fillG, fillB, fillA)
     end
 
     -- ========================================

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -2551,8 +2551,8 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
         AddWidget(copyContainer, 38)
     end
 
-    -- Color picker callback shorthand
-    local function RPL() if RefreshPreviewLightweight then RefreshPreviewLightweight() end end
+    -- Color picker callback shorthand — refreshes both the AD preview and live frames
+    local function RPL() if RefreshPreviewLightweight then RefreshPreviewLightweight() end RefreshLiveFramesThrottled() end
 
     if typeKey == "icon" then
         -- Position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (Aura Designer) Fix bar fill colour alpha having no effect. The alpha channel of the fill colour is now applied to bar indicators in live frames and updates immediately when changed in settings.
+
 ## [4.3.7] - 2026-05-02
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- The alpha channel of `fillColor` was read from config in `ConfigureBar` but never stored or passed through — all `SetStatusBarColor` calls hardcoded alpha `1`
- Colour picker changes in the AD options called `RefreshPreviewLightweight` only, so live frames never updated without a `/reload`

## Changes

- `AuraDesigner/Indicators.lua` — extract `fillA` from `fillColor`, store as `bar.dfAD_fillA`, pass to all `SetStatusBarColor` calls in both `ConfigureBar` and `UpdateBar`
- `AuraDesigner/Options.lua` — `RPL` callback now also calls `RefreshLiveFramesThrottled` so all colour picker changes apply to live frames immediately

## Testing

- Set bar fill colour alpha to ~30% with an aura active on live frames
- Alpha now applies immediately without `/reload`
- Preview and live frames stay in sync

Fixes Lab bug #573