### PR TITLE
Fix arena frames showing wrong teammates between Solo Shuffle rounds with FrameSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (Arena/Solo Shuffle) Fix teammate frames not updating between rounds when FrameSort is active. New teammates now appear correctly at the start of each round instead of showing the previous round's team.
+
 ## [4.3.7] - 2026-05-02
 
 ### Bug Fixes

--- a/Features/FrameSort.lua
+++ b/Features/FrameSort.lua
@@ -56,7 +56,8 @@ local function UnitsToNameList(units)
     wipe(namesBuf)
     for i = 1, #units do
         local name = GetUnitName(units[i], true)
-        if name then
+        -- Guard against secret values (Midnight API restriction on some unit names)
+        if type(name) == "string" then
             namesBuf[#namesBuf + 1] = name
         end
     end
@@ -130,7 +131,7 @@ local function SortGroupedRaidFrames(units)
             wipe(groupUnitsBuf)
             for raidIndex = 1, GetNumGroupMembers() do
                 local name, _, subgroup = GetRaidRosterInfo(raidIndex)
-                if name and subgroup == groupIndex then
+                if type(name) == "string" and subgroup == groupIndex then
                     local unitToken = "raid" .. raidIndex
                     groupUnitsBuf[#groupUnitsBuf + 1] = {
                         name = name,
@@ -168,9 +169,11 @@ end
 
 -- Sort arena frames using FrameSort's unit order
 -- Note: arena header shows the player's own team (raid1-5), not opponents
+-- No IsVisible() guard: SetAttribute works on hidden frames, so we pre-set nameList
+-- even before the header is shown (e.g. after a reload in the arena prep room).
+-- The header picks it up as soon as it becomes visible.
 local function SortArenaFrames(units)
     if not DF.arenaHeader then return false end
-    if not DF.arenaHeader:IsVisible() then return false end
 
     local nameList = UnitsToNameList(units)
     if nameList == "" then return false end
@@ -249,6 +252,13 @@ local provider = {
     Sort = OnFrameSortRequest,
     Init = function() end,  -- No-op: FrameSort calls provider:Init() on all providers
 }
+
+-- Allow other modules to trigger a FrameSort sort (e.g. on arena roster change)
+function FrameSortMod:RequestSort()
+    if registered and not InCombatLockdown() then
+        OnFrameSortRequest(provider)
+    end
+end
 
 -- Check if the setting is enabled (without requiring fs to be set)
 local function IsFrameSortSettingEnabled()

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -6199,8 +6199,24 @@ function DF:ApplyArenaHeaderSorting()
     if InCombatLockdown() then return end
     if not DF.arenaHeader then return end
 
-    -- FrameSort integration: yield sorting to FrameSort when active
-    if DF:IsFrameSortActive() then return end
+    -- FrameSort integration: yield sorting to FrameSort when active.
+    -- But first clear any stale nameList from the previous Solo Shuffle round —
+    -- if we just return, SecureGroupHeaderTemplate keeps filtering by the old
+    -- teammate's name, hiding the new one. Clearing to INDEX shows all current
+    -- units immediately, then RequestSort lets FrameSort rebuild nameList.
+    if DF:IsFrameSortActive() then
+        DF.arenaHeader:SetAttribute("nameList", nil)
+        DF.arenaHeader:SetAttribute("sortMethod", "INDEX")
+        DF.arenaHeader:SetAttribute("groupBy", nil)
+        DF.arenaHeader:SetAttribute("groupingOrder", nil)
+        DF.arenaHeader:SetAttribute("groupFilter", nil)
+        DF.arenaHeader:SetAttribute("roleFilter", nil)
+        DF.arenaHeader:SetAttribute("strictFiltering", nil)
+        if DF.FrameSort and DF.FrameSort.RequestSort then
+            DF.FrameSort:RequestSort()
+        end
+        return
+    end
 
     local db = DF:GetDB()
     local selfPosition = db.sortSelfPosition or "FIRST"


### PR DESCRIPTION
## Problem

When FrameSort is active and the player is in Solo Shuffle, `ApplyArenaHeaderSorting` was returning early without clearing the `nameList` attribute set by the previous round. `SecureGroupHeaderTemplate` filters children by `nameList`, so the new teammate was hidden because their name wasn't in the stale list from the previous round.

Additionally, `UnitsToNameList` (called by FrameSort's sort callback) could crash with `invalid value (secret) at index N in table for 'concat'` when `GetUnitName` returns a Midnight secret value. Same issue existed in `SortGroupedRaidFrames` with `GetRaidRosterInfo`.

## Changes

**`Frames/Headers.lua`** — `ApplyArenaHeaderSorting`:
- Instead of simply returning when FrameSort is active, first clears `nameList` and resets to `sortMethod=INDEX` (shows all current units)
- Then calls `FrameSortMod:RequestSort()` to let FrameSort immediately apply the correct order for the new roster

**`Features/FrameSort.lua`**:
- `UnitsToNameList`: changed `if name then` to `if type(name) == "string" then` to guard against Midnight secret values from `GetUnitName`
- `SortGroupedRaidFrames`: same guard applied to `GetRaidRosterInfo` return value
- Added `FrameSortMod:RequestSort()` public method so `Headers.lua` can trigger a FrameSort sort without depending on internal state

## Test plan

- [x] Enable FrameSort integration in DandersFrames settings
- [x] Queue Solo Shuffle and verify your teammate appears on round 1
- [x] Complete a round and verify the new teammate appears correctly on round 2 (previously they would be hidden)
- [x] Verify no Lua errors in `/console errors`