### PR TITLE
Fix auras not showing on pinned frames for units absent from main frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (Pinned Frames) Fix auras not appearing on pinned frames when the pinned unit is not shown in the main party or raid frames (e.g. yourself with "Hide Self from Party Frames" enabled).
+
 ## [4.3.7] - 2026-05-07
 
 ### Bug Fixes

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -1839,8 +1839,40 @@ local directModeActive = false
 
 function directModeSubscriber:OnUnitAura(event, unit, updateInfo)
     if not unit then return end
-    -- Only process units we care about (party/raid members with DF frames)
-    if not DF.unitFrameMap or not DF.unitFrameMap[unit] then return end
+    -- Only process units shown by DF frames (main frames or pinned frames).
+    -- Main frames: O(1) check via unitFrameMap.
+    -- Pinned frames are excluded from unitFrameMap (to avoid overwriting main
+    -- frame entries), so fall through and check them when unitFrameMap misses.
+    -- Common case: player unit when hidePlayerFrame = true — the player has no
+    -- main party frame but may be pinned, causing auras to never update on the
+    -- pinned frame without this check.
+    if not DF.unitFrameMap then return end
+    if not DF.unitFrameMap[unit] then
+        -- Fast bail: non-roster units (target, focus, nameplate, etc.) are
+        -- never shown by pinned party/raid frames.
+        if not IsRosterUnit(unit) then return end
+        -- Check if any enabled pinned header currently shows this unit.
+        -- SecureGroupHeaderTemplate assigns children contiguously, so we
+        -- break as soon as GetAttribute returns nil (no more children).
+        local shownInPinned = false
+        if DF.PinnedFrames and DF.PinnedFrames.initialized and DF.PinnedFrames.headers then
+            for setIndex = 1, 2 do
+                local header = DF.PinnedFrames.headers[setIndex]
+                if header and header:IsShown() then
+                    for i = 1, 40 do
+                        local child = header:GetAttribute("child" .. i)
+                        if not child then break end  -- children are contiguous
+                        if child.unit == unit then
+                            shownInPinned = true
+                            break
+                        end
+                    end
+                end
+                if shownInPinned then break end
+            end
+        end
+        if not shownInPinned then return end
+    end
 
     DF.AuraCacheStats.eventsSeen = DF.AuraCacheStats.eventsSeen + 1
 
@@ -1899,6 +1931,27 @@ function DF:DirectScanAllUnits()
     for unit in pairs(DF.unitFrameMap) do
         ScanUnitDirect(unit)
         TriggerAuraUpdateForUnit(unit)
+    end
+    -- Also scan units shown only in pinned frames (not in unitFrameMap).
+    -- Example: player unit when hidePlayerFrame = true. Without this pass the
+    -- aura cache for those units is empty until the first UNIT_AURA fires.
+    if DF.PinnedFrames and DF.PinnedFrames.initialized and DF.PinnedFrames.headers then
+        local scanned = {}  -- avoid double-scanning units already handled above
+        for setIndex = 1, 2 do
+            local header = DF.PinnedFrames.headers[setIndex]
+            if header and header:IsShown() then
+                for i = 1, 40 do
+                    local child = header:GetAttribute("child" .. i)
+                    if not child then break end  -- children are contiguous
+                    local unit = child.unit
+                    if unit and not DF.unitFrameMap[unit] and not scanned[unit] then
+                        scanned[unit] = true
+                        ScanUnitDirect(unit)
+                        TriggerAuraUpdateForUnit(unit)
+                    end
+                end
+            end
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- Fixes auras not appearing on pinned frames when the pinned unit has no entry in the main party/raid frames — most commonly the player themselves with **Hide Self from Party Frames** enabled (bug #831)
- Extends `DirectScanAllUnits` to also populate the aura cache for pinned-only units on initial load and roster changes

## Root cause

In Direct mode (forced for all Midnight users), `directModeSubscriber:OnUnitAura` guarded on `unitFrameMap[unit]`. Pinned group frames are intentionally excluded from `unitFrameMap` to avoid overwriting main frame entries. This meant that when `hidePlayerFrame = true`, the player unit had no `unitFrameMap` entry — so the subscriber returned early on every UNIT_AURA event, leaving the aura cache empty and `TriggerAuraUpdateForUnit` never called for the player. The pinned frame's `UpdateAuras_Enhanced` would read from an empty cache and show nothing.

## Fix

When `unitFrameMap[unit]` is nil, fall through to a secondary check: iterate enabled pinned headers and see if any child currently shows that unit. `SecureGroupHeaderTemplate` assigns children contiguously, so the inner loop breaks on the first nil child — cheap in practice. If the unit is found in a pinned frame the event is processed normally; otherwise it's discarded.

`DirectScanAllUnits` gets a matching second pass that scans pinned-only units so the cache is pre-populated at load time rather than waiting for the first UNIT_AURA.

## Test plan

- [x] Enable **Hide Self from Party Frames**, add yourself to a Pinned Frame set, enter a group or use Test Mode
- [x] Verify auras appear on the pinned self-frame and update live as buffs/debuffs are applied/removed
- [x] Verify normal party/raid frames and pinned frames showing party members are unaffected
- [x] Verify no regression when both main frames and pinned frames show the same unit