### PR TITLE
Fix Aura Designer cold-cache miss on first aura application

### DIFF
--- a/AuraDesigner/AuraAdapter.lua
+++ b/AuraDesigner/AuraAdapter.lua
@@ -229,39 +229,49 @@ function Provider:GetUnitAuras(unit, spec)
             end
         end
 
-    elseif GetUnitAuras then
+    else
         -- ------------------------------------------------------------
-        -- LEGACY FALLBACK — direct GetUnitAuras scan
+        -- CACHE BOOTSTRAP — synchronous scan when cache is cold
         -- ------------------------------------------------------------
-        -- TODO (post-Blizzard-removal, ~2026-04-15): delete this entire
-        -- else branch. It's only reachable when:
-        --   (a) Blizzard mode is active and DF.AuraCache[unit] has no
-        --       buffsByID (because CaptureAurasFromBlizzardFrame doesn't
-        --       populate the Fix A fields), or
-        --   (b) Direct mode edge case where Provider:GetUnitAuras fires
-        --       before the first UNIT_AURA event for a unit.
-        -- After Blizzard mode is removed, case (a) goes away and case
-        -- (b) can be handled by calling DF:ScanUnitFull(unit) here.
-        local filters = { "HELPFUL|PLAYER", "HARMFUL" }
-        for _, filter in ipairs(filters) do
-            local auras = GetUnitAuras(unit, filter, 100)
-            if auras then
-                for _, auraData in ipairs(auras) do
+        -- Reached when cache.hasFullScan is false (or cache is nil):
+        -- Direct mode edge case where GetUnitAuras fires before the
+        -- first UNIT_AURA event has been processed for this unit (e.g.
+        -- first HOT application on a fresh group member, or zone entry
+        -- before the 0.2s DirectModeRosterUpdate delay has elapsed).
+        --
+        -- Fix: populate the cache synchronously right now so this render
+        -- pass returns real data instead of empty. Subsequent calls take
+        -- the fast path above (hasFullScan is now true).
+        --
+        -- (The old GetUnitAuras legacy fallback that lived here has been
+        -- removed — GetUnitAuras no longer exists on Midnight 12.0+.)
+        if DF.ScanUnitFull and UnitExists(unit) then
+            DF:ScanUnitFull(unit)
+            -- Re-read cache after the scan
+            cache = DF.AuraCache and DF.AuraCache[unit]
+        end
+
+        if cache and cache.hasFullScan then
+            for id, auraData in pairs(cache.buffsByID) do
+                if not IsAuraFilteredOut or not IsAuraFilteredOut(unit, id, "HELPFUL|PLAYER") then
                     scannedCount = scannedCount + 1
                     if ClassifyAuraForSpec(result, unit, spec, auraData, lookup, forwardLookup) then
                         matchedCount = matchedCount + 1
                     end
                 end
             end
-        end
 
-        -- Self-only scan on player unit (legacy path)
-        if UnitIsUnit(unit, "player") then
-            local selfOnly = DF.AuraDesigner.SelfOnlySpellIDs and DF.AuraDesigner.SelfOnlySpellIDs[spec]
-            if selfOnly then
-                local selfAuras = GetUnitAuras(unit, "HELPFUL", 100)
-                if selfAuras then
-                    for _, auraData in ipairs(selfAuras) do
+            for id, auraData in pairs(cache.debuffsByID) do
+                scannedCount = scannedCount + 1
+                if ClassifyAuraForSpec(result, unit, spec, auraData, lookup, forwardLookup) then
+                    matchedCount = matchedCount + 1
+                end
+            end
+
+            if UnitIsUnit(unit, "player") then
+                local selfOnly = DF.AuraDesigner.SelfOnlySpellIDs and DF.AuraDesigner.SelfOnlySpellIDs[spec]
+                if selfOnly then
+                    for id, auraData in pairs(cache.buffsByID) do
                         local sid = auraData.spellId
                         if sid and not issecretvalue(sid) then
                             local auraName = selfOnly[sid]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (Aura Designer) Fix indicators briefly not firing on the first aura application after joining a group or entering a new zone.
+
 ## [4.3.7] - 2026-05-07
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Fixes AD indicators not firing on the very first aura application after joining a group or entering a zone (bug #834, same root cause as #836)
- Removes dead legacy `GetUnitAuras` fallback code that has been a no-op since Midnight 12.0+ removed that API

## Root cause

`AuraAdapter:GetUnitAuras()` has a fast path (reads from `DF.AuraCache`) and a legacy fallback for when `cache.hasFullScan` is false. The fallback used `GetUnitAuras` directly — an API that no longer exists on Midnight 12.0+. The `elseif GetUnitAuras` condition silently evaluated false, so the function returned an empty table. Indicators didn't fire, then corrected themselves on the next UNIT_AURA event once the cache was properly populated.

The race window is ~0.2s after a roster change (the `DirectModeRosterUpdate` delay), so it's hard to hit in normal play but real in scripted scenarios or on zone entry with existing auras.

The code itself had a TODO comment flagging this exact fix since ~2026-04-15.

## Fix

Replace the dead `elseif GetUnitAuras` branch with a synchronous `ScanUnitFull(unit)` call. If the cache is cold when `GetUnitAuras` is called, populate it right now and read from it. All subsequent calls take the normal fast path.

## Test plan

- [x] Verify AD indicators still fire correctly in normal use (no regression)
- [x] No Lua errors on `/rl` with AD enabled
- [x] No Lua errors on zone entry or group join with tracked auras active