### PR TITLE
Add Maelstrom to resource bar color options

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -894,6 +894,7 @@ L["Low"] = true
 L["Low Health (0%)"] = true
 L["Lunar Power"] = true
 L["Mage"] = true
+L["Maelstrom"] = true
 L["Magic"] = true
 L["Major defensive cooldowns like Divine Shield, Ice Block, or Barkskin."] = true
 L["Make icons click-through for external click-casting addons. Not needed for DF built-in click-casting."] = true

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -3529,6 +3529,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             { token = "FOCUS",        name = L["Focus"] },
             { token = "ENERGY",       name = L["Energy"] },
             { token = "RUNIC_POWER",  name = L["Runic Power"] },
+            { token = "MAELSTROM",    name = L["Maelstrom"] },
             { token = "INSANITY",     name = L["Insanity"] },
             { token = "FURY",         name = L["Fury"] },
             { token = "LUNAR_POWER",  name = L["Lunar Power"] },


### PR DESCRIPTION
## What does this change?

Adds **Maelstrom** to the list of configurable resource bar colors in the Resource Bar settings page (Bars > Resource Bar > Resource Colors).

## Why?

Shamans use the Maelstrom resource type, which was not included in the `POWER_LIST` used to generate color pickers. Users who set all listed resource colors (e.g. to black) would still see Shaman resource bars rendered in Blizzard's default blue, because there was no override entry for the `MAELSTROM` token.

## Changes

- `Options/Options.lua` — Added `{ token = "MAELSTROM", name = L["Maelstrom"] }` to `POWER_LIST`
- `Locales/enUS.lua` — Added `L["Maelstrom"] = true` (alphabetically sorted)

No new settings keys, no migration needed, no logic changes. Follows the identical pattern used by all other power types. The existing `GetPowerColor`, profile export/import, and Reset All to Default button all handle Maelstrom automatically once it's in the list.