### PR TITLE
(Aura Designer) Fix health bar tint indicator not fading correctly when out of range

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1033,12 +1033,29 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
 
     local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
     local mode = string.lower(config.mode or "replace")
-    -- Both modes use the overlay — replace forces full opacity, tint uses blend slider
+    -- Replace: full opacity overlay; Tint: blend slider controls mix strength
     local blend = (mode == "replace") and 1 or (config.blend or 0.5)
+
+    -- Store on state so UpdateAuraDesignerAppearance can access these for OOR handling
+    state.healthbarMode  = mode
+    state.healthbarR     = r
+    state.healthbarG     = g
+    state.healthbarB     = b
+    state.healthbarBlend = blend
 
     local overlay = GetOrCreateTintOverlay(frame)
     if overlay then
         overlay:SetStatusBarColor(r, g, b, blend)
+        -- In replace mode, also colour the underlying health bar texture to match the overlay.
+        -- This prevents class-colour bleedthrough when the overlay fades OOR. In tint mode the
+        -- underlying bar colour is intentionally visible through the semi-transparent overlay,
+        -- so we leave it at its normal colour.
+        if mode == "replace" then
+            local hbTex = healthBar:GetStatusBarTexture()
+            if hbTex then
+                hbTex:SetVertexColor(r, g, b)
+            end
+        end
         -- Snap fill to current health before showing so the bar doesn't animate
         -- from near-empty to the correct position (ExponentialEaseOut + the
         -- min/max changing from the creation default of 0-1 to 0-maxHealth

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -1089,6 +1089,27 @@ function DF:UpdateAuraDesignerAppearance(frame)
                 end
             end
         end
+        -- Tint overlay (health bar "show when missing" indicator)
+        -- Control opacity via SetStatusBarColor rather than SetAlpha.
+        -- SetAlpha compounds with the blend baked into SetStatusBarColor:
+        -- blend × oorAlpha = e.g. 0.5 × 0.2 = 0.1 (nearly invisible OOR).
+        -- Setting SetStatusBarColor directly gives the exact target opacity.
+        local tintOverlay = frame.dfAD and frame.dfAD.tintOverlay
+        if tintOverlay and tintOverlay:IsShown() then
+            local adState = frame.dfAD
+            local r, g, b = adState.healthbarR or 1, adState.healthbarG or 1, adState.healthbarB or 1
+            local blend   = adState.healthbarBlend or 0.5
+
+            if issecretvalue and issecretvalue(inRange) then
+                -- Secret boolean fallback — can't branch; leave at configured blend.
+                tintOverlay:SetStatusBarColor(r, g, b, blend)
+            elseif inRange then
+                tintOverlay:SetStatusBarColor(r, g, b, blend)
+            else
+                tintOverlay:SetStatusBarColor(r, g, b, oorAlpha)
+            end
+            tintOverlay:SetAlpha(1.0)
+        end
     else
         -- Frame-level mode: restore each indicator's base alpha
         if frame.dfAD_icons then
@@ -1105,6 +1126,17 @@ function DF:UpdateAuraDesignerAppearance(frame)
             for _, bar in pairs(frame.dfAD_bars) do
                 if bar then bar:SetAlpha(bar.dfBaseAlpha or 1.0) end
             end
+        end
+        -- Tint overlay (health bar "show when missing" indicator)
+        -- Frame-level mode: the frame cascade handles OOR alpha. Restore the overlay's
+        -- own alpha and SetStatusBarColor to their configured values.
+        local tintOverlay = frame.dfAD and frame.dfAD.tintOverlay
+        if tintOverlay and tintOverlay:IsShown() then
+            local adState = frame.dfAD
+            local r, g, b = adState.healthbarR or 1, adState.healthbarG or 1, adState.healthbarB or 1
+            local blend   = adState.healthbarBlend or 0.5
+            tintOverlay:SetStatusBarColor(r, g, b, blend)
+            tintOverlay:SetAlpha(1.0)
         end
     end
 end


### PR DESCRIPTION
## Summary

- The Aura Designer health bar "show when missing" tint overlay was missing from `UpdateAuraDesignerAppearance`, so it never received OOR alpha in element-specific OOR mode — remaining fully opaque while all other AD indicators faded.
- A secondary issue: the tintOverlay is semi-transparent (`blend < 1`), so when it fades the underlying health bar fill shows through. That fill still held the unit's class colour (e.g. shaman blue), causing an unwanted colour change instead of a smooth fade. Fixed by matching the health bar texture colour to the AD-configured colour while the indicator is active (`adHealthBarActive` already prevents `UpdateHealthBarAppearance` from overwriting it; `RevertHealthBar` restores class colour on revert).

## Changes

**`AuraDesigner/Indicators.lua`** — `ApplyHealthBar`: after setting the tintOverlay colour, also set the main health bar texture vertex colour to the AD colour.

**`Features/ElementAppearance.lua`** — `UpdateAuraDesignerAppearance`: extend both the `oorEnabled` and frame-level branches to handle the tintOverlay. Uses plain `SetAlpha` rather than `ApplyOORAlpha` to avoid `SetAlphaFromBoolean` on health-linked StatusBars.

## Test plan

- [ ] Set up an Aura Designer health bar indicator in "show when missing" mode with a distinctive colour (e.g. red)
- [ ] Enable element-specific OOR mode
- [ ] Move out of range — the health bar tint should fade to the configured OOR alpha, maintaining the AD colour throughout (no class-colour bleedthrough)
- [ ] Return in range — tint should restore to full opacity at the AD colour
- [ ] Disable element-specific OOR mode — standard frame-level cascade should handle the fade naturally with no colour change

(PR by Krathe)