### PR TITLE
(Aura Designer) Fix health bar tint indicator stale state and live settings update

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1038,7 +1038,31 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
 
     local overlay = GetOrCreateTintOverlay(frame)
     if overlay then
+        -- Re-sync texture in case the health bar's texture changed since the overlay
+        -- was first created (frame recycled to a different unit can swap textures).
+        local currentTex = healthBar:GetStatusBarTexture()
+        overlay:SetStatusBarTexture(currentTex and currentTex:GetTexture() or "Interface\\Buttons\\WHITE8x8")
         overlay:SetStatusBarColor(r, g, b, blend)
+        -- In replace mode, also colour the underlying health bar texture to match the overlay.
+        -- This prevents class-colour bleedthrough when the overlay fades OOR. In tint mode the
+        -- underlying bar colour is intentionally visible through the semi-transparent overlay,
+        -- so we restore it to the normal class/custom colour instead.
+        if mode == "replace" then
+            local hbTex = healthBar:GetStatusBarTexture()
+            if hbTex then
+                hbTex:SetVertexColor(r, g, b)
+            end
+        else
+            -- Tint mode: the underlying bar must show its normal colour through the overlay.
+            -- A previous replace-mode apply may have left a stale AD vertex colour on hbTex.
+            -- Briefly release the AD lock so UpdateHealthBarAppearance restores the normal
+            -- class/custom colour before we re-claim the bar.
+            state.healthbar = false
+            if DF.UpdateHealthBarAppearance then
+                DF:UpdateHealthBarAppearance(frame)
+            end
+            state.healthbar = true
+        end
         -- Snap fill to current health before showing so the bar doesn't animate
         -- from near-empty to the correct position (ExponentialEaseOut + the
         -- min/max changing from the creation default of 0-1 to 0-maxHealth
@@ -1105,6 +1129,7 @@ function Indicators:RevertHealthBar(frame)
             state.tintOverlay:SetAlpha(1)
         end
         state.tintOverlay:Hide()
+        state.tintOverlay:SetStatusBarColor(1, 1, 1, 1)
     end
 
     -- Refresh health bar color so the bar shows the correct color

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -190,9 +190,13 @@ function DF:UpdateHealthBarAppearance(frame)
     -- overwrite it.  Alpha is still applied below so OOR/dead fade
     -- continues to work.
     -- ========================================
+    -- In replace mode AD owns the bar colour entirely — skip normal colour updates.
+    -- In tint mode the underlying bar shows through the overlay, so normal colour
+    -- logic (class / percent / custom) must still run.
     local adHealthBarActive = frame.dfAD and frame.dfAD.healthbar
+    local adHealthBarMode   = adHealthBarActive and frame.dfAD.healthbarMode
 
-    if adHealthBarActive then
+    if adHealthBarMode == "replace" then
         -- AD owns the color — don't touch it
     elseif aggroActive then
         -- Priority 1: Aggro override


### PR DESCRIPTION
## Summary

- **Texture re-sync on apply**: `GetOrCreateTintOverlay` captures the health bar's StatusBarTexture at creation time. When a frame is recycled to a different party member the underlying texture can change, leaving the overlay showing a stale texture. `ApplyHealthBar` now re-syncs the texture before each `Show()`.
- **Colour reset on revert**: `RevertHealthBar` now calls `SetStatusBarColor(1,1,1,1)` after hiding the overlay so stale tint from a previous unit cannot bleed through on the next activation cycle (bug 861).
- **Tint mode live update**: Switching from replace → tint mode in the settings panel now takes effect immediately on live frames without needing to toggle the aura. Previously, `UpdateHealthBarAppearance` blocked all colour updates while the AD indicator was active (including tint mode, where the underlying bar colour should still be managed normally). The guard now only blocks colour in replace mode; tint mode lets class/percent/custom colour logic run as expected.

## Test plan

- [x] Set up a health bar indicator in **replace** mode — confirm the indicator colour shows correctly in range and fades OOR
- [x] Switch to **tint** mode in the settings panel — confirm the tint updates immediately on live frames without toggling the aura
- [x] Switch back to replace mode — confirm replace mode updates immediately
- [x] With tint mode active, verify the underlying bar shows class colour (not the AD colour) visible through the overlay
- [x] Test with multiple party members to exercise frame recycling — confirm no stale texture or colour from a previous member bleeds through
- [x] Toggle the indicator on and off several times — confirm no stale tint persists after revert