### PR TITLE
Click-casting: resolve spec-replacement spell overrides at macro build time

### DIFF
--- a/ClickCasting/Bindings.lua
+++ b/ClickCasting/Bindings.lua
@@ -1937,14 +1937,38 @@ function CC:BuildMacroTextForBinding(binding, forGlobalBinding)
         -- Bindings store the spell name from the language the client was using at
         -- creation time.  We must re-resolve via spell ID so the macro contains
         -- the name WoW's parser expects on the current client language.
-        -- IMPORTANT: Always use the BASE spell name, never the override name.
-        -- WoW's /cast command is override-aware and will automatically resolve
-        -- base spells to their current form (e.g. /cast Flash of Light will cast
-        -- Benediction when the proc is active). Using the override name in the
-        -- macro causes "spell not learned" errors when the proc expires.
+        --
+        -- Override handling — two distinct cases:
+        --   1. Proc-style override (e.g. Flash of Light -> Benediction): the
+        --      base is permanently in the spellbook; the override is transient.
+        --      Keep the BASE name — /cast resolves the proc at click time, and
+        --      using the override name would cause "spell not learned" errors
+        --      when the proc expires.
+        --   2. Spec-replacement override (e.g. Remove Corruption -> Nature's
+        --      Cure for Resto Druid): the base is NOT directly castable in this
+        --      spec; only the override is in the spellbook. Use the OVERRIDE
+        --      name — /cast on the base name would fail to resolve.
+        --
+        -- Distinguish via IsSpellInSpellBook(includeOverrides=false): if the
+        -- base is directly in the book, it's proc-style; if not, it's a spec
+        -- replacement. This matches what IsSpellKnownByName already does at
+        -- bind-time, applied here at macro-build-time too. ApplyBindings is
+        -- called on ACTIVE_PLAYER_SPECIALIZATION_CHANGED / TRAIT_CONFIG_UPDATED
+        -- so the macro is regenerated when the resolution would change.
         local spellName = binding.spellName
         if binding.spellId then
-            local localizedName = GetLocalizedSpellName(binding.spellId)
+            local resolvedId = binding.spellId
+            if C_Spell.GetOverrideSpell and C_SpellBook and C_SpellBook.IsSpellInSpellBook then
+                local baseInBookDirect = C_SpellBook.IsSpellInSpellBook(
+                    binding.spellId, Enum.SpellBookSpellBank.Player, false)
+                if not baseInBookDirect then
+                    local overrideId = C_Spell.GetOverrideSpell(binding.spellId)
+                    if overrideId and overrideId ~= binding.spellId then
+                        resolvedId = overrideId
+                    end
+                end
+            end
+            local localizedName = GetLocalizedSpellName(resolvedId)
             if localizedName then
                 spellName = localizedName
             end


### PR DESCRIPTION
## Summary
- Fixes #63: click-cast macros for spec-replacement spells (e.g. Nature's Cure, Cleanse Spirit) silently failed because the macro contained the base spell name, which isn't in the replacement spec's spellbook.
- At macro-build time, distinguish proc-style overrides (e.g. Flash of Light → Benediction; base stays in book) from spec-replacement overrides (only override is in book) using `C_SpellBook.IsSpellInSpellBook(..., includeOverrides=false)`. Resolve to the override name only in the spec-replacement case so proc behavior is preserved.
- `ApplyBindings` already runs on `ACTIVE_PLAYER_SPECIALIZATION_CHANGED` / `TRAIT_CONFIG_UPDATED`, so macros regenerate when the resolution would change.

## Test plan
- [ ] Resto Druid: bind Nature's Cure → click-cast fires Nature's Cure (not Remove Corruption).
- [ ] Shaman with Cleanse Spirit talented: click-cast fires Cleanse Spirit.
- [ ] Holy Paladin: bind Flash of Light, trigger Infusion of Light → click still casts (proc resolves Flash of Light → Holy Light/Benediction); after proc expires, base name still works.
- [ ] Switch specs: macro regenerates and casts the correct spell for the new spec without re-binding.
- [ ] Non-localized client / non-English locale: macro still resolves to the correct localized name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)