### PR TITLE
(Dispel Overlay) Fix absorb bar z-ordering and gradient opacity on live frames

### DIFF
--- a/Features/Dispel.lua
+++ b/Features/Dispel.lua
@@ -1002,15 +1002,19 @@ local function ShowOverlayWithSecretColor(overlay, db, unit, auraInstanceID, fra
                     local texturePath = GRADIENT_TEXTURES[gradientStyle] or GRADIENT_TEXTURES.FULL
                     overlay.gradient:SetStatusBarTexture(texturePath)
                     
-                    -- Apply the color with baked-in alpha from curve
+                    -- Apply the color from the curve. GetRGBA() returns a secret alpha
+                    -- (the ColorMixin from GetAuraDispelTypeColor is secret-tainted) which
+                    -- SetVertexColor cannot handle in the alpha position — it silently renders
+                    -- at full opacity. Use GetRGB() for the secret-safe colour and apply the
+                    -- base opacity via the frame's own alpha instead, folding OOR in together.
+                    local gradientAlpha = math.min((db.dispelGradientAlpha or 0.5) * (db.dispelGradientIntensity or 1.0), 1.0)
                     local tex = overlay.gradient:GetStatusBarTexture()
-                    tex:SetVertexColor(gradientColor:GetRGBA())
+                    tex:SetVertexColor(gradientColor:GetRGB())
                     tex:SetBlendMode(blendMode)
-                    -- Apply OOR alpha via SetAlphaFromBoolean
                     if overlay.gradient.SetAlphaFromBoolean then
-                        overlay.gradient:SetAlphaFromBoolean(inRange, 1.0, oorDispelAlpha)
+                        overlay.gradient:SetAlphaFromBoolean(inRange, gradientAlpha, gradientAlpha * oorDispelAlpha)
                     else
-                        overlay.gradient:SetAlpha(1)
+                        overlay.gradient:SetAlpha(gradientAlpha)
                     end
                     
                     overlay.gradient:Show()

--- a/Frames/Create.lua
+++ b/Frames/Create.lua
@@ -1111,18 +1111,23 @@ function DF:CreateFrameElementsExtended(frame, db)
     -- ========================================
     -- ABSORB BAR
     -- ========================================
-    frame.dfAbsorbBar = CreateFrame("StatusBar", nil, frame)
+    -- Parent to healthBar (not frame) so frame level tracks alongside the dispel
+    -- gradient (also parented to healthBar). This prevents the gradient from
+    -- drifting above the absorb bars when SecureGroupHeaderTemplate adjusts
+    -- healthBar's frame level after creation. Levels bumped to stay above
+    -- the gradient which sits at healthBar+2.
+    frame.dfAbsorbBar = CreateFrame("StatusBar", nil, frame.healthBar)
     frame.dfAbsorbBar:SetStatusBarTexture("Interface\\RaidFrame\\Shield-Fill")
     frame.dfAbsorbBar:SetMinMaxValues(0, 1)
     frame.dfAbsorbBar:SetValue(0)
-    frame.dfAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 3)
+    frame.dfAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 4)
     frame.dfAbsorbBar:Hide()
-    
+
     local absorbBg = frame.dfAbsorbBar:CreateTexture(nil, "BACKGROUND")
     absorbBg:SetAllPoints()
     absorbBg:SetColorTexture(0, 0, 0, 0)
     frame.dfAbsorbBar.bg = absorbBg
-    
+
     local absorbBorder = CreateFrame("Frame", nil, frame.dfAbsorbBar, "BackdropTemplate")
     absorbBorder:SetPoint("TOPLEFT", -1, 1)
     absorbBorder:SetPoint("BOTTOMRIGHT", 1, -1)
@@ -1133,22 +1138,22 @@ function DF:CreateFrameElementsExtended(frame, db)
     absorbBorder:SetBackdropBorderColor(0, 0, 0, 1)
     absorbBorder:Hide()
     frame.dfAbsorbBar.border = absorbBorder
-    
+
     -- ========================================
     -- HEAL ABSORB BAR
     -- ========================================
-    frame.dfHealAbsorbBar = CreateFrame("StatusBar", nil, frame)
+    frame.dfHealAbsorbBar = CreateFrame("StatusBar", nil, frame.healthBar)
     frame.dfHealAbsorbBar:SetStatusBarTexture("Interface\\RaidFrame\\Shield-Fill")
     frame.dfHealAbsorbBar:SetMinMaxValues(0, 1)
     frame.dfHealAbsorbBar:SetValue(0)
-    frame.dfHealAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 4)
+    frame.dfHealAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 5)
     frame.dfHealAbsorbBar:Hide()
-    
+
     local healAbsorbBg = frame.dfHealAbsorbBar:CreateTexture(nil, "BACKGROUND")
     healAbsorbBg:SetAllPoints()
     healAbsorbBg:SetColorTexture(0, 0, 0, 0)
     frame.dfHealAbsorbBar.bg = healAbsorbBg
-    
+
     local healAbsorbBorder = CreateFrame("Frame", nil, frame.dfHealAbsorbBar, "BackdropTemplate")
     healAbsorbBorder:SetPoint("TOPLEFT", -1, 1)
     healAbsorbBorder:SetPoint("BOTTOMRIGHT", 1, -1)
@@ -1828,18 +1833,23 @@ function DF:CreateUnitFrame(unit, index, isRaid)
     -- ========================================
     -- ABSORB BAR
     -- ========================================
-    frame.dfAbsorbBar = CreateFrame("StatusBar", nil, frame)
+    -- Parent to healthBar (not frame) so frame level tracks alongside the dispel
+    -- gradient (also parented to healthBar). This prevents the gradient from
+    -- drifting above the absorb bars when SecureGroupHeaderTemplate adjusts
+    -- healthBar's frame level after creation. Levels bumped to stay above
+    -- the gradient which sits at healthBar+2.
+    frame.dfAbsorbBar = CreateFrame("StatusBar", nil, frame.healthBar)
     frame.dfAbsorbBar:SetStatusBarTexture("Interface\\RaidFrame\\Shield-Fill")
     frame.dfAbsorbBar:SetMinMaxValues(0, 1)
     frame.dfAbsorbBar:SetValue(0)
-    frame.dfAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 3)
+    frame.dfAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 4)
     frame.dfAbsorbBar:Hide()
-    
+
     local absorbBg = frame.dfAbsorbBar:CreateTexture(nil, "BACKGROUND")
     absorbBg:SetAllPoints()
     absorbBg:SetColorTexture(0, 0, 0, 0)
     frame.dfAbsorbBar.bg = absorbBg
-    
+
     -- Border for absorb bar
     local absorbBorder = CreateFrame("Frame", nil, frame.dfAbsorbBar, "BackdropTemplate")
     absorbBorder:SetPoint("TOPLEFT", -1, 1)
@@ -1851,22 +1861,22 @@ function DF:CreateUnitFrame(unit, index, isRaid)
     absorbBorder:SetBackdropBorderColor(0, 0, 0, 1)
     absorbBorder:Hide()
     frame.dfAbsorbBar.border = absorbBorder
-    
+
     -- ========================================
     -- HEAL ABSORB BAR
     -- ========================================
-    frame.dfHealAbsorbBar = CreateFrame("StatusBar", nil, frame)
+    frame.dfHealAbsorbBar = CreateFrame("StatusBar", nil, frame.healthBar)
     frame.dfHealAbsorbBar:SetStatusBarTexture("Interface\\RaidFrame\\Shield-Fill")
     frame.dfHealAbsorbBar:SetMinMaxValues(0, 1)
     frame.dfHealAbsorbBar:SetValue(0)
-    frame.dfHealAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 4)
+    frame.dfHealAbsorbBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 5)
     frame.dfHealAbsorbBar:Hide()
-    
+
     local healAbsorbBg = frame.dfHealAbsorbBar:CreateTexture(nil, "BACKGROUND")
     healAbsorbBg:SetAllPoints()
     healAbsorbBg:SetColorTexture(0, 0, 0, 0)
     frame.dfHealAbsorbBar.bg = healAbsorbBg
-    
+
     -- Border for heal absorb bar
     local healAbsorbBorder = CreateFrame("Frame", nil, frame.dfHealAbsorbBar, "BackdropTemplate")
     healAbsorbBorder:SetPoint("TOPLEFT", -1, 1)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -7423,11 +7423,11 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         gradSize.hideOn = HideDispelOptions
         local gradAlpha = gradientGroup:AddWidget(GUI:CreateSlider(self.child, L["Gradient Opacity"], 0.1, 1.0, 0.1, db, "dispelGradientAlpha", function()
             InvalidateCurves()
-        end, function() DF:LightweightUpdateDispelOverlay() end, true), 55)
+        end, function() DF:InvalidateDispelColorCurve(); DF:LightweightUpdateDispelOverlay() end, true), 55)
         gradAlpha.hideOn = HideDispelOptions
         local gradIntensity = gradientGroup:AddWidget(GUI:CreateSlider(self.child, L["Gradient Intensity"], 0.5, 3.0, 0.1, db, "dispelGradientIntensity", function()
             InvalidateCurves()
-        end, function() DF:LightweightUpdateDispelOverlay() end, true), 55)
+        end, function() DF:InvalidateDispelColorCurve(); DF:LightweightUpdateDispelOverlay() end, true), 55)
         gradIntensity.hideOn = HideDispelOptions
         local blendModes = { ["ADD"]= L["Glow (ADD)"], ["BLEND"]= L["Solid (BLEND)"] }
         local blendDropdown = gradientGroup:AddWidget(GUI:CreateDropdown(self.child, L["Blend Mode"], blendModes, db, "dispelGradientBlendMode", function()


### PR DESCRIPTION
## Summary

- **Absorb bar z-ordering (https://danders-lab.netlify.app/bugs/865)**: `dfAbsorbBar` and `dfHealAbsorbBar` were parented to `frame` with frame levels set to `healthBar+3` and `healthBar+4` at creation. The dispel gradient is a child of `healthBar` at `healthBar+2`, so its effective level floats when `SecureGroupHeaderTemplate` adjusts `healthBar`'s level after creation. Re-parenting the absorb bars to `healthBar` and bumping their levels to `+4`/`+5` ensures all three track frame level changes together — the gradient can never drift above the absorbs.

- **Gradient opacity on live frames**: `ShowOverlayWithSecretColor` called `tex:SetVertexColor(gradientColor:GetRGBA())`, passing the alpha channel from a secret `ColorMixin` returned by `C_UnitAuras.GetAuraDispelTypeColor`. `SetVertexColor` cannot handle secret values in the alpha position and silently renders at full opacity. Fixed by using `GetRGB()` for the secret-safe colour and folding the base opacity into the `SetAlphaFromBoolean` call on the gradient frame (`inAlpha=gradientAlpha`, `oorAlpha=gradientAlpha*oorAlpha`). This also means health-tracking `SetValue` calls in `UpdateDispelGradientHealth` can no longer reset the opacity, which explains why the bug only manifested on live frames (not test mode, where health events don't fire).

- **Opacity slider live preview**: The gradient opacity and intensity slider preview callbacks (during drag) were not invalidating the curve cache. On live frames, the next `UNIT_AURA` event would call `UpdateDispelOverlay` → `GetGradientCurve` → return the stale cached curve → overwrite whatever the lightweight update had just applied. Added `InvalidateDispelColorCurve()` to both preview callbacks.

## Test plan

- [ ] With a dispellable debuff active on a live frame, confirm the absorb bar (shield) remains visible on top of the dispel gradient overlay
- [ ] Change group size mid-session to trigger frame re-layout — absorb bars should remain above the gradient
- [ ] Drag the Gradient Opacity slider — confirm the gradient on live frames responds in real time
- [ ] Drag the Gradient Intensity slider — confirm the same
- [ ] Confirm OOR fading still applies correctly to the gradient when targets go out of range