### PR TITLE
(Dispel Overlay) Fix overlay leaking onto live frames when editing settings in test mode

### DIFF
--- a/Features/Dispel.lua
+++ b/Features/Dispel.lua
@@ -1666,6 +1666,34 @@ end
 -- ============================================================
 
 function DF:UpdateAllDispelOverlays()
+    -- In test mode, only update test frames.  Live frames are hidden behind the
+    -- test container and must not receive overlay state derived from test data —
+    -- if they do, the overlay appears "stuck" on live frames after test mode
+    -- closes.  When test mode exits, DF.testMode is set to false *before* the
+    -- cleanup C_Timer fires, so the live-frame cleanup pass still runs correctly.
+    if DF.testMode or DF.raidTestMode then
+        if DF.testMode and DF.testPartyFrames then
+            local db = DF:GetDB()
+            local count = db and db.testFrameCount or 5
+            for i = 0, count - 1 do
+                local frame = DF.testPartyFrames[i]
+                if frame and frame:IsShown() then
+                    DF:UpdateDispelOverlay(frame)
+                end
+            end
+        end
+        if DF.raidTestMode and DF.testRaidFrames then
+            local raidDb = DF:GetRaidDB()
+            local count = raidDb and raidDb.raidTestFrameCount or 10
+            for i = 1, count do
+                local frame = DF.testRaidFrames[i]
+                if frame and frame:IsShown() then
+                    DF:UpdateDispelOverlay(frame)
+                end
+            end
+        end
+        return
+    end
     DF:IterateAllFrames(function(frame)
         if frame then
             DF:UpdateDispelOverlay(frame)


### PR DESCRIPTION
## Summary

- `UpdateAllDispelOverlays` iterates live party/raid frames via `IterateAllFrames` with no test-mode check
- When called during test mode (e.g. slider commit in the Dispel Overlay settings panel), `UpdateDispelOverlay` runs the test-mode branch on live secure frames and calls `ShowOverlayWithRGB` with test data on those hidden live frames
- When test mode closes and live frames become visible, the dispel overlay appears stuck on them — only a `/reload` clears it
- Fix: `UpdateAllDispelOverlays` now detects active test mode and routes to the test frame arrays directly, skipping live frames entirely
- When test mode exits (`testMode = false` is set before the cleanup timer fires), the live-frame cleanup pass runs correctly via the normal `IterateAllFrames` path

## Test plan

- [ ] Enter test mode (`/df test`)
- [ ] Enable dispel overlay glow on at least one test frame
- [ ] Open Settings → Dispel Overlay, drag and commit any slider (opacity, border, gradient, etc.)
- [ ] Close test mode
- [ ] Confirm no dispel overlay is stuck on any live frame — no `/reload` required
- [ ] Confirm dispel overlays still appear correctly on live frames when a unit actually has a dispellable debuff