### PR TITLE
(Aura Blacklist) Fix incorrect icon for Skyfury in Buff Blacklist

### DIFF
--- a/AuraBlacklist/Config.lua
+++ b/AuraBlacklist/Config.lua
@@ -81,7 +81,7 @@ DF.AuraBlacklist.BuffSpells = {
         { spellId = 444490, display = "Hydrobubble",            icon = 1320371  },
         { spellId = 20608,  display = "Reincarnation",          icon = 451167   },
         { spellId = 61295,  display = "Riptide",                icon = 252995   },
-        { spellId = 462854, display = "Skyfury",                icon = 135831   },
+        { spellId = 462854, display = "Skyfury",                icon = 4630367  },
         { spellId = 369459, display = "Source of Magic",        icon = 4630412  },
         { spellId = 462757, display = "Thunderstrike Ward",     icon = 5975854  },
         { spellId = 457496, display = "Tidecaller's Guard",     icon = 1355357  },


### PR DESCRIPTION
## Summary

- The Skyfury entry in the Shaman Buff Blacklist (`AuraBlacklist/Config.lua` line 84) used icon `135831` (Windfury Weapon), which is unrelated to Skyfury.
- Replaced with the correct file data ID `4630367` (`achievement_raidprimalist_windelemental`), confirmed via the Wowhead tooltip API for spellId 462854.

## Test plan

- [x] Open Options → Auras → Aura Blacklist → Buff Blacklist, select SHAMAN class
- [x] Confirm the Skyfury row now shows the correct wind elemental icon instead of the Windfury Weapon icon