### PR TITLE
(Pet Frames) Fix RIGHT anchor misalignment in ATTACHED and GROUPED modes

### DIFF
--- a/Frames/Pets.lua
+++ b/Frames/Pets.lua
@@ -701,7 +701,7 @@ function DF:PositionPetFrame(frame)
     elseif anchor == "LEFT" then
         frame:SetPoint("RIGHT", frame.ownerFrame, "LEFT", offsetX, offsetY)
     elseif anchor == "RIGHT" then
-        frame:SetPoint("LEFT", frame.ownerFrame, "RIGHT", -offsetX, offsetY)
+        frame:SetPoint("LEFT", frame.ownerFrame, "RIGHT", offsetX, offsetY)
     end
 end
 
@@ -883,9 +883,9 @@ function DF:UpdatePetGroupLayout()
                 end
             elseif anchor == "RIGHT" then
                 if partyGrowth == "HORIZONTAL" then
-                    container:SetPoint("LEFT", rightmostFrame, "RIGHT", -offsetX, offsetY)
+                    container:SetPoint("LEFT", rightmostFrame, "RIGHT", offsetX, offsetY)
                 else
-                    container:SetPoint("TOPLEFT", bottommostFrame, "TOPRIGHT", -offsetX, -centerOffsetY + offsetY)
+                    container:SetPoint("TOPLEFT", topmostFrame, "TOPRIGHT", offsetX, -centerOffsetY + offsetY)
                 end
             end
             


### PR DESCRIPTION
## Summary

Two related issues with the RIGHT pet anchor, both in `Frames/Pets.lua`:

**1. GROUPED + VERTICAL: container anchored to wrong frame (main bug)**

In `UpdatePetGroupLayout`, the `anchor == "RIGHT"` + `partyGrowth == "VERTICAL"` branch was anchoring the pet container to `bottommostFrame` instead of `topmostFrame`. This placed the entire pet container below the party stack rather than alongside it. The LEFT anchor case correctly uses `topmostFrame`; this makes RIGHT symmetric with it.

**2. Inverted `offsetX` sign on all RIGHT anchor paths**

All three RIGHT anchor `SetPoint` calls used `-offsetX`, meaning a positive Offset X value moved the pet *toward* the owner rather than away from it. Fixed to use `offsetX` directly (no negation), so positive Offset X consistently nudges the pet rightward (more gap) — the intuitive behaviour for an Offset X slider when the pet is positioned to the right.

Affected paths:
- `PositionPetFrame` — ATTACHED mode (line 704)
- `UpdatePetGroupLayout` — GROUPED + HORIZONTAL (line 886)
- `UpdatePetGroupLayout` — GROUPED + VERTICAL (line 888)

Addresses the issue reported in https://discord.com/channels/1443538945605636149/1500157530763165696. Also supersedes PR #68 which fixes the `bottommostFrame` issue alone.

## Test plan

- [x] GROUPED mode, RIGHT anchor, VERTICAL party growth — pet container sits alongside the party stack at the correct vertical position
- [x] GROUPED mode, RIGHT anchor, HORIZONTAL party growth — pet container is correctly placed to the right
- [x] ATTACHED mode, RIGHT anchor — individual pet frames sit to the right of their owner frames
- [x] Non-zero Offset X with RIGHT anchor — positive value increases the gap (pet moves right), negative closes it