### PR TITLE
(Pet Frames) Fix Lua error on pet name update in instanced content

### DIFF
--- a/Frames/Pets.lua
+++ b/Frames/Pets.lua
@@ -536,11 +536,15 @@ function DF:UpdatePetName(frame)
     
     local name = GetUnitName(frame.unit, true)
     if name then
-        -- Truncate long names
+        -- Truncate long names. Use secret-value-safe UTF-8 helpers — GetUnitName
+        -- can return a secret string in instanced content (delves, encounters).
+        -- DF:UTF8Len returns 0 for secret values so the truncation branch
+        -- no-ops, and SetText receives the secret string directly (FontStrings
+        -- accept secret values; only Lua string ops on them cause errors).
         local db = DF:GetFrameDB(frame)
         local maxLen = db.petNameMaxLength or 12
-        if #name > maxLen then
-            name = name:sub(1, maxLen) .. "..."
+        if maxLen > 0 and DF:UTF8Len(name) > maxLen then
+            name = DF:UTF8Sub(name, 1, maxLen) .. "..."
         end
         frame.nameText:SetText(name)
     end


### PR DESCRIPTION
## Summary

`DF:UpdatePetName` called `#name` and `name:sub()` on the result of `GetUnitName`, which throws a Lua error in delves and encounters where unit names are returned as secret string values in Midnight 12.0. `GetUnitName` does **not** guarantee a non-secret result in instanced content (contrary to the assumption in commit b36ffc3).

Routes truncation through `DF:UTF8Len` / `DF:UTF8Sub` (the same helpers used in `Frames/Bars.lua:UpdateName`), which both gate on `issecretvalue` internally and return safe defaults when the input is secret. The truncation branch silently no-ops, `SetText` still receives the secret string, and FontStrings render it correctly — only Lua string operations on secret values cause errors.

**Supersedes PR #67**, which guards the entire block with `not issecretvalue(name)`, preventing the crash but also skipping `SetText` entirely — leaving the pet name text stale instead of updating it.

Also adds a `maxLen > 0` guard, consistent with `Bars.lua`, so a max-length setting of 0 (no limit) is correctly handled.

## Test plan

- [ ] `/reload` while in a delve on a pet class (warlock, hunter, etc.) — no Lua error spam on pet name updates
- [ ] Normal world pet (outside instance) — name still displays and truncates correctly when longer than `petNameMaxLength`
- [ ] Boss encounters — no regression from the previous b36ffc3 fix