### PR TITLE
Fix FrameSort frame ordering instability in Solo Shuffle

### DIFF
--- a/Features/FrameSort.lua
+++ b/Features/FrameSort.lua
@@ -12,6 +12,7 @@ local GetUnitName = GetUnitName
 local GetNumGroupMembers = GetNumGroupMembers
 local GetRaidRosterInfo = GetRaidRosterInfo
 local IsInRaid = IsInRaid
+local issecretvalue = issecretvalue
 local wipe = wipe
 local tconcat = table.concat
 local tsort = table.sort
@@ -56,8 +57,10 @@ local function UnitsToNameList(units)
     wipe(namesBuf)
     for i = 1, #units do
         local name = GetUnitName(units[i], true)
-        -- Guard against secret values (Midnight API restriction on some unit names)
-        if type(name) == "string" then
+        -- Skip nil and secret values (Midnight 12.0 returns opaque secret strings
+        -- for some unit names in instanced content; type() == "string" is not
+        -- sufficient — secret values pass that check but crash table.concat).
+        if name and not issecretvalue(name) then
             namesBuf[#namesBuf + 1] = name
         end
     end

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -6199,11 +6199,17 @@ function DF:ApplyArenaHeaderSorting()
     if InCombatLockdown() then return end
     if not DF.arenaHeader then return end
 
-    -- FrameSort integration: yield sorting to FrameSort when active.
-    -- But first clear any stale nameList from the previous Solo Shuffle round —
-    -- if we just return, SecureGroupHeaderTemplate keeps filtering by the old
-    -- teammate's name, hiding the new one. Clearing to INDEX shows all current
-    -- units immediately, then RequestSort lets FrameSort rebuild nameList.
+    -- FrameSort integration: yield sorting entirely to FrameSort when active.
+    -- Clear any stale nameList from the previous Solo Shuffle round so
+    -- SecureGroupHeaderTemplate stops filtering by an old teammate's name and
+    -- shows all current units in INDEX order immediately.
+    -- Do NOT call RequestSort() here — that would fire synchronously in the same
+    -- event frame as GROUP_ROSTER_UPDATE, before WoW has finished assigning units
+    -- to raid slots. The stale data would produce the wrong nameList, which then
+    -- persists for the whole round once combat starts.
+    -- FrameSort's Blizzard provider already schedules a sort on every
+    -- GROUP_ROSTER_UPDATE; it calls our Sort() via RequestSelfManagedProvidersSort()
+    -- on the next OnUpdate frame, by which time the unit API is fully settled.
     if DF:IsFrameSortActive() then
         DF.arenaHeader:SetAttribute("nameList", nil)
         DF.arenaHeader:SetAttribute("sortMethod", "INDEX")
@@ -6212,9 +6218,6 @@ function DF:ApplyArenaHeaderSorting()
         DF.arenaHeader:SetAttribute("groupFilter", nil)
         DF.arenaHeader:SetAttribute("roleFilter", nil)
         DF.arenaHeader:SetAttribute("strictFiltering", nil)
-        if DF.FrameSort and DF.FrameSort.RequestSort then
-            DF.FrameSort:RequestSort()
-        end
         return
     end
 
@@ -7775,8 +7778,16 @@ headerEventFrame:SetScript("OnEvent", function(self, event, arg1, arg2)
             if DF.debugHeaders then
                 print("|cFF00FF00[DF Headers]|r Applying queued sorting update after combat")
             end
-            -- Re-run ProcessRosterUpdate which will now apply sorting
-            DF:ProcessRosterUpdate()
+            -- When FrameSort integration is active, FrameSort already fires its own
+            -- combat-end sort synchronously on PLAYER_REGEN_ENABLED (via its
+            -- RunWhenCombatEnds callback queue). Calling ProcessRosterUpdate here
+            -- would run ApplyArenaHeaderSorting → clear nameList to INDEX, undoing
+            -- FrameSort's work. The event handler order between DF and FrameSort is
+            -- non-deterministic, so this caused intermittent wrong ordering between
+            -- Solo Shuffle rounds. Let FrameSort own the sort entirely.
+            if not DF:IsFrameSortActive() then
+                DF:ProcessRosterUpdate()
+            end
             -- BUG #4 FIX: Force refresh all frames after arena combat-end recovery.
             -- Health bars may show stale data because UNIT_HEALTH events were dropped
             -- while the arena header was hidden / events disabled.


### PR DESCRIPTION
## Summary

- Fix `table.concat` Lua crash in FrameSort's sort callback caused by Midnight 12.0 secret values passing the `type() == "string"` guard — replaced with `issecretvalue()` check
- Fix race condition in `ApplyArenaHeaderSorting`: removed synchronous `RequestSort()` call that fired with stale unit data before WoW finished reassigning raid slots after a Solo Shuffle round transition; FrameSort's Blizzard provider already schedules a correct sort on the next frame
- Fix race condition in `PLAYER_REGEN_ENABLED`: added `IsFrameSortActive()` guard around `ProcessRosterUpdate()` so DF no longer clobbers FrameSort's combat-end sort when the integration is active (event handler order between DF and FrameSort is non-deterministic)

## Test plan

- [x] Enable FrameSort integration in DF settings
- [x] Play several Solo Shuffle rounds — frame ordering should match FrameSort's configured sort (e.g. Player: Middle) consistently across all rounds, with no oscillation between rounds
- [x] Confirm no Lua errors appear in FrameSort's log during round transitions
- [x] Confirm behaviour is unchanged when FrameSort integration is disabled