### PR TITLE
Fix Aura Designer health bar expiring colour flashing back to active colour

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1050,6 +1050,12 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
     state.healthbarCurrentR = r
     state.healthbarCurrentG = g
     state.healthbarCurrentB = b
+    -- healthbarEffectiveBlend: the alpha last written to the overlay by
+    -- UpdateAuraDesignerAppearance (blend in-range, oorAlpha OOR). Expiring
+    -- callbacks read this so they don't override the OOR fade back to full
+    -- blend between UpdateAuraDesignerAppearance calls. Not reset here so
+    -- OOR state is preserved across UNIT_AURA events; nil on first use falls
+    -- back to entry.blend in the callbacks.
 
     local overlay = GetOrCreateTintOverlay(frame)
     if overlay then
@@ -1057,7 +1063,9 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
         -- was first created (frame recycled to a different unit can swap textures).
         local currentTex = healthBar:GetStatusBarTexture()
         overlay:SetStatusBarTexture(currentTex and currentTex:GetTexture() or "Interface\\Buttons\\WHITE8x8")
-        overlay:SetStatusBarColor(r, g, b, blend)
+        -- Use OOR-aware blend if already established (preserves OOR fade on UNIT_AURA).
+        local initialBlend = state.healthbarEffectiveBlend or blend
+        overlay:SetStatusBarColor(r, g, b, initialBlend)
         -- In replace mode, also colour the underlying health bar texture to match the overlay.
         -- This prevents class-colour bleedthrough when the overlay fades OOR. In tint mode the
         -- underlying bar colour is intentionally visible through the semi-transparent overlay,
@@ -1112,12 +1120,14 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
             thresholdMode = config.expiringThresholdMode,
             color = ec, originalColor = oc,
             applyResult = function(el, result, entry)
-                el:SetStatusBarColor(result.r, result.g, result.b, entry.blend)
+                local adState = frame.dfAD
+                -- Use OOR-aware blend if UpdateAuraDesignerAppearance has set one.
+                local effectiveBlend = (adState and adState.healthbarEffectiveBlend) or entry.blend
+                el:SetStatusBarColor(result.r, result.g, result.b, effectiveBlend)
                 local oc2 = entry.originalColor
                 local isExp = IsColorExpiring(result, oc2)
                 -- Keep current-color in sync so UpdateAuraDesignerAppearance
                 -- (OOR handler) uses the expiring color rather than the active one.
-                local adState = frame.dfAD
                 if adState then
                     adState.healthbarCurrentR = result.r
                     adState.healthbarCurrentG = result.g
@@ -1128,10 +1138,12 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
             applyManual = function(el, isExp, entry)
                 local c = isExp and entry.color or entry.originalColor
                 local cr, cg, cb = c.r or 1, c.g or 1, c.b or 1
-                el:SetStatusBarColor(cr, cg, cb, entry.blend)
+                local adState = frame.dfAD
+                -- Use OOR-aware blend if UpdateAuraDesignerAppearance has set one.
+                local effectiveBlend = (adState and adState.healthbarEffectiveBlend) or entry.blend
+                el:SetStatusBarColor(cr, cg, cb, effectiveBlend)
                 -- Keep current-color in sync so UpdateAuraDesignerAppearance
                 -- (OOR handler) uses the expiring color rather than the active one.
-                local adState = frame.dfAD
                 if adState then
                     adState.healthbarCurrentR = cr
                     adState.healthbarCurrentG = cg
@@ -1163,6 +1175,13 @@ function Indicators:RevertHealthBar(frame)
         state.tintOverlay:Hide()
         state.tintOverlay:SetStatusBarColor(1, 1, 1, 1)
     end
+
+    -- Clear tracked color and blend so stale values don't affect the next
+    -- aura that claims this frame's health bar indicator.
+    state.healthbarCurrentR      = nil
+    state.healthbarCurrentG      = nil
+    state.healthbarCurrentB      = nil
+    state.healthbarEffectiveBlend = nil
 
     -- Refresh health bar color so the bar shows the correct color
     -- (class color, custom color, etc.) after the overlay is removed.

--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1038,11 +1038,18 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
 
     -- Store on state so UpdateAuraDesignerAppearance / UpdateHealthBarAppearance
     -- can access these for OOR handling and the replace/tint mode gate.
-    state.healthbarMode  = mode
-    state.healthbarR     = r
-    state.healthbarG     = g
-    state.healthbarB     = b
-    state.healthbarBlend = blend
+    state.healthbarMode     = mode
+    state.healthbarR        = r
+    state.healthbarG        = g
+    state.healthbarB        = b
+    state.healthbarBlend    = blend
+    -- Track the currently displayed color (may differ from healthbarR/G/B when
+    -- the expiring ticker has switched the overlay to the expiring color).
+    -- UpdateAuraDesignerAppearance reads this so it doesn't reset the expiring
+    -- color back to the active color on every UNIT_AURA event.
+    state.healthbarCurrentR = r
+    state.healthbarCurrentG = g
+    state.healthbarCurrentB = b
 
     local overlay = GetOrCreateTintOverlay(frame)
     if overlay then
@@ -1108,11 +1115,28 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
                 el:SetStatusBarColor(result.r, result.g, result.b, entry.blend)
                 local oc2 = entry.originalColor
                 local isExp = IsColorExpiring(result, oc2)
+                -- Keep current-color in sync so UpdateAuraDesignerAppearance
+                -- (OOR handler) uses the expiring color rather than the active one.
+                local adState = frame.dfAD
+                if adState then
+                    adState.healthbarCurrentR = result.r
+                    adState.healthbarCurrentG = result.g
+                    adState.healthbarCurrentB = result.b
+                end
                 UpdatePulseState(el, isExp)
             end,
             applyManual = function(el, isExp, entry)
                 local c = isExp and entry.color or entry.originalColor
-                el:SetStatusBarColor(c.r or 1, c.g or 1, c.b or 1, entry.blend)
+                local cr, cg, cb = c.r or 1, c.g or 1, c.b or 1
+                el:SetStatusBarColor(cr, cg, cb, entry.blend)
+                -- Keep current-color in sync so UpdateAuraDesignerAppearance
+                -- (OOR handler) uses the expiring color rather than the active one.
+                local adState = frame.dfAD
+                if adState then
+                    adState.healthbarCurrentR = cr
+                    adState.healthbarCurrentG = cg
+                    adState.healthbarCurrentB = cb
+                end
                 UpdatePulseState(el, isExp)
             end,
         })

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -1101,7 +1101,13 @@ function DF:UpdateAuraDesignerAppearance(frame)
         local tintOverlay = frame.dfAD and frame.dfAD.tintOverlay
         if tintOverlay and tintOverlay:IsShown() then
             local adState = frame.dfAD
-            local r, g, b = adState.healthbarR or 1, adState.healthbarG or 1, adState.healthbarB or 1
+            -- Use the current displayed color (healthbarCurrent*), which the expiring
+            -- ticker updates to the expiring color when past the threshold. Falling back
+            -- to healthbarR/G/B (the configured active color) covers the non-expiring
+            -- case and initial setup before any ticker callback has fired.
+            local r = adState.healthbarCurrentR or adState.healthbarR or 1
+            local g = adState.healthbarCurrentG or adState.healthbarG or 1
+            local b = adState.healthbarCurrentB or adState.healthbarB or 1
             local blend   = adState.healthbarBlend or 0.5
 
             if issecretvalue and issecretvalue(inRange) then
@@ -1137,7 +1143,11 @@ function DF:UpdateAuraDesignerAppearance(frame)
         local tintOverlay = frame.dfAD and frame.dfAD.tintOverlay
         if tintOverlay and tintOverlay:IsShown() then
             local adState = frame.dfAD
-            local r, g, b = adState.healthbarR or 1, adState.healthbarG or 1, adState.healthbarB or 1
+            -- Use the current displayed color (healthbarCurrent*) so the expiring
+            -- color is preserved rather than reset to the active configured color.
+            local r = adState.healthbarCurrentR or adState.healthbarR or 1
+            local g = adState.healthbarCurrentG or adState.healthbarG or 1
+            local b = adState.healthbarCurrentB or adState.healthbarB or 1
             local blend   = adState.healthbarBlend or 0.5
             tintOverlay:SetStatusBarColor(r, g, b, blend)
             tintOverlay:SetAlpha(1.0)

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -1110,15 +1110,20 @@ function DF:UpdateAuraDesignerAppearance(frame)
             local b = adState.healthbarCurrentB or adState.healthbarB or 1
             local blend   = adState.healthbarBlend or 0.5
 
+            local effectiveBlend
             if issecretvalue and issecretvalue(inRange) then
                 -- Secret boolean fallback — can't branch; leave at configured blend.
-                tintOverlay:SetStatusBarColor(r, g, b, blend)
+                effectiveBlend = blend
             elseif inRange then
-                tintOverlay:SetStatusBarColor(r, g, b, blend)
+                effectiveBlend = blend
             else
-                tintOverlay:SetStatusBarColor(r, g, b, oorAlpha)
+                effectiveBlend = oorAlpha
             end
+            tintOverlay:SetStatusBarColor(r, g, b, effectiveBlend)
             tintOverlay:SetAlpha(1.0)
+            -- Record the alpha used so expiring callbacks (ticker) can match it
+            -- rather than resetting to full blend when the unit is OOR.
+            adState.healthbarEffectiveBlend = effectiveBlend
         end
     else
         -- Frame-level mode: restore each indicator's base alpha
@@ -1148,9 +1153,12 @@ function DF:UpdateAuraDesignerAppearance(frame)
             local r = adState.healthbarCurrentR or adState.healthbarR or 1
             local g = adState.healthbarCurrentG or adState.healthbarG or 1
             local b = adState.healthbarCurrentB or adState.healthbarB or 1
-            local blend   = adState.healthbarBlend or 0.5
+            local blend = adState.healthbarBlend or 0.5
             tintOverlay:SetStatusBarColor(r, g, b, blend)
             tintOverlay:SetAlpha(1.0)
+            -- In frame-level mode the frame cascade handles OOR alpha, so the
+            -- effective blend for this overlay is always the configured blend.
+            adState.healthbarEffectiveBlend = blend
         end
     end
 end


### PR DESCRIPTION
## Summary

- `UpdateAuraDesignerAppearance` (added for OOR fade support) ran after every `Engine:UpdateFrame` and reset the tint overlay to the configured active colour (`healthbarR/G/B`), undoing the expiring colour the 3 FPS ticker had applied. This caused a visible flash between active and expiring colours on every `UNIT_AURA` event while an aura was past its expiring threshold (e.g. green↔red flicker on Renew at <30% duration)
- The expiring ticker also called `SetStatusBarColor` with the full configured `blend` rather than the OOR alpha, so the flash persisted when the target was out of range
- Fix: added `healthbarCurrentR/G/B` and `healthbarEffectiveBlend` tracking on `frame.dfAD`. `UpdateAuraDesignerAppearance` writes the effective alpha it uses (blend in-range, oorAlpha OOR) and reads the current displayed colour. Expiring callbacks read `healthbarEffectiveBlend` so they always match the OOR state. All tracked fields are cleared in `RevertHealthBar`.

## Test plan

- [ ] Configure a health bar indicator with an expiring colour (e.g. green active, red at 30%)
- [ ] Apply the aura to a target — bar should turn green
- [ ] Let the aura reach the expiring threshold — bar should turn red and stay red without flashing
- [ ] Confirm the bar returns to green cleanly if the aura is refreshed before expiry
- [ ] Move out of range while the aura is expiring — bar should fade to OOR alpha (red, faded) with no flashing between full and faded opacity
- [ ] Move back in range — bar should return to full expiring colour