### PR TITLE
Fix missing buff indicators persisting after leaving a group

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -4575,10 +4575,24 @@ DF._MainEventDispatcher = function(self, event, arg1)
 
     elseif event == "GROUP_ROSTER_UPDATE" then
         if DF.RosterDebugEvent then DF:RosterDebugEvent("Core.lua:GROUP_ROSTER_UPDATE") end
-        
-        -- Skip completely - Headers.lua handles roster updates via ProcessRosterUpdate
-        -- which manages container visibility and sorting. Frame updates happen via
-        -- OnAttributeChanged (unit changes) and PLAYER_ROLES_ASSIGNED (role changes).
+
+        -- Headers.lua handles roster updates via ProcessRosterUpdate (container
+        -- visibility, sorting). Frame updates happen via OnAttributeChanged (unit
+        -- changes) and PLAYER_ROLES_ASSIGNED (role changes).
+        --
+        -- Missing buff icons are not cleared by OnAttributeChanged when a slot
+        -- empties (unit → nil skips the refresh), and UNIT_AURA stops firing for
+        -- units that left the group. Frames that remain visible (player frame,
+        -- remaining group members) can be left with stale indicators. Sweep after
+        -- the roster settles. The 0.1s throttle inside UpdateAllMissingBuffIcons
+        -- prevents spam from rapid GRU bursts on group transitions.
+        if DF.UpdateAllMissingBuffIcons then
+            C_Timer.After(0.3, function()
+                if not InCombatLockdown() then
+                    DF:UpdateAllMissingBuffIcons()
+                end
+            end)
+        end
         return
         
     elseif event == "PLAYER_ROLES_ASSIGNED" then


### PR DESCRIPTION
## Summary

- `GROUP_ROSTER_UPDATE` returns early in `Core.lua` (Headers.lua owns roster processing), so `UpdateAllMissingBuffIcons` was never called on group transitions
- Frames that remain visible after leaving a group — the player frame (always shown) and any frames for members still in the group — could be left with stale missing buff indicators that only cleared on `/reload`
- `OnAttributeChanged` correctly triggers a full refresh when a frame gains a new unit, but skips the refresh when a slot empties (`unit → nil`), and `UNIT_AURA` stops firing for units that left the group, leaving no other path to clear the icon
- Fix: schedule `UpdateAllMissingBuffIcons` 0.3s after `GROUP_ROSTER_UPDATE` so the sweep runs after the header system has settled. The existing 0.1s throttle inside `UpdateAllMissingBuffIcons` prevents spam from the rapid GRU bursts WoW fires on group transitions

## Test plan

- [ ] Configure a missing buff indicator and join a group where it shows on frames
- [ ] Leave the group — indicators should clear on all visible frames within ~0.3s without a `/reload`
- [ ] Confirm rapid member joins/leaves mid-session don't cause stuttering
- [ ] Confirm indicators still show correctly when in a group