### PR TITLE
Fix Global Fonts Affected Elements list missing entries and clipping

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1407,7 +1407,7 @@ L["Z to A"] = true
 L["Zoom Icon"] = true
 L["%sGlobal: 80%s %s— Setting matches global, no override stored%s"] = true
 L["%sModified%s %s— Setting differs from global. Click%s %sreset%s %sto revert.%s"] = true
-L["• Name Text\n• Health Text\n• Status Text (Dead/Offline)\n• Buff Stack & Duration\n• Debuff Stack & Duration\n• Pet Frame Text\n• Targeted Spell Duration\n• Defensive Icon Duration\n• Status Icon Text (Res, Summon, etc.)\n• Group Labels (Raid)"] = true
+L["• Name Text\n• Health Text\n• Status Text (Dead/Offline)\n• Buff Stack & Duration\n• Debuff Stack & Duration\n• Pet Frame Text\n• Targeted Spell Duration\n• Defensive Icon Duration\n• Status Icon Text (Res, Summon, etc.)\n• Group Labels (Raid)\n• Targeted List\n• Personal Targeted Spell\n• Aura Designer Indicators\n• Pinned Frames"] = true
 L["⚠ Note: Click-through icons will not show tooltips."] = true
 
 -- Popup.lua and WizardBuilder.lua strings

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1898,7 +1898,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         -- ===== AFFECTED ELEMENTS GROUP (Column 2) =====
         local infoGroup = GUI:CreateSettingsGroup(self.child, 280)
         infoGroup:AddWidget(GUI:CreateHeader(self.child, L["Affected Elements"]), 40)
-        infoGroup:AddWidget(GUI:CreateLabel(self.child, L["• Name Text\n• Health Text\n• Status Text (Dead/Offline)\n• Buff Stack & Duration\n• Debuff Stack & Duration\n• Pet Frame Text\n• Targeted Spell Duration\n• Defensive Icon Duration\n• Status Icon Text (Res, Summon, etc.)\n• Group Labels (Raid)"], 250), 175)
+        infoGroup:AddWidget(GUI:CreateLabel(self.child, L["• Name Text\n• Health Text\n• Status Text (Dead/Offline)\n• Buff Stack & Duration\n• Debuff Stack & Duration\n• Pet Frame Text\n• Targeted Spell Duration\n• Defensive Icon Duration\n• Status Icon Text (Res, Summon, etc.)\n• Group Labels (Raid)\n• Targeted List\n• Personal Targeted Spell\n• Aura Designer Indicators\n• Pinned Frames"], 250), 235)
         infoGroup:AddWidget(GUI:CreateLabel(self.child, L["Note: Font sizes are not changed. Adjust sizes in each element's page."], 250), 40)
         Add(infoGroup, nil, 2)
     end)


### PR DESCRIPTION
## Summary

- The "Affected Elements" bullet list on the Global Fonts page was a static hand-maintained string that had fallen behind the Apply button logic — four elements were not listed: Targeted List, Personal Targeted Spell, Aura Designer Indicators, and Pinned Frames
- Added all four missing bullets to the locale string and the Options widget
- Bumped the widget height from 175 to 235 to prevent the longer list from being clipped

Fixes https://danders-lab.netlify.app/bugs/924

## Test plan

- [ ] Open `/df` → General → Global Fonts
- [ ] Confirm the Affected Elements column shows all 14 bullets without clipping