### PR TITLE
Fix Global Fonts dropdown showing stale font after profile switch

### DIFF
--- a/Profile.lua
+++ b/Profile.lua
@@ -238,6 +238,10 @@ function DF:SetProfile(name)
         DF.AutoProfilesUI.pendingAutoProfileEval = false
     end
     DF.raidOverrides = nil
+    -- Clear the Global Fonts temp selection so the page re-initialises from
+    -- the new profile's font settings rather than showing the old profile's
+    -- last-used font until the next /reload.
+    DF.GlobalFontTemp = nil
     DF:Debug("PROFILE", "SetProfile: cleared runtime state before switching to " .. name)
 
     -- Create new profile if doesn't exist


### PR DESCRIPTION
## Summary

- `DF.GlobalFontTemp` was initialised once per session with a `if not` guard, so switching profiles (or creating a new one) left the old profile's font selection in the dropdown until `/reload`
- Fix: clear `DF.GlobalFontTemp = nil` in `SetProfile` alongside the other runtime state that is reset on profile switch, so the Global Fonts page re-initialises from the new profile's `db.nameFont` on next open

Fixes https://danders-lab.netlify.app/bugs/843

## Test plan

- [x] Set a non-default font via Global Fonts and apply it on Profile A
- [x] Switch to a new/different profile — open Global Fonts and confirm the dropdown reflects the new profile's font, not Profile A's
- [x] Confirm the Apply button still works correctly after switching