### PR TITLE
Fix Export All preset unchecking Pinned Frames, Aura Designer, and Auto Layouts

### DIFF
--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -7842,7 +7842,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         presetRow:SetSize(240, 24)
         
         local presets = {
-            {name = "All", x = 0, cats = {"position", "layout", "bars", "auras", "text", "icons", "other"}},
+            {name = "All", x = 0, cats = {"position", "layout", "bars", "auras", "text", "icons", "other", "pinnedFrames", "auraDesigner", "autoLayout"}},
             {name = "Look", x = 60, cats = {"bars", "auras", "text", "icons", "other"}},
             {name = "Layout", x = 120, cats = {"position", "layout"}},
             {name = "None", x = 180, cats = {}},


### PR DESCRIPTION
## Summary

- The "All" preset in Export Settings had a `cats` list missing `"pinnedFrames"`, `"auraDesigner"`, and `"autoLayout"` — the three categories added after the preset was originally written
- The `OnClick` handler iterates all checkboxes and calls `SetChecked(sel[cat] or false)`, so any category absent from the preset list was explicitly unchecked — clicking "All" was actively de-selecting those three categories
- Fix: added the three missing categories to the All preset's `cats` list

Fixes https://danders-lab.netlify.app/bugs/933

## Test plan

- [x] Open `/df` → Profiles → Import/Export
- [x] Click "All" — Pinned Frames, Aura Designer, and Auto Layouts should all remain checked
- [x] Click "None" — all categories should uncheck
- [x] Click "All" again — all categories should check