### PR TITLE
Fix defensive icon border not covering all sides when Pixel Perfect is enabled

### DIFF
--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -1093,8 +1093,7 @@ function DF:UpdateDefensiveBar(frame)
         local wrap = db.defensiveBarWrap or 5
 
         if db.pixelPerfect then
-            borderSize = DF:PixelPerfect(borderSize)
-            iconSize = DF:PixelPerfect(iconSize)
+            iconSize, scale, borderSize = DF:PixelPerfectSizeAndScaleForBorder(iconSize, scale, borderSize)
         end
 
         -- Parse compound growth direction (PRIMARY_SECONDARY)


### PR DESCRIPTION
## Problem

With Pixel Perfect enabled, defensive icon borders were missing on one or more sides. When `DF:PixelPerfect()` snapped `borderSize` and `iconSize`, those values were correct screen pixels — but then `icon:SetScale(scale)` was applied to the container. `SetScale` rescales the frame's coordinate space, so the pixel-snapped border dimensions no longer mapped to exact screen pixels, causing edge gaps.

This is the same root cause that was previously fixed for Highlights in bug #553, which introduced `DF:PixelPerfectSizeAndScaleForBorder()`.

## Fix

Replace the two `DF:PixelPerfect()` calls in `UpdateDefensiveBar` with `DF:PixelPerfectSizeAndScaleForBorder(iconSize, scale, borderSize)`. This helper bakes the icon scale into the size and returns `scale = 1.0`, so the icon is rendered at native scale and the border dimensions are exact screen pixels on all four sides.

## Testing

- Enable Pixel Perfect in settings
- Trigger a defensive aura (or use `/df test`)
- Verify the defensive icon border covers all four edges cleanly at various scale values

https://danders-lab.netlify.app/bugs/871