### PR TITLE
Fix resource bar match-width leaving a pixel gap on left or right with Pixel Perfect

### DIFF
--- a/Frames/Bars.lua
+++ b/Frames/Bars.lua
@@ -136,24 +136,34 @@ function DF:ApplyResourceBarLayout(frame)
             -- SWAP: "Width" Value applies to Height (Length), "Height" value applies to Width (Thickness)
             bar:SetWidth(ppThickness)
             bar:SetHeight(ppLength)
-
-            if db.resourceBarMatchWidth then
-                if healthBarHeight > 1 then
-                    bar:SetHeight(healthBarHeight - (borderInset * 2))
-                end
-            end
         else
             -- NORMAL: "Width" Value applies to Width, "Height" value applies to Height
             bar:SetWidth(ppLength)
             bar:SetHeight(ppThickness)
+        end
 
+        -- When Pixel Perfect is on, borderInset must be snapped to a whole screen pixel
+        -- before being subtracted from healthBarWidth. Without this, barW is a fractional
+        -- screen-pixel value and WoW rounds it differently per frame depending on screen
+        -- position, producing a 1-pixel gap alternating left/right. Snapping borderInset
+        -- guarantees (FW - barW) = 2*(P+K) screen pixels (always even), so centering
+        -- always lands on a clean pixel boundary regardless of frame width parity.
+        local bInset = db.pixelPerfect and DF:PixelPerfect(borderInset) or borderInset
+
+        if isVertical then
+            if db.resourceBarMatchWidth then
+                if healthBarHeight > 1 then
+                    bar:SetHeight(healthBarHeight - bInset * 2)
+                end
+            end
+        else
             if db.resourceBarMatchWidth then
                 if healthBarWidth > 1 then
-                    bar:SetWidth(healthBarWidth - (borderInset * 2))
+                    bar:SetWidth(healthBarWidth - bInset * 2)
                 end
             end
         end
-        
+
         local anchor = db.resourceBarAnchor or "CENTER"
         bar:SetPoint(anchor, frame, anchor, db.resourceBarX or 0, db.resourceBarY or 0)
         


### PR DESCRIPTION
﻿## Problem

With Pixel Perfect enabled and "Match Health Bar Width" active, the resource bar showed a 1-pixel gap on either the left or right side. The gap alternated between sides depending on the frame's position on screen.

When Pixel Perfect is on, frameWidth and padding are each snapped to whole screen pixels before computing healthBarWidth. However, borderInset (db.borderSize) was left unsnapped, so healthBarWidth - borderInset*2 produced a fractional screen-pixel bar width. WoW rounds fractional widths differently depending on the frame's screen position, causing the gap to appear on different sides across frames.

Without Pixel Perfect the bar is the correct size.

## Fix

Snap borderInset to a whole screen pixel via DF:PixelPerfect() before subtracting it from healthBarWidth. This guarantees the resulting bar width is a clean integer number of screen pixels, so centering always lands on a pixel boundary regardless of frame width parity. No anchor changes.

## Testing

- Enable Pixel Perfect in settings
- Enable resource bar with Match Health Bar Width
- Verify the bar fills edge-to-edge with no gap on either side across multiple party/raid frames
