### PR TITLE
(Aura Designer) Fix banner controls overlapping when settings window is narrow

### DIFF
--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3333,15 +3333,26 @@ local function RefreshRightPanel() end
 
 local function CreateEnableBanner(parent)
     local banner = CreateFrame("Frame", nil, parent, "BackdropTemplate")
-    banner:SetHeight(36)
+    -- Two-row layout: row 1 (36px) has Enable toggle + Sound Alerts;
+    -- row 2 (32px) has Spec dropdown + Sync/Copy buttons.
+    banner:SetHeight(68)
     banner:SetPoint("TOPLEFT", parent, "TOPLEFT", 0, 0)
     banner:SetPoint("TOPRIGHT", parent, "TOPRIGHT", 0, 0)
     ApplyBackdrop(banner, {r = 0.14, g = 0.14, b = 0.14, a = 1}, {r = 0.30, g = 0.30, b = 0.30, a = 0.5})
 
+    -- Subtle divider between the two rows
+    local rowDivider = banner:CreateTexture(nil, "BACKGROUND")
+    rowDivider:SetHeight(1)
+    rowDivider:SetPoint("TOPLEFT", banner, "TOPLEFT", 0, -36)
+    rowDivider:SetPoint("TOPRIGHT", banner, "TOPRIGHT", 0, -36)
+    rowDivider:SetColorTexture(0.25, 0.25, 0.25, 1)
+
     -- Themed checkbox (matches GUI:CreateCheckbox style)
+    -- Row 1 centre = 18px from top. Banner centre = 34px from top.
+    -- Offset from banner centre to row 1 centre = +16.
     local cb = CreateFrame("CheckButton", nil, banner, "BackdropTemplate")
     cb:SetSize(18, 18)
-    cb:SetPoint("LEFT", 10, 0)
+    cb:SetPoint("LEFT", banner, "LEFT", 10, 16)
     ApplyBackdrop(cb, C_ELEMENT, {r = C_BORDER.r, g = C_BORDER.g, b = C_BORDER.b, a = 0.5})
 
     cb.Check = cb:CreateTexture(nil, "OVERLAY")
@@ -3386,8 +3397,9 @@ local function CreateEnableBanner(parent)
     cbSubLabel:SetText(L["Custom buff and frame effect indicators"])
     cbSubLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
 
+    -- Row 2 centre = 52px from top = 18px below banner centre → y offset -18.
     local specLabel = banner:CreateFontString(nil, "OVERLAY", "DFFontHighlightSmall")
-    specLabel:SetPoint("RIGHT", banner, "RIGHT", -145, 0)
+    specLabel:SetPoint("RIGHT", banner, "RIGHT", -145, -18)
     specLabel:SetText(L["Spec:"])
     specLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
 
@@ -3505,10 +3517,10 @@ local function CreateEnableBanner(parent)
         end
     end)
 
-    -- Mute Sound Alerts checkbox
+    -- Mute Sound Alerts checkbox — row 1 right side, decoupled from specLabel.
     local muteCb = CreateFrame("CheckButton", nil, banner)
     muteCb:SetSize(16, 16)
-    muteCb:SetPoint("RIGHT", specLabel, "LEFT", -20, 0)
+    muteCb:SetPoint("RIGHT", banner, "RIGHT", -10, 16)
 
     local muteBg = muteCb:CreateTexture(nil, "BACKGROUND")
     muteBg:SetAllPoints()
@@ -5811,7 +5823,7 @@ function DF.BuildAuraDesignerPage(guiRef, pageRef, dbRef)
     spellPickerType = nil
 
     -- Layout constants
-    local BANNER_H = 36
+    local BANNER_H = 68
     local SECTION_GAP = 8
 
     -- ========================================
@@ -5848,10 +5860,11 @@ function DF.BuildAuraDesignerPage(guiRef, pageRef, dbRef)
     if GUI.CreateCopyButton then
         local copyBtn = GUI.CreateCopyButton(enableBanner, {"auraDesigner"}, "Aura Designer", "auras_auradesigner", true)
         copyBtn:ClearAllPoints()
-        copyBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -5, 0)
+        -- Row 2 centre is 18px below banner centre, so y = -18.
+        copyBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -5, -18)
         enableBanner.specBtn:SetSize(135, 22)
         enableBanner.specBtn:ClearAllPoints()
-        enableBanner.specBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -256, 0)
+        enableBanner.specBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -256, -18)
         enableBanner.specLabel:ClearAllPoints()
         enableBanner.specLabel:SetPoint("RIGHT", enableBanner.specBtn, "LEFT", -4, 0)
     end

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3365,6 +3365,9 @@ local function CreateEnableBanner(parent)
 
     local adDB = GetAuraDesignerDB()
     cb:SetChecked(adDB and adDB.enabled)
+
+    -- Forward declaration — UpdateMuteEnabled is defined after muteCb/muteLabel are created.
+    local UpdateMuteEnabled
     cb:SetScript("OnClick", function(self)
         local checked = self:GetChecked()
         if checked then
@@ -3372,6 +3375,7 @@ local function CreateEnableBanner(parent)
             ShowBuffCoexistPopup(function(keepBuffs)
                 GetAuraDesignerDB().enabled = true
                 db.showBuffs = keepBuffs
+                if UpdateMuteEnabled then UpdateMuteEnabled(true) end
                 DF:AuraDesigner_RefreshPage()
                 DF:InvalidateAuraLayout()
                 DF:UpdateAllFrames()
@@ -3381,6 +3385,7 @@ local function CreateEnableBanner(parent)
             end)
         else
             GetAuraDesignerDB().enabled = false
+            if UpdateMuteEnabled then UpdateMuteEnabled(false) end
             DF:AuraDesigner_RefreshPage()
             DF:InvalidateAuraLayout()
             DF:UpdateAllFrames()
@@ -3517,21 +3522,14 @@ local function CreateEnableBanner(parent)
         end
     end)
 
-    -- Mute Sound Alerts checkbox — row 1 right side, decoupled from specLabel.
+    -- Mute Sound Alerts checkbox — row 2 left side, same size as Enable checkbox.
     local muteCb = CreateFrame("CheckButton", nil, banner)
-    muteCb:SetSize(16, 16)
-    muteCb:SetPoint("RIGHT", banner, "RIGHT", -10, 16)
+    muteCb:SetSize(18, 18)
+    muteCb:SetPoint("LEFT", banner, "LEFT", 10, -18)
 
-    local muteBg = muteCb:CreateTexture(nil, "BACKGROUND")
-    muteBg:SetAllPoints()
-    muteBg:SetColorTexture(C_ELEMENT.r, C_ELEMENT.g, C_ELEMENT.b, 1)
+    -- Use the same ApplyBackdrop treatment as the Enable checkbox so both look identical.
+    ApplyBackdrop(muteCb, C_ELEMENT, {r = C_BORDER.r, g = C_BORDER.g, b = C_BORDER.b, a = 0.5})
 
-    local muteBorder = muteCb:CreateTexture(nil, "BORDER")
-    muteBorder:SetPoint("TOPLEFT", -1, 1)
-    muteBorder:SetPoint("BOTTOMRIGHT", 1, -1)
-    muteBorder:SetColorTexture(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1)
-
-    -- Match GUI:CreateCheckbox visual: solid themed square, not a tick icon.
     local muteCheck = muteCb:CreateTexture(nil, "OVERLAY")
     muteCheck:SetTexture("Interface\\Buttons\\WHITE8x8")
     muteCheck:SetVertexColor(tc.r, tc.g, tc.b)
@@ -3551,11 +3549,26 @@ local function CreateEnableBanner(parent)
     end)
 
     local muteLabel = banner:CreateFontString(nil, "OVERLAY", "DFFontHighlightSmall")
-    muteLabel:SetPoint("RIGHT", muteCb, "LEFT", -4, 0)
+    muteLabel:SetPoint("LEFT", muteCb, "RIGHT", 4, 0)
     muteLabel:SetText(L["Sound Alerts"])
     muteLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
 
+    -- Grey out Sound Alerts when Aura Designer is disabled.
+    UpdateMuteEnabled = function(enabled)
+        if enabled then
+            muteCb:SetEnabled(true)
+            muteCb:SetAlpha(1)
+            muteLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+        else
+            muteCb:SetEnabled(false)
+            muteCb:SetAlpha(0.35)
+            muteLabel:SetTextColor(C_TEXT_DIM.r * 0.4, C_TEXT_DIM.g * 0.4, C_TEXT_DIM.b * 0.4)
+        end
+    end
+    UpdateMuteEnabled(adDB and adDB.enabled or false)
+
     banner.UpdateSpecText = UpdateSpecText
+    banner.UpdateMuteEnabled = UpdateMuteEnabled
     banner.checkbox = cb
     banner.specLabel = specLabel
     banner.specBtn = specBtn
@@ -5860,11 +5873,11 @@ function DF.BuildAuraDesignerPage(guiRef, pageRef, dbRef)
     if GUI.CreateCopyButton then
         local copyBtn = GUI.CreateCopyButton(enableBanner, {"auraDesigner"}, "Aura Designer", "auras_auradesigner", true)
         copyBtn:ClearAllPoints()
-        -- Row 2 centre is 18px below banner centre, so y = -18.
-        copyBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -5, -18)
+        -- Row 1 centre is 16px above banner centre, so y = +16.
+        copyBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -5, 16)
         enableBanner.specBtn:SetSize(135, 22)
         enableBanner.specBtn:ClearAllPoints()
-        enableBanner.specBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -256, -18)
+        enableBanner.specBtn:SetPoint("RIGHT", enableBanner, "RIGHT", -5, -18)
         enableBanner.specLabel:ClearAllPoints()
         enableBanner.specLabel:SetPoint("RIGHT", enableBanner.specBtn, "LEFT", -4, 0)
     end

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -8116,6 +8116,18 @@ function DF:CreateGUI()
                 end
             end
         end
+        -- Aura Designer needs the same minimum width as Click Casting to
+        -- prevent the two-row banner controls from overlapping.
+        local adMinWidth = 760
+        if name == "auras_auradesigner" then
+            frame:SetResizeBounds(adMinWidth, minHeight, maxWidth, maxHeight)
+            if frame:GetWidth() < adMinWidth then
+                frame:SetWidth(adMinWidth)
+            end
+        else
+            frame:SetResizeBounds(normalMinWidth, minHeight, maxWidth, maxHeight)
+        end
+
         GUI.CurrentPageName = name
         UpdateThemeColors()
     end


### PR DESCRIPTION
## Summary

- Reworks the Aura Designer enable banner from a single row into two rows: row 1 has the Enable toggle and Sound Alerts checkbox; row 2 has the Spec dropdown, Synced with Raid, and Copy to Raid buttons
- Adds a 760px minimum window width when the Aura Designer tab is active (matching the Click Casting minimum) so the row 2 controls always have room to render without clipping or overlapping

## Test plan

- [ ] Open Aura Designer settings — banner should show two clean rows with no overlap
- [ ] Narrow the window to minimum — row 1 and row 2 should remain separated by the divider line with no clashing
- [ ] Switch away from Aura Designer tab — window min width should restore to normal (520px)
- [ ] Switch to Aura Designer tab when window is narrower than 760px — window should auto-expand to 760px
- [ ] Sound Alerts checkbox and Spec dropdown should function normally
- [ ] Synced with Raid and Copy to Raid buttons should function normally