### PR TITLE
(Class Power) Fix section headers showing when Class Power Pips is disabled

### DIFF
--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -8387,6 +8387,7 @@ function DF:CreateGUI()
                 spacer.layoutHeight = h
                 spacer.layoutCol = col or "both"
                 table.insert(self.children, spacer)
+                return spacer
             end
             
             -- Sync point: forces both columns to align to the same Y position

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -3712,8 +3712,10 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             return not d.classPowerEnabled
         end
         
-        AddSpace(10, 1)
-        Add(GUI:CreateHeader(self.child, L["Size"]), 40, 1)
+        local cpSizeSpace = AddSpace(10, 1)
+        if cpSizeSpace then cpSizeSpace.hideOn = HideClassPower end
+        local cpSizeHeader = Add(GUI:CreateHeader(self.child, L["Size"]), 40, 1)
+        cpSizeHeader.hideOn = HideClassPower
         
         local cpHeight = Add(GUI:CreateSlider(self.child, L["Pip Height"], 1, 12, 1, db, "classPowerHeight", nil, function() if DF.RefreshClassPower then DF.RefreshClassPower() end end, true), 55, 1)
         cpHeight.hideOn = HideClassPower
@@ -3726,8 +3728,10 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         end), 25, 1)
         cpIgnoreFade.hideOn = HideClassPower
 
-        AddSpace(10, 1)
-        Add(GUI:CreateHeader(self.child, L["Colors"]), 40, 1)
+        local cpColorsSpace = AddSpace(10, 1)
+        if cpColorsSpace then cpColorsSpace.hideOn = HideClassPower end
+        local cpColorsHeader = Add(GUI:CreateHeader(self.child, L["Colors"]), 40, 1)
+        cpColorsHeader.hideOn = HideClassPower
 
         local cpUseCustomColor = Add(GUI:CreateCheckbox(self.child, L["Use Custom Pip Color"], db, "classPowerUseCustomColor", function()
             self:RefreshStates()
@@ -3752,7 +3756,8 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         cpBgColor.hideOn = HideClassPower
         cpBgColor.tooltip = L["Color and opacity of the empty/inactive pips."]
 
-        Add(GUI:CreateHeader(self.child, L["Position"]), 40, 2)
+        local cpPositionHeader = Add(GUI:CreateHeader(self.child, L["Position"]), 40, 2)
+        cpPositionHeader.hideOn = HideClassPower
         local anchorOptions = {
             INSIDE_BOTTOM = L["Inside (Bottom)"],
             INSIDE_TOP = L["Inside (Top)"],
@@ -3771,8 +3776,10 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         local cpY = Add(GUI:CreateSlider(self.child, L["Offset Y"], -20, 20, 1, db, "classPowerY", nil, function() if DF.RefreshClassPower then DF.RefreshClassPower() end end, true), 55, 2)
         cpY.hideOn = HideClassPower
 
-        AddSpace(10, 2)
-        Add(GUI:CreateHeader(self.child, L["Show for Roles"]), 40, 2)
+        local cpRolesSpace = AddSpace(10, 2)
+        if cpRolesSpace then cpRolesSpace.hideOn = HideClassPower end
+        local cpRolesHeader = Add(GUI:CreateHeader(self.child, L["Show for Roles"]), 40, 2)
+        cpRolesHeader.hideOn = HideClassPower
 
         local cpShowTank = Add(GUI:CreateCheckbox(self.child, L["Tank"], db, "classPowerShowTank", function()
             if DF.RefreshClassPower then DF.RefreshClassPower() end


### PR DESCRIPTION
## Summary

- The Size, Colors, Position, and Show for Roles section headers were missing `hideOn = HideClassPower`, leaving them visible as floating labels with no controls beneath them when Enable Class Power Pips was toggled off
- Also hides the `AddSpace` padding above each header so no blank gaps remain

## Test plan

- [ ] Open Party or Raid → Bars → Class Power tab
- [ ] Toggle **Enable Class Power Pips** off — only the master checkbox and intro label should remain visible
- [ ] Toggle it back on — all four headers and their controls should reappear correctly