### PR TITLE
Fix several Reset Page issues not resetting or refreshing correctly

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -5218,6 +5218,23 @@ function DF:FullProfileRefresh()
         DF:UpdateRestedIndicator()
     end
     
+    -- === REFRESH NAME TRUNCATION ===
+    -- UpdateAllFrames only pushes attribute changes; name truncation requires
+    -- a full visible-frame pass to recalculate text widths.
+    if DF.RefreshAllVisibleFrames then
+        DF:RefreshAllVisibleFrames()
+    end
+
+    -- === UPDATE MINIMAP BUTTON ===
+    if DF.UpdateMinimapButton then
+        DF:UpdateMinimapButton()
+    end
+
+    -- === CLEAR GLOBAL FONT TEMP ===
+    -- Force the Global Fonts page to re-read current DB values on next visit,
+    -- so its dropdowns reflect any settings reset since the last page build.
+    DF.GlobalFontTemp = nil
+
     -- === REFRESH GUI IF OPEN ===
     if DF.GUIFrame and DF.GUIFrame:IsShown() then
         if DF.GUI and DF.GUI.RefreshCurrentPage then

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4656,7 +4656,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         Add(adBanner, 32, "both")
 
         -- Copy button at top right
-        Add(CreateCopyButton(self.child, {"buff"}, L["Buffs"], "auras_buffs"), 25, 2)
+        Add(CreateCopyButton(self.child, {"buff", "showBuffs"}, L["Buffs"], "auras_buffs"), 25, 2)
 
         -- ===== DEDUPLICATION =====
         AddSpace(10, "both")
@@ -4876,7 +4876,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
     local pageDebuffs = CreateSubTab("auras", "auras_debuffs", L["Debuffs"])
     BuildPage(pageDebuffs, function(self, db, Add, AddSpace, AddSyncPoint)
         -- Copy button at top
-        Add(CreateCopyButton(self.child, {"debuff"}, L["Debuffs"], "auras_debuffs"), 25, 2)
+        Add(CreateCopyButton(self.child, {"debuff", "showDebuffs"}, L["Debuffs"], "auras_debuffs"), 25, 2)
         
         AddSpace(10, "both")
         


### PR DESCRIPTION
## Summary

- Buffs page reset now includes `showBuffsEnabled` (prefix `showBuffs` was missing from the reset key list)
- Debuffs page reset now includes `showDebuffsEnabled` (prefix `showDebuffs` was missing)
- `FullProfileRefresh` now calls `RefreshAllVisibleFrames` so name truncation updates correctly after a reset
- `FullProfileRefresh` now calls `UpdateMinimapButton` so the minimap icon state reflects the reset profile
- `FullProfileRefresh` now clears `GlobalFontTemp` so the Global Fonts page dropdowns re-read current DB values on next visit instead of showing stale selections

Fixes https://danders-lab.netlify.app/bugs/931

## Changelog entry

* Fix several settings on the Buffs, Debuffs, and Global Fonts pages not resetting correctly, and minimap icon state not reflecting the reset profile. (PR #83 by Krathe)