### PR TITLE
Fix debuff icons persisting on dead frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
+* Fix debuff icons remaining visible on frames after a unit dies. (PR #85 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)
 * (Export Settings) Fix the "All" preset unchecking Pinned Frames, Aura Designer, and Auto Layouts. (PR #78 by Krathe)
 * (Global Fonts) Fix the Affected Elements list missing entries and being clipped. (PR #76 by Krathe)

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -2628,7 +2628,32 @@ end
 function DF:UpdateAuraIconsDirect(frame, icons, auraType, maxAuras)
     local unit = frame.unit
     local db = DF:GetFrameDB(frame)
-    
+
+    -- Dead/ghost units: hide all aura icons immediately. WoW does not fire
+    -- UNIT_AURA on death, so the cache may still hold pre-death auras —
+    -- suppress them visually rather than displaying stale data on a corpse.
+    if UnitIsDeadOrGhost(unit) then
+        for i = 1, #icons do
+            local icon = icons[i]
+            icon.auraData = nil
+            icon.testAuraData = nil
+            icon.expirationTime = nil
+            icon.auraDuration = nil
+            if icon.duration then icon.duration:Hide() end
+            if icon.expiringTint then icon.expiringTint:Hide() end
+            if icon.expiringBorderAlphaContainer then
+                icon.expiringBorderAlphaContainer:Hide()
+                if icon.expiringBorderPulse and icon.expiringBorderPulse:IsPlaying() then
+                    icon.expiringBorderPulse:Stop()
+                end
+            end
+            icon:Hide()
+        end
+        local countKey = auraType == "BUFF" and "buffDisplayedCount" or "debuffDisplayedCount"
+        frame[countKey] = 0
+        return
+    end
+
     -- Quick out: no cache = no approved auras = hide everything
     local cache = DF.BlizzardAuraCache[unit]
     local cacheSet = cache and (auraType == "BUFF" and cache.buffs or cache.debuffs)

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -1062,6 +1062,10 @@ function DF:UpdateHealthFast(frame)
             if DF.RestoreHealthBarFromReducedMax then DF:RestoreHealthBarFromReducedMax(frame) end
         end
         DF:ApplyDeadFade(frame, "Dead")
+        -- Clear aura icons — WoW doesn't fire UNIT_AURA on death so the cache
+        -- stays stale. UpdateAuraIconsDirect now has a dead guard, so calling
+        -- UpdateAuras_Enhanced here flushes any pre-death icons from the frame.
+        if DF.UpdateAuras_Enhanced then DF:UpdateAuras_Enhanced(frame) end
         return
     end
 

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -1062,15 +1062,20 @@ function DF:UpdateHealthFast(frame)
             if DF.RestoreHealthBarFromReducedMax then DF:RestoreHealthBarFromReducedMax(frame) end
         end
         DF:ApplyDeadFade(frame, "Dead")
-        -- Clear aura icons — WoW doesn't fire UNIT_AURA on death so the cache
-        -- stays stale. UpdateAuraIconsDirect now has a dead guard, so calling
-        -- UpdateAuras_Enhanced here flushes any pre-death icons from the frame.
-        if DF.UpdateAuras_Enhanced then DF:UpdateAuras_Enhanced(frame) end
+        -- Clear aura icons on the first dead tick only. WoW doesn't fire
+        -- UNIT_AURA on death so the cache stays stale; flushing once is enough.
+        -- The edge-detect flag prevents re-running the full AD engine on every
+        -- subsequent UNIT_HEALTH tick while the unit stays dead (e.g. wipe spam).
+        if not frame.dfLastKnownDead then
+            frame.dfLastKnownDead = true
+            if DF.UpdateAuras_Enhanced then DF:UpdateAuras_Enhanced(frame) end
+        end
         return
     end
 
     -- Unit is alive and connected - reset dead fade if it was applied
     DF:ResetDeadFade(frame)
+    frame.dfLastKnownDead = nil
     frame.dfLastKnownConnected = true
 
     -- Clear resurrection icon if unit was pending a res and is now alive


### PR DESCRIPTION
﻿## Summary

When a unit dies, WoW does not fire `UNIT_AURA` — so the aura cache retains the pre-death aura list and any debuff icons that were showing before death remain on the dead frame until something else triggers an aura update.

Two-part fix:

- `Features/Auras.lua` `UpdateAuraIconsDirect`: Added a dead/ghost guard at the top of the function. If `UnitIsDeadOrGhost(unit)` is true, all aura icons are immediately hidden and the function returns early — same code path as the existing "no cache" quick-out.
- `Frames/Update.lua` `UpdateHealthFast`: Added a call to `UpdateAuras_Enhanced` in the death path (after `ApplyDeadFade`), so the new dead guard fires at the moment of death rather than waiting for the next external aura event.

Fixes https://danders-lab.netlify.app/bugs/863
