### PR TITLE
Fix locking frames turning off test mode when it was already active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
+* Fix locking frames while test mode is active turning off test mode. (PR #87 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)
 * (Export Settings) Fix the "All" preset unchecking Pinned Frames, Aura Designer, and Auto Layouts. (PR #78 by Krathe)
 * (Global Fonts) Fix the Affected Elements list missing entries and being clipped. (PR #76 by Krathe)

--- a/Frames/Init.lua
+++ b/Frames/Init.lua
@@ -971,6 +971,10 @@ function DF:UnlockRaidFrames()
         end
     end
     
+    -- Remember whether raid test mode was already active before this unlock cycle.
+    -- LockRaidFrames reads this to decide whether to keep or hide test frames.
+    DF.raidTestModeBeforeUnlock = DF.raidTestMode
+
     -- Enable raid test mode using the proper function
     DF:ShowRaidTestFrames()
     
@@ -1031,8 +1035,12 @@ function DF:LockRaidFrames()
         DF.positionPanel:Hide()
     end
     
-    -- Disable raid test mode using the proper function
-    DF:HideRaidTestFrames()
+    -- Only disable raid test mode if it was not already active before the last unlock.
+    -- Preserves the user's test mode state across the lock/unlock cycle.
+    if not DF.raidTestModeBeforeUnlock then
+        DF:HideRaidTestFrames()
+    end
+    DF.raidTestModeBeforeUnlock = nil
     
     -- Hide container if not in raid
     if not IsInRaid() then

--- a/Frames/Position.lua
+++ b/Frames/Position.lua
@@ -2315,6 +2315,10 @@ function DF:UnlockFrames()
         DF.displayLockButton.Text:SetText(L["Lock Frames"])
     end
 
+    -- Remember whether test mode was already active before this unlock cycle.
+    -- LockFrames reads this to decide whether to keep or hide test frames.
+    DF.partyTestModeBeforeUnlock = DF.testMode
+
     -- Enable test mode so user can position with full group visible
     DF:ShowTestFrames(true)
 
@@ -2381,8 +2385,12 @@ function DF:LockFrames()
         if DF.GUI.UpdateTestButtonState then DF.GUI.UpdateTestButtonState() end
     end
 
-    -- Disable test mode
-    DF:HideTestFrames(true)
+    -- Only disable test mode if it was not already active before the last unlock.
+    -- Preserves the user's test mode state across the lock/unlock cycle.
+    if not DF.partyTestModeBeforeUnlock then
+        DF:HideTestFrames(true)
+    end
+    DF.partyTestModeBeforeUnlock = nil
 
     print("|cff00ff00DandersFrames:|r " .. L["Frames locked."])
 end


### PR DESCRIPTION
## Summary
- Locking the frames after unlocking would unconditionally call `HideTestFrames`/`HideRaidTestFrames`, turning off test mode even if the user had it enabled before unlocking
- `UnlockFrames` and `UnlockRaidFrames` now save whether test mode was already active before the unlock cycle
- `LockFrames` and `LockRaidFrames` only hide test frames if test mode was *not* already active — preserving the user's state across the lock/unlock cycle

## Test plan
- [ ] Test mode ON → Unlock → move → Lock: test frames remain visible after locking
- [ ] Test mode OFF → Unlock → move → Lock: test frames hide on lock (existing behaviour unchanged)
- [ ] Test mode OFF → Unlock → enable test mode in UI → Lock: test frames hide on lock (pre-unlock state was OFF)