### PR TITLE
Fix dispel overlay gradient snapping to full brightness after OOR transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* (Dispel Overlay) Fix gradient snapping to full brightness after a unit goes out of range and back in range while they have a dispellable debuff. (PR #88 by Krathe)
+* (Dispel Overlay) Fix gradient snapping to full brightness after a unit goes out of range and back in range while they have a dispellable debuff. (PR #89 by Krathe)
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* (Dispel Overlay) Fix gradient snapping to full brightness after a unit goes out of range and back in range while they have a dispellable debuff. (PR #88 by Krathe)
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -798,35 +798,45 @@ function DF:UpdateDispelOverlayAppearance(frame)
     local deadOrOffline = IsDeadOrOffline(frame)
     local inRange = GetInRange(frame)
     local overlay = frame.dfDispelOverlay
-    local alpha = 1.0
+
+    -- Dead/offline fade multiplier (1.0 when alive)
+    local deadAlpha = 1.0
     if deadOrOffline and db.fadeDeadFrames then
-        alpha = db.fadeDeadBackground or 1
+        deadAlpha = db.fadeDeadBackground or 1
     end
-    
+
+    -- Element-specific base alphas, matching what ShowOverlayWithSecretColor sets.
+    -- Using 1.0 here (as before PR #65) caused the gradient to snap back to full
+    -- opacity after OOR->in-range transitions, because UpdateDispelOverlayAppearance
+    -- overwrote the configured alpha that ShowOverlayWithSecretColor had applied.
+    local gradAlpha = math.min((db.dispelGradientAlpha or 0.5) * (db.dispelGradientIntensity or 1.0), 1.0) * deadAlpha
+    local brdAlpha  = (db.dispelBorderAlpha or 0.8) * deadAlpha
+    local icnAlpha  = (db.dispelIconAlpha   or 1.0) * deadAlpha
+
     if db.oorEnabled then
         local oorAlpha = db.oorDispelOverlayAlpha or 0.2
-        ApplyOORAlpha(overlay.gradient, inRange, alpha, oorAlpha)
-        ApplyOORAlpha(overlay.borderTop, inRange, alpha, oorAlpha)
-        ApplyOORAlpha(overlay.borderBottom, inRange, alpha, oorAlpha)
-        ApplyOORAlpha(overlay.borderLeft, inRange, alpha, oorAlpha)
-        ApplyOORAlpha(overlay.borderRight, inRange, alpha, oorAlpha)
+        ApplyOORAlpha(overlay.gradient,     inRange, gradAlpha, gradAlpha * oorAlpha)
+        ApplyOORAlpha(overlay.borderTop,    inRange, brdAlpha,  brdAlpha  * oorAlpha)
+        ApplyOORAlpha(overlay.borderBottom, inRange, brdAlpha,  brdAlpha  * oorAlpha)
+        ApplyOORAlpha(overlay.borderLeft,   inRange, brdAlpha,  brdAlpha  * oorAlpha)
+        ApplyOORAlpha(overlay.borderRight,  inRange, brdAlpha,  brdAlpha  * oorAlpha)
         if overlay.icons then
             for _, icon in pairs(overlay.icons) do
-                ApplyOORAlpha(icon, inRange, alpha, oorAlpha)
+                ApplyOORAlpha(icon, inRange, icnAlpha, icnAlpha * oorAlpha)
             end
         end
         if DF.ApplyDispelOverlayAppearance then
             DF:ApplyDispelOverlayAppearance(frame)
         end
     else
-        if overlay.gradient then overlay.gradient:SetAlpha(alpha) end
-        if overlay.borderTop then overlay.borderTop:SetAlpha(alpha) end
-        if overlay.borderBottom then overlay.borderBottom:SetAlpha(alpha) end
-        if overlay.borderLeft then overlay.borderLeft:SetAlpha(alpha) end
-        if overlay.borderRight then overlay.borderRight:SetAlpha(alpha) end
+        if overlay.gradient     then overlay.gradient:SetAlpha(gradAlpha) end
+        if overlay.borderTop    then overlay.borderTop:SetAlpha(brdAlpha) end
+        if overlay.borderBottom then overlay.borderBottom:SetAlpha(brdAlpha) end
+        if overlay.borderLeft   then overlay.borderLeft:SetAlpha(brdAlpha) end
+        if overlay.borderRight  then overlay.borderRight:SetAlpha(brdAlpha) end
         if overlay.icons then
             for _, icon in pairs(overlay.icons) do
-                icon:SetAlpha(alpha)
+                icon:SetAlpha(icnAlpha)
             end
         end
     end

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -805,13 +805,17 @@ function DF:UpdateDispelOverlayAppearance(frame)
         deadAlpha = db.fadeDeadBackground or 1
     end
 
-    -- Element-specific base alphas, matching what ShowOverlayWithSecretColor sets.
-    -- Using 1.0 here (as before PR #65) caused the gradient to snap back to full
-    -- opacity after OOR->in-range transitions, because UpdateDispelOverlayAppearance
-    -- overwrote the configured alpha that ShowOverlayWithSecretColor had applied.
+    -- Gradient alpha reads the configured value — this was the bug: using 1.0 here
+    -- caused the gradient to snap back to full brightness after OOR->in-range
+    -- transitions because UpdateDispelOverlayAppearance overwrote the value that
+    -- ShowOverlayWithSecretColor had applied.
+    -- Borders and icons stay at 1.0 to match what ShowOverlayWithSecretColor
+    -- hardcodes. Until that function is updated to read the user settings, using
+    -- db.dispelBorderAlpha/db.dispelIconAlpha here would cause ~5Hz flicker
+    -- (ShowOverlayWithSecretColor sets 1.0, range ticker dims them back).
     local gradAlpha = math.min((db.dispelGradientAlpha or 0.5) * (db.dispelGradientIntensity or 1.0), 1.0) * deadAlpha
-    local brdAlpha  = (db.dispelBorderAlpha or 0.8) * deadAlpha
-    local icnAlpha  = (db.dispelIconAlpha   or 1.0) * deadAlpha
+    local brdAlpha  = 1.0 * deadAlpha
+    local icnAlpha  = 1.0 * deadAlpha
 
     if db.oorEnabled then
         local oorAlpha = db.oorDispelOverlayAlpha or 0.2


### PR DESCRIPTION
## Root cause

`UpdateDispelOverlayAppearance` (called every ~0.2s by the range timer) was passing `alpha = 1.0` as the in-range value for every element, including the gradient. When a unit went OOR the gradient was correctly dimmed to `oorAlpha`, but on returning in range it was restored to `1.0` rather than the configured `dispelGradientAlpha`.

This was masked before PR #65 because `ShowOverlayWithSecretColor` also used `1.0` for the gradient — both functions agreed. PR #65 correctly changed `ShowOverlayWithSecretColor` to use the configured alpha, but `UpdateDispelOverlayAppearance` was not updated to match. The `dfLastDispelAuraID` skip (added earlier for performance) then prevented `ShowOverlayWithSecretColor` from correcting the value on subsequent ticks, leaving the gradient stuck at full brightness permanently after any OOR→in-range transition.

## Fix

Use element-specific alphas in `UpdateDispelOverlayAppearance` derived from the same settings that `ShowOverlayWithSecretColor` uses:

- Gradient: `min(dispelGradientAlpha * dispelGradientIntensity, 1.0) * deadAlpha`
- Borders: `dispelBorderAlpha * deadAlpha`
- Icons: `dispelIconAlpha * deadAlpha`

OOR dimming is applied as a multiplier on top of these base values, matching the behaviour in `ShowOverlayWithSecretColor` and `ApplyDispelOverlayAppearance`.

## Test

1. In a raid, have a unit with a dispellable debuff and the dispel overlay visible at its configured opacity
2. Move out of range of that unit and back in — the gradient should return to the same opacity it had before going OOR, not jump to full brightness