### PR TITLE
Fix pinned frame override indicators showing all settings as overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* (Pinned Frames) Fix all settings showing as overridden by an Auto Layout when only one setting is actually overridden. (PR #91 by Krathe)
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -3507,7 +3507,16 @@ function AutoProfilesUI:IsOverriddenByRuntime(key)
 
     local setIndex, setting = ParsePinnedKey(key)
     if setIndex and setting then
-        return DF.raidOverrides.pinnedFrames ~= nil
+        -- Compare the specific setting value in the overlay against _realRaidDB.
+        -- The overlay always has a pinnedFrames copy when any layout is active;
+        -- only per-setting differences indicate an actual override.
+        local overlayPF = DF.raidOverrides.pinnedFrames
+        local realPF = DF._realRaidDB and DF._realRaidDB.pinnedFrames
+        if not overlayPF or not realPF then return false end
+        local overlaySet = overlayPF.sets and overlayPF.sets[setIndex]
+        local realSet = realPF.sets and realPF.sets[setIndex]
+        if not overlaySet or not realSet then return false end
+        return not DeepCompare(overlaySet[setting], realSet[setting])
     end
 
     local tableName, index = ParseTableKey(key)


### PR DESCRIPTION
## Summary

When an auto layout had a single pinned frame override active, the global Pinned Frames settings page showed the gold star override indicator on **every** setting instead of just the one that was overridden.

**Root cause:** `AutoProfilesUI:IsOverriddenByRuntime` checked whether `DF.raidOverrides.pinnedFrames` existed at all. Since `ApplyRuntimeProfile` always places the entire `pinnedFrames` deep-copy into the overlay when any layout is active, this was always `true` — so every setting appeared overridden regardless of its actual value.

**Fix:** Compare the specific setting's value in the overlay against `_realRaidDB` using `DeepCompare`, so the star only appears on settings that genuinely differ.

The Edit-mode indicators (shown while inside the layout editor) were already correct and are unchanged.

## Changelog entry

* (Pinned Frames) Fix all settings showing as overridden by an Auto Layout when only one setting is actually overridden. (PR #91 by Krathe)

## Test plan

- [x] Enable an auto layout that overrides exactly one pinned frame setting (e.g. Lock Position)
- [x] Open the global Pinned Frames settings page — star should appear **only** on the overridden setting
- [x] Click Edit on the layout — edit-mode indicators still show only the one override
- [x] Exit Editing — global page still shows only the one star
- [x] Disable the auto layout — no stars visible