### PR TITLE
Fix mover bounding boxes above GUI, position offset on Auto Layout edit, and position panel not refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
+* Fix orange and blue bounding boxes (raidMoverFrame / DandersFramesMover) rendering above the settings GUI when frames are unlocked; fix orange box position offset when clicking Edit on an Auto Layout while already unlocked; fix position panel X/Y inputs not updating when clicking Edit while the panel is already open. (PR #93 by Krathe)
 * (Defensive Icons) Fix icon borders missing on one or more sides when Pixel Perfect is enabled. (PR #79 by Krathe)
 * (Export Settings) Fix the "All" preset unchecking Pinned Frames, Aura Designer, and Auto Layouts. (PR #78 by Krathe)
 * (Global Fonts) Fix the Affected Elements list missing entries and being clipped. (PR #76 by Krathe)

--- a/Core.lua
+++ b/Core.lua
@@ -5073,14 +5073,23 @@ function DF:FullProfileRefresh()
     end
 
     -- === UPDATE RAID CONTAINER POSITION ===
+    -- Use UpdateRaidContainerPosition so raidMoverFrame and testRaidContainer
+    -- are synced in the same call (and CENTER-anchor compensation is applied).
+    -- Falls back to direct SetPoint if the function isn't loaded yet.
     if DF.raidContainer then
         local scale = raidDB.frameScale or 1.0
         DF:Debug("RAIDPOS", "FullProfileRefresh: applying raid container pos (%.1f,%.1f) scale=%.3f autoActive=%s",
             raidDB.raidAnchorX or 0, raidDB.raidAnchorY or 0, scale,
             tostring(DF.AutoProfilesUI and DF.AutoProfilesUI.activeRuntimeProfile and DF.AutoProfilesUI.activeRuntimeProfile.name or "none"))
-        DF.raidContainer:SetScale(scale)
-        DF.raidContainer:ClearAllPoints()
-        DF.raidContainer:SetPoint("CENTER", UIParent, "CENTER", (raidDB.raidAnchorX or 0) / scale, (raidDB.raidAnchorY or 0) / scale)
+        if DF.UpdateRaidContainerPosition and not InCombatLockdown() then
+            DF:UpdateRaidContainerPosition()
+        else
+            -- Combat fallback: move only the secure container (mover/test container
+            -- can't be modified in combat anyway)
+            DF.raidContainer:SetScale(scale)
+            DF.raidContainer:ClearAllPoints()
+            DF.raidContainer:SetPoint("CENTER", UIParent, "CENTER", (raidDB.raidAnchorX or 0) / scale, (raidDB.raidAnchorY or 0) / scale)
+        end
     end
     
     -- === FORCE UPDATE INDIVIDUAL FRAMES VIA ITERATORS ===

--- a/Frames/Init.lua
+++ b/Frames/Init.lua
@@ -689,9 +689,9 @@ function DF:CreateRaidMoverFrame()
     -- Parent to UIParent (not raidContainer) so strata works properly
     -- Position over the container
     local mover = CreateFrame("Frame", "DandersRaidFramesMover", UIParent, "BackdropTemplate")
-    mover:SetFrameStrata("TOOLTIP")  -- Very high strata to be above secure frames
-    mover:SetFrameLevel(100)
-    
+    mover:SetFrameStrata("MEDIUM")  -- Same strata as unit frames; SetFrameLevel(100) puts us above them
+    mover:SetFrameLevel(100)        -- Unit frame children are level 1-4; 100 renders above them
+
     -- Set initial size from container
     local cWidth, cHeight = DF.raidContainer:GetSize()
     mover:SetSize(math.max(cWidth, 100), math.max(cHeight, 100))
@@ -930,11 +930,10 @@ function DF:UnlockRaidFrames()
     DF.raidMoverFrame:SetScale(scale)
     DF.raidMoverFrame:ClearAllPoints()
     DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", (db.raidAnchorX or 0) / scale, (db.raidAnchorY or 0) / scale)
-    DF.raidMoverFrame:SetFrameStrata("TOOLTIP")  -- Very high strata
-    DF.raidMoverFrame:SetFrameLevel(100)
+    DF.raidMoverFrame:SetFrameStrata("MEDIUM")  -- Keeps mover below DIALOG settings GUI
+    DF.raidMoverFrame:SetFrameLevel(100)        -- Above unit frame children (level 1-4)
     DF.raidMoverFrame:SetAlpha(1)
     DF.raidMoverFrame:Show()
-    DF.raidMoverFrame:Raise()
 
     -- Sync testRaidContainer position (and size only when not in test mode,
     -- since test mode already has the correct calculated size)

--- a/Frames/Position.lua
+++ b/Frames/Position.lua
@@ -139,8 +139,8 @@ function DF:CreateMoverFrame()
     
     local mover = CreateFrame("Frame", "DandersFramesMover", DF.container, "BackdropTemplate")
     mover:SetAllPoints(DF.container)
-    mover:SetFrameStrata("TOOLTIP")  -- Very high strata to be above secure frames
-    mover:SetFrameLevel(100)
+    mover:SetFrameStrata("MEDIUM")  -- Same strata as unit frames; level 100 renders above them
+    mover:SetFrameLevel(100)        -- Unit frame children are level 1-4; keeps us above them
     mover:SetBackdrop({
         bgFile = "Interface\\Buttons\\WHITE8x8",
         edgeFile = "Interface\\Buttons\\WHITE8x8",
@@ -2255,11 +2255,10 @@ function DF:UnlockFrames()
     -- Ensure mover frame matches container before showing
     DF.moverFrame:ClearAllPoints()
     DF.moverFrame:SetAllPoints(DF.container)
-    DF.moverFrame:SetFrameStrata("TOOLTIP")  -- Very high strata to be above secure frames
-    DF.moverFrame:SetFrameLevel(100)
+    DF.moverFrame:SetFrameStrata("MEDIUM")  -- Keeps mover below DIALOG settings GUI
+    DF.moverFrame:SetFrameLevel(100)        -- Above unit frame children (level 1-4)
     DF.moverFrame:SetAlpha(1)
     DF.moverFrame:Show()
-    DF.moverFrame:Raise()
 
     -- Sync testPartyContainer to current position and size
     if DF.testPartyContainer then

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -2537,6 +2537,10 @@ function AutoProfilesUI:EnterEditing(contentType, profileIndex)
             DF.raidMoverFrame:ClearAllPoints()
             DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", (moverDb.raidAnchorX or 0) / moverScale, (moverDb.raidAnchorY or 0) / moverScale)
         end
+        -- Refresh position panel inputs to reflect the newly-applied override anchor/scale
+        if DF.positionPanel and DF.positionPanel:IsShown() and DF.UpdatePositionPanel then
+            DF:UpdatePositionPanel()
+        end
         if DF.RefreshTestFramesWithLayout then
             DF:RefreshTestFramesWithLayout()
         end
@@ -2673,6 +2677,12 @@ function AutoProfilesUI:ExitEditing(skipUIUpdates)
             DF.raidMoverFrame:SetScale(moverScale)
             DF.raidMoverFrame:ClearAllPoints()
             DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", (moverDb.raidAnchorX or 0) / moverScale, (moverDb.raidAnchorY or 0) / moverScale)
+        end
+        -- Refresh position panel inputs to reflect the restored anchor/scale values.
+        -- EvaluateAndApply above may have re-applied a runtime overlay, so
+        -- DF:GetRaidDB() is already authoritative at this point.
+        if DF.positionPanel and DF.positionPanel:IsShown() and DF.UpdatePositionPanel then
+            DF:UpdatePositionPanel()
         end
         if DF.RefreshTestFramesWithLayout then
             DF:RefreshTestFramesWithLayout()

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -2526,6 +2526,17 @@ function AutoProfilesUI:EnterEditing(contentType, profileIndex)
         if DF.PositionTestRaidContainer then
             DF:PositionTestRaidContainer()
         end
+        -- If the mover is visible (frames unlocked), sync its position and scale
+        -- to match the freshly-positioned test container. The profile overrides
+        -- applied above may include a different raidAnchorX/Y or frameScale, so
+        -- the mover needs to follow the container or it will appear offset.
+        if DF.raidMoverFrame and DF.raidMoverFrame:IsShown() then
+            local moverDb = DF:GetRaidDB()
+            local moverScale = moverDb.frameScale or 1.0
+            DF.raidMoverFrame:SetScale(moverScale)
+            DF.raidMoverFrame:ClearAllPoints()
+            DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", (moverDb.raidAnchorX or 0) / moverScale, (moverDb.raidAnchorY or 0) / moverScale)
+        end
         if DF.RefreshTestFramesWithLayout then
             DF:RefreshTestFramesWithLayout()
         end
@@ -2652,6 +2663,16 @@ function AutoProfilesUI:ExitEditing(skipUIUpdates)
     if DF.raidTestMode then
         if DF.PositionTestRaidContainer then
             DF:PositionTestRaidContainer()
+        end
+        -- Sync mover position/scale to match the restored base anchor.
+        -- EvaluateAndApply above may have re-applied a runtime overlay, so
+        -- DF:GetRaidDB() here reflects whichever values are now authoritative.
+        if DF.raidMoverFrame and DF.raidMoverFrame:IsShown() then
+            local moverDb = DF:GetRaidDB()
+            local moverScale = moverDb.frameScale or 1.0
+            DF.raidMoverFrame:SetScale(moverScale)
+            DF.raidMoverFrame:ClearAllPoints()
+            DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", (moverDb.raidAnchorX or 0) / moverScale, (moverDb.raidAnchorY or 0) / moverScale)
         end
         if DF.RefreshTestFramesWithLayout then
             DF:RefreshTestFramesWithLayout()


### PR DESCRIPTION
## Summary

Three related fixes for the raid position panel and mover bounding boxes when interacting with Auto Layouts:

- **Strata fix**: `raidMoverFrame` and `DandersFramesMover` were hardcoded to `TOOLTIP` strata and called `Raise()` on unlock, causing the orange and blue bounding boxes to render above the settings GUI. Changed to `MEDIUM` strata with `SetFrameLevel(100)` and removed `Raise()` at all four sites (`Frames/Init.lua` lines 692 & 933, `Frames/Position.lua` lines 142 & 2258).
- **Position offset fix**: When clicking Edit on an Auto Layout while frames were already unlocked, `EnterEditing` applied anchor/scale overrides and repositioned `testRaidContainer` but `raidMoverFrame` didn't follow. Added mover sync blocks in both `EnterEditing` and `ExitEditing` (`Options/AutoProfiles.lua`).
- **Position panel refresh fix**: The position panel's X/Y input fields weren't refreshing when entering or exiting Auto Layout edit mode. Added `UpdatePositionPanel()` calls alongside the mover sync blocks so the panel immediately reflects the override anchor on enter and the restored values on exit.
- **FullProfileRefresh gap**: Replaced the direct `raidContainer:SetPoint` in `FullProfileRefresh` (`Core.lua`) with `UpdateRaidContainerPosition()` to keep `raidMoverFrame` and `testRaidContainer` in sync during dynamic profile switches, with a combat fallback.

## Test plan

- [x] Unlock raid frames — orange box aligns with test container, settings GUI renders above the box
- [x] Unlock party frames — blue box visible, settings GUI renders above it
- [x] Click Edit on an Auto Layout with a different anchor while frames are unlocked — orange box and position panel X/Y both update immediately
- [x] Exit editing — orange box and position panel both snap back to restored values