### PR TITLE
feat: add Default button to DF colour picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* (Color Picker) Added a Default button to the DF color picker that resets the colour to its configured default value. Also populates ElvUI's Default button on the native picker for DF settings.
+
 * **Reduced Max Health bar** — a new sub-bar appears on the right edge of party and raid frames when a unit's maximum health has been temporarily reduced (e.g. by certain Mythic+ affixes or boss debuffs), showing exactly how much of the bar is locked out. Customise it under **Health Bar → Reduced Max Health**: enable/disable, choose a texture and colour, set a blend mode, and toggle whether the health bar visually shrinks to fit (Clip Health Bar) or the reduced section overlays it.
 
 ### Bug Fixes

--- a/GUI/ColorPickerTest.lua
+++ b/GUI/ColorPickerTest.lua
@@ -1099,7 +1099,7 @@ local function CreateColorPickerTest(hasAlpha)
     -- ============================================================
     
     local tabFrame = CreateFrame("Frame", nil, content)
-    tabFrame:SetSize(300, 22)
+    tabFrame:SetSize(300, 42)
     tabFrame:SetPoint("TOPLEFT", hexFrame, "BOTTOMLEFT", 0, -8)
     
     local tabButtons = {}
@@ -1134,10 +1134,10 @@ local function CreateColorPickerTest(hasAlpha)
     CreateTab("recent", "Recent", 60)
     CreateTab("class", "Class", 120)
     
-    -- Save button in tab row (right-aligned)
+    -- Save button in tab row (top-right)
     local saveBtn = CreateFrame("Button", nil, tabFrame, "BackdropTemplate")
     saveBtn:SetSize(50, 18)
-    saveBtn:SetPoint("RIGHT", 0, 0)
+    saveBtn:SetPoint("TOPRIGHT", 0, 0)
     saveBtn:SetBackdrop({
         bgFile = "Interface\\Buttons\\WHITE8x8",
         edgeFile = "Interface\\Buttons\\WHITE8x8",
@@ -1149,12 +1149,38 @@ local function CreateColorPickerTest(hasAlpha)
     saveBtnText:SetPoint("CENTER")
     saveBtnText:SetText("Save")
     saveBtnText:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
-    saveBtn:SetScript("OnEnter", function(self) 
-        self:SetBackdropBorderColor(C_ACCENT.r, C_ACCENT.g, C_ACCENT.b, 1) 
+    saveBtn:SetScript("OnEnter", function(self)
+        self:SetBackdropBorderColor(C_ACCENT.r, C_ACCENT.g, C_ACCENT.b, 1)
     end)
-    saveBtn:SetScript("OnLeave", function(self) 
-        self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1) 
+    saveBtn:SetScript("OnLeave", function(self)
+        self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1)
     end)
+
+    -- Default button: stacked below Save, same width
+    local defaultBtn = CreateFrame("Button", nil, tabFrame, "BackdropTemplate")
+    defaultBtn:SetSize(50, 18)
+    defaultBtn:SetPoint("TOP", saveBtn, "BOTTOM", 0, -2)
+    defaultBtn:SetBackdrop({
+        bgFile = "Interface\\Buttons\\WHITE8x8",
+        edgeFile = "Interface\\Buttons\\WHITE8x8",
+        edgeSize = 1,
+    })
+    defaultBtn:SetBackdropColor(C_ELEMENT.r, C_ELEMENT.g, C_ELEMENT.b, 1)
+    defaultBtn:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1)
+    local defaultBtnText = defaultBtn:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
+    defaultBtnText:SetPoint("CENTER")
+    defaultBtnText:SetText("Default")
+    defaultBtnText:SetTextColor(C_TEXT.r, C_TEXT.g, C_TEXT.b)
+    defaultBtn:SetScript("OnClick", function()
+        local d = testFrame.defaultColor
+        if not d then return end
+        -- SetColor triggers UpdateAllColors which fires onChangeCallback for live preview
+        testFrame:SetColor(d.r, d.g, d.b, d.a or 1)
+    end)
+    defaultBtn:SetScript("OnEnter", function(self) self:SetBackdropBorderColor(C_ACCENT.r, C_ACCENT.g, C_ACCENT.b, 1) end)
+    defaultBtn:SetScript("OnLeave", function(self) self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1) end)
+    defaultBtn:Hide()
+    testFrame.defaultBtn = defaultBtn
     
     local classContent = CreateFrame("Frame", nil, tabContent)
     classContent:SetAllPoints()
@@ -1548,7 +1574,7 @@ local function CreateColorPickerTest(hasAlpha)
     cancelBtn:SetScript("OnClick", function() testFrame:Hide() end)
     cancelBtn:SetScript("OnEnter", function(self) self:SetBackdropBorderColor(0.8, 0.4, 0.4, 1) end)
     cancelBtn:SetScript("OnLeave", function(self) self:SetBackdropBorderColor(C_BORDER.r, C_BORDER.g, C_BORDER.b, 1) end)
-    
+
     -- ============================================================
     -- API Methods
     -- ============================================================
@@ -1641,22 +1667,32 @@ end
 -- @param hasAlpha: boolean - show alpha slider
 -- @param onAccept: function(newColor) - called with {r, g, b, a} on accept
 -- @param onCancel: function() - called on cancel
-function GUI:OpenColorPicker(initialColor, hasAlpha, onAccept, onCancel, onChange)
+function GUI:OpenColorPicker(initialColor, hasAlpha, onAccept, onCancel, onChange, defaultColor)
     -- Ensure the picker is created
     CreateColorPickerTest(hasAlpha)
-    
+
     -- If picker is already visible, hide it first without triggering cancel callback
     -- This prevents state leakage when quickly switching between color pickers
     if testFrame:IsShown() then
         testFrame.appliedColor = true  -- Prevent OnHide from calling old cancel callback
         testFrame:Hide()
     end
-    
+
     -- Clear any previous callbacks to prevent state leakage
     testFrame:ClearCallbacks()
     testFrame.appliedColor = false
     testFrame.skipOnChange = false
-    
+
+    -- Store default colour and show/hide the Default button accordingly
+    testFrame.defaultColor = defaultColor or nil
+    if testFrame.defaultBtn then
+        if defaultColor then
+            testFrame.defaultBtn:Show()
+        else
+            testFrame.defaultBtn:Hide()
+        end
+    end
+
     -- Set new callbacks
     testFrame:SetCallbacks(onAccept, onCancel, onChange)
     
@@ -1925,7 +1961,7 @@ local function OpenDFColorPickerWithBlizzard(info, useBlizzardAsBackend)
         C_Timer.After(0.01, function()
             HideBlizzardPicker()
         end)
-        
+
         -- Open our picker with callbacks that interact with Blizzard's hidden picker
         GUI:OpenColorPicker(
             { r = r, g = g, b = b, a = a },
@@ -1942,7 +1978,9 @@ local function OpenDFColorPickerWithBlizzard(info, useBlizzardAsBackend)
             -- On Change: sync to Blizzard (triggers live preview callbacks)
             function(newColor)
                 SyncColorToBlizzard(newColor.r, newColor.g, newColor.b, newColor.a)
-            end
+            end,
+            -- Default colour (passed from DF setting defaults)
+            info.dfDefaultColor
         )
     else
         -- Direct mode (DandersFrames internal, no Blizzard backend needed)
@@ -2005,7 +2043,9 @@ local function OpenDFColorPickerWithBlizzard(info, useBlizzardAsBackend)
             -- On Change
             function(newColor)
                 ApplyColor(newColor)
-            end
+            end,
+            -- Default colour (passed from DF setting defaults)
+            info.dfDefaultColor
         )
     end
 end

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -2901,6 +2901,23 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
             end)
         end
         
+        -- Attach default colour so the picker can offer a Default button
+        local defaultVal = (DF.PartyDefaults and DF.PartyDefaults[dbKey])
+                        or (DF.RaidDefaults  and DF.RaidDefaults[dbKey])
+        -- Fallback: power bar colours use WoW's PowerBarColor table as their default
+        if not defaultVal and PowerBarColor and dbKey then
+            defaultVal = PowerBarColor[dbKey]
+        end
+        if defaultVal and type(defaultVal) == "table" and defaultVal.r then
+            info.dfDefaultColor = {r = defaultVal.r or 1, g = defaultVal.g or 1, b = defaultVal.b or 1, a = defaultVal.a or 1}
+            -- Populate ElvUI's "Default" button (ColorPPDefault) so it enables and
+            -- pastes the DF setting default when the native Blizzard picker is shown
+            local elvDefault = _G["ColorPPDefault"]
+            if elvDefault then
+                elvDefault.colors = info.dfDefaultColor
+            end
+        end
+
         -- Mark this as a DandersFrames color picker call
         GUI:MarkColorPickerCall()
         ColorPickerFrame:SetupColorPickerAndShow(info)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -3115,11 +3115,13 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         
         colorPickerGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Use DF Color Picker"], db, "colorPickerOverride", function()
             if db.colorPickerOverride or db.colorPickerGlobalOverride then
-                local success = GUI:InstallColorPickerHook()
-                if success then print("|cff00ff00DandersFrames:|r Color picker override enabled")
-                elseif GUI:IsColorPickerHookInstalled() then print("|cff00ff00DandersFrames:|r Color picker override already active") end
+                GUI:InstallColorPickerHook()
             else
                 GUI:UninstallColorPickerHook()
+            end
+            if db.colorPickerOverride then
+                print("|cff00ff00DandersFrames:|r Color picker override enabled")
+            else
                 print("|cffff9900DandersFrames:|r Color picker override disabled")
             end
         end), 30)
@@ -3127,12 +3129,14 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         
         colorPickerGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Use DF Color Picker for All Addons"], db, "colorPickerGlobalOverride", function()
             if db.colorPickerOverride or db.colorPickerGlobalOverride then
-                local success = GUI:InstallColorPickerHook()
-                if success then print("|cff00ff00DandersFrames:|r Custom color picker enabled for all addons")
-                elseif GUI:IsColorPickerHookInstalled() then print("|cff00ff00DandersFrames:|r Color picker hook already active") end
+                GUI:InstallColorPickerHook()
             else
                 GUI:UninstallColorPickerHook()
-                print("|cffff9900DandersFrames:|r Color picker hook disabled")
+            end
+            if db.colorPickerGlobalOverride then
+                print("|cff00ff00DandersFrames:|r Custom color picker enabled for all addons")
+            else
+                print("|cffff9900DandersFrames:|r Custom color picker disabled for all addons")
             end
         end), 30)
         colorPickerGroup:AddWidget(GUI:CreateLabel(self.child, L["Show the DF color picker when any addon opens a color picker."], 250), 30)


### PR DESCRIPTION
## Summary

- Adds a **Default** button to the DF colour picker, stacked below the **Save** button in the tab row. Clicking it resets the colour to the setting's configured default value with live preview.
- Populates ElvUI's `ColorPPDefault` button with the DF default when any DF setting's colour picker is opened, enabling it on the native Blizzard picker.
- Resource bar (power) colour pickers now correctly resolve defaults via WoW's `PowerBarColor` table as a fallback when no entry exists in `PartyDefaults`/`RaidDefaults`.
- Fixes a noisy "Color picker hook already active" chat message that fired incorrectly when toggling the global color picker override checkbox.

## Test plan

- [x] Open any DF colour setting — Default button appears below Save in the picker tab row and resets to the setting default with live preview
- [x] Open a resource bar power colour — Default button appears and resets to the WoW default for that power type
- [x] With ElvUI installed and DF override off, open a DF colour setting — ElvUI's Default button on the native picker is enabled and pastes the correct DF default
- [x] Toggle "Use DF Color Picker for All Addons" on and off — no spurious chat messages