### PR TITLE
feat: add addon compartment button and Unit Frames category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Added DandersFrames to the Blizzard addon compartment — left-click opens settings, right-click toggles solo mode. Also correctly listed under Unit Frames in the addon list. (Suggested by JPEscher)
 * **Reduced Max Health bar** — a new sub-bar appears on the right edge of party and raid frames when a unit's maximum health has been temporarily reduced (e.g. by certain Mythic+ affixes or boss debuffs), showing exactly how much of the bar is locked out. Customise it under **Health Bar → Reduced Max Health**: enable/disable, choose a texture and colour, set a blend mode, and toggle whether the health bar visually shrinks to fit (Clip Health Bar) or the reduced section overlays it.
 
 ### Bug Fixes

--- a/Core.lua
+++ b/Core.lua
@@ -5357,6 +5357,49 @@ local LDB = LibStub("LibDataBroker-1.1"):NewDataObject("DandersFrames", {
     end,
 })
 
+-- ============================================================
+-- ADDON COMPARTMENT
+-- Registers DandersFrames in Blizzard's addon compartment button
+-- ============================================================
+
+local addonCompartmentRegistered = false
+
+function DF:CreateAddonCompartment()
+    if addonCompartmentRegistered then return end
+    if not AddonCompartmentFrame then return end
+
+    AddonCompartmentFrame:RegisterAddon({
+        text = "DandersFrames",
+        icon = "Interface\\AddOns\\DandersFrames\\Media\\DF_Icon",
+        registerForAnyClick = true,
+        notCheckable = true,
+        func = function(button, menuInputData, menu)
+            if menuInputData.buttonName == "LeftButton" then
+                DF:ToggleGUI()
+            elseif menuInputData.buttonName == "RightButton" then
+                local db = DF:GetDB()
+                if db.soloMode ~= nil then
+                    db.soloMode = not db.soloMode
+                    DF:UpdateAllFrames()
+                    print("|cff00ff00DandersFrames:|r " .. format(L["Solo mode %s"], db.soloMode and L["enabled"] or L["disabled"]))
+                end
+            end
+        end,
+        funcOnEnter = function(button)
+            MenuUtil.ShowTooltip(button, function(tooltip)
+                tooltip:AddLine("DandersFrames")
+                tooltip:AddLine("|cffffffffLeft-Click:|r Open settings", 0.8, 0.8, 0.8)
+                tooltip:AddLine("|cffffffffRight-Click:|r Toggle solo mode", 0.8, 0.8, 0.8)
+            end)
+        end,
+        funcOnLeave = function(button)
+            MenuUtil.HideTooltip(button)
+        end,
+    })
+
+    addonCompartmentRegistered = true
+end
+
 function DF:CreateMinimapButton()
     if minimapButtonRegistered then return end
     if not LibDBIcon then return end
@@ -5437,12 +5480,13 @@ function DF:UpdateDefaultPlayerFrame()
     end
 end
 
--- Initialize minimap button after PLAYER_LOGIN
+-- Initialize minimap button and addon compartment after PLAYER_LOGIN
 C_Timer.After(1, function()
     local db = DF:GetDB()
     if db and db.showMinimapButton then
         DF:CreateMinimapButton()
     end
+    DF:CreateAddonCompartment()
 end)
 
 -- ============================================================

--- a/DandersFrames.toc
+++ b/DandersFrames.toc
@@ -11,6 +11,17 @@
 ## SavedVariablesPerCharacter: DandersFramesCharDB
 ## AllowAddOnTableAccess: 1
 ## OptionalDeps: Masque, LibSharedMedia-3.0, SharedMedia, SharedMedia_MyMedia, SharedMediaAdditionalFonts, FrameSort
+## Category: Unit Frames
+## Category-deDE: Einheitenfenster
+## Category-esES: Marcos de unidades
+## Category-esMX: Marcos de unidades
+## Category-frFR: Portraits d'unités
+## Category-itIT: Riquadri delle unità
+## Category-koKR: 개체창
+## Category-ptBR: Quadros de unidade
+## Category-ruRU: Рамки юнитов
+## Category-zhCN: 单位框体
+## Category-zhTW: 單位框架
 
 # Libraries
 Libs\LibStub\LibStub.lua


### PR DESCRIPTION
## Summary

- Registers DandersFrames in Blizzard's addon compartment button (Retail 10.x+): left-click opens settings, right-click toggles solo mode — matching the minimap button behaviour exactly, including the tooltip
- Adds `## Category: Unit Frames` to the TOC (with all locale variants) so DF is correctly listed under Unit Frames in the addon manager

## Implementation notes

- Uses `AddonCompartmentFrame:RegisterAddon()` with `registerForAnyClick = true` for left/right click support
- No opt-in toggle — always registers when the frame is available
- A guard (`if not AddonCompartmentFrame then return end`) future-proofs against any environment where the frame isn't present
- Registered from the existing `C_Timer.After(1)` block alongside minimap init
- This supersedes PR #43 and PR #44 by JPEscher — credit to them for the original suggestion and implementation

## Test plan

- [x] `/rl` and confirm DF icon appears in the addon compartment
- [x] Left-click opens the DF settings panel
- [x] Right-click toggles solo mode and prints the confirmation message
- [x] Hover shows the tooltip with left/right click hints
- [x] Addon list shows DandersFrames under the Unit Frames category