### PR TITLE
fix: search results not firing setting-specific callbacks for any widget type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* (Search) Fix checkbox settings toggled from search results not firing their update — e.g. the minimap button toggle had no effect when used from search.
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
 * (Click Casting) Fix keyboard binds occasionally firing your action bar spell instead of the click-cast spell while the cursor is still on the frame. The mouseover-state guard now requires both checks to agree the cursor has actually left before clearing bindings.
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * (Range Fading) Fix out-of-range members briefly flashing at full alpha when joining a group or when the roster reshuffles. (PR #84 by Krathe)
 * (Reset Page) Fix Buffs and Debuffs Enable toggles not resetting, plus name truncation and the minimap button now refresh live after a profile reset. (PR #83 by Krathe)
 * (Resource Bar) Fix a 1-pixel gap appearing on one side when "Match Health Bar Width" is on with Pixel Perfect. (PR #80 by Krathe)
+* (Search) Fix sliders, dropdowns, colour pickers, and toggle switches edited from search results not firing their setting-specific update. (PR #100 by Krathe)
 * (Test Mode) Fix locking frames turning off test mode when it was already active. (PR #87 by Krathe)
 
 ## [4.3.9]

--- a/Features/Search.lua
+++ b/Features/Search.lua
@@ -645,9 +645,10 @@ function Search:CreateInlineSlider(parent, entry)
                 input:SetText(string.format("%d", value))
             end
         end
+        if entry.callback then entry.callback() end
         DF:ThrottledUpdateAll()
     end)
-    
+
     input:SetScript("OnEnterPressed", function(self)
         local val = tonumber(self:GetText())
         if val then
@@ -659,6 +660,7 @@ function Search:CreateInlineSlider(parent, entry)
             suppressCallback = false
         end
         self:ClearFocus()
+        if entry.callback then entry.callback() end
         DF:UpdateAll()
     end)
     
@@ -710,6 +712,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 local a = hasAlpha and ColorPickerFrame:GetColorAlpha() or (c.a or 1)
                 db[dbKey] = {r = r, g = g, b = b, a = a}
                 UpdateSwatch()
+                if entry.callback then entry.callback() end
                 DF:UpdateAll()
             end,
             hasOpacity = hasAlpha,
@@ -718,6 +721,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 if a and db[dbKey] then
                     db[dbKey].a = a
                     UpdateSwatch()
+                    if entry.callback then entry.callback() end
                     DF:UpdateAll()
                 end
             end,
@@ -725,6 +729,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 if restore then
                     db[dbKey] = {r = restore.r, g = restore.g, b = restore.b, a = restore.a or restore.opacity or 1}
                     UpdateSwatch()
+                    if entry.callback then entry.callback() end
                     DF:UpdateAll()
                 end
             end,
@@ -788,6 +793,7 @@ function Search:CreateInlineDropdown(parent, entry)
         db[dbKey] = key
         btnText:SetText(display)
         list:Hide()
+        if entry.callback then entry.callback() end
         DF:UpdateAll()
     end
     
@@ -1253,7 +1259,7 @@ function Search:RegisterCheckbox(label, dbKey, keywords, customGetSet, callback)
     })
 end
 
-function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords)
+function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
@@ -1262,25 +1268,28 @@ function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords)
         maxVal = maxVal,
         step = step,
         keywords = keywords,
+        callback = callback,
     })
 end
 
-function Search:RegisterDropdown(label, dbKey, values, keywords)
+function Search:RegisterDropdown(label, dbKey, values, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
         widgetType = "dropdown",
         values = values,
         keywords = keywords,
+        callback = callback,
     })
 end
 
-function Search:RegisterColorPicker(label, dbKey, hasAlpha, keywords)
+function Search:RegisterColorPicker(label, dbKey, hasAlpha, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
         widgetType = "colorpicker",
         hasAlpha = hasAlpha,
         keywords = keywords,
+        callback = callback,
     })
 end

--- a/Features/Search.lua
+++ b/Features/Search.lua
@@ -562,6 +562,7 @@ function Search:CreateInlineCheckbox(parent, entry)
     
     cb:SetScript("OnClick", function(self)
         db[dbKey] = self:GetChecked()
+        if entry.callback then entry.callback() end
         DF:UpdateAll()
     end)
     
@@ -1240,7 +1241,7 @@ end
 -- REGISTRATION HELPERS
 -- Now store all widget metadata
 -- ============================================================
-function Search:RegisterCheckbox(label, dbKey, keywords, customGetSet)
+function Search:RegisterCheckbox(label, dbKey, keywords, customGetSet, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
@@ -1248,6 +1249,7 @@ function Search:RegisterCheckbox(label, dbKey, keywords, customGetSet)
         widgetType = "checkbox",
         keywords = keywords,
         isCustom = customGetSet or false,
+        callback = callback,
     })
 end
 

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -2231,7 +2231,7 @@ function GUI:CreateToggleSwitch(parent, labelA, labelB, dbTable, dbKey, valueA, 
 
     -- Search registration
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterCheckbox(labelA .. " / " .. labelB, dbKey, nil, false)
+        container.searchEntry = DF.Search:RegisterCheckbox(labelA .. " / " .. labelB, dbKey, nil, false, callback)
     end
 
     UpdateVisuals()
@@ -2730,7 +2730,7 @@ function GUI:CreateSlider(parent, label, minVal, maxVal, step, dbTable, dbKey, c
     
     -- SEARCH: Register this setting with slider metadata
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterSlider(label, dbKey, minVal, maxVal, step, nil)
+        container.searchEntry = DF.Search:RegisterSlider(label, dbKey, minVal, maxVal, step, nil, callback)
     end
     
     -- Expose label for dynamic updates
@@ -2922,7 +2922,7 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
     
     -- SEARCH: Register this setting
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterColorPicker(label, dbKey, hasAlpha, nil)
+        container.searchEntry = DF.Search:RegisterColorPicker(label, dbKey, hasAlpha, nil, callback)
     end
     
     return container
@@ -3130,7 +3130,7 @@ function GUI:CreateDropdown(parent, label, options, dbTable, dbKey, callback)
     
     -- SEARCH: Register this setting
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, options, nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, options, nil, callback)
     end
     
     return container
@@ -3694,7 +3694,7 @@ function GUI:CreateTextureDropdown(parent, label, dbTable, dbKey, callback, cust
     -- SEARCH: Register this setting (use current texture list)
     if DF.Search and dbKey and type(dbKey) == "string" then
         local currentOptions = customOptions or DF:GetTextureList()
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, currentOptions, nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, currentOptions, nil, callback)
     end
     
     return container
@@ -4000,7 +4000,7 @@ function GUI:CreateFontDropdown(parent, label, dbTable, dbKey, callback)
     
     -- SEARCH: Register this setting (use current font list)
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, DF:GetFontList(), nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, DF:GetFontList(), nil, callback)
     end
     
     return container

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -2044,9 +2044,9 @@ function GUI:CreateCheckbox(parent, label, dbTable, dbKey, callback, customGet, 
     if DF.Search then
         local hasCustomGetSet = (customGet ~= nil or customSet ~= nil)
         if dbKey and type(dbKey) == "string" then
-            container.searchEntry = DF.Search:RegisterCheckbox(label, dbKey, nil, false)
+            container.searchEntry = DF.Search:RegisterCheckbox(label, dbKey, nil, false, callback)
         elseif hasCustomGetSet then
-            container.searchEntry = DF.Search:RegisterCheckbox(label, nil, nil, true)
+            container.searchEntry = DF.Search:RegisterCheckbox(label, nil, nil, true, callback)
         end
     end
     


### PR DESCRIPTION
## Summary

Settings edited from the search results panel were not firing their setting-specific update callbacks — only the generic `DF:UpdateAll()` ran. This meant settings whose update isn't covered by `DF:UpdateAll()` (e.g. the minimap button toggle) silently had no effect when changed from search.

The gap affected every widget type registered with the search system.

## Changes

**`Features/Search.lua`**
- `RegisterCheckbox` — already stored `callback`; inline `OnClick` now calls it (original fix)
- `RegisterSlider` — gains `callback` parameter; `OnValueChanged` and `OnEnterPressed` call it
- `RegisterColorPicker` — gains `callback` parameter; `swatchFunc`, `opacityFunc`, and `cancelFunc` call it
- `RegisterDropdown` — gains `callback` parameter; `Select()` calls it

**`GUI/GUI.lua`**
- `CreateCheckbox` — already forwarding `callback` (original fix)
- `CreateToggleSwitch`, `CreateSlider`, `CreateColorPicker`, `CreateDropdown`, `CreateTextureDropdown`, `CreateFontDropdown` — all now forward `callback` to their `Search:Register*` call

Pattern throughout: `if entry.callback then entry.callback() end` before `DF:UpdateAll()`.