### PR TITLE
fix: missing buff icon stays stale on player frame after entering a delve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * (Global Fonts) Fix the Affected Elements list missing entries and being clipped. (PR #76 by Krathe)
 * (Global Fonts) Fix the font dropdown showing the previous profile's font after switching profiles. (PR #77 by Krathe)
 * (Missing Buff Indicators) Fix stale icons remaining on frames after leaving a group. (PR #75 by Krathe)
+* (Missing Buff Indicators) Fix a missing buff icon staying on your own frame after entering a delve and rebuffing. (PR #99 by Krathe)
 * (Pinned Frames) Fix all settings showing as overridden by an Auto Layout when only one setting is actually overridden. (PR #91 by Krathe)
 * (Pinned Frames) Fix pinned frame position being lost when an Auto Layout is active and the layout rebuilds, or resetting when clicking Edit on an active Auto Layout. (PR #90 by Krathe)
 * (Range Fading) Fix out-of-range members briefly flashing at full alpha when joining a group or when the roster reshuffles. (PR #84 by Krathe)

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -632,7 +632,8 @@ local function TriggerAuraUpdateForUnit(unit)
                             DF:UpdateMyBuffIndicator(child)
                         end
                         if DF.UpdateMissingBuffIcon then
-                            DF:UpdateMissingBuffIcon(child)
+                            -- forceUpdate=true: same cache-desync fix as the main fan-out above.
+                            DF:UpdateMissingBuffIcon(child, true)
                         end
                         if DF.UpdateDispelOverlay then
                             DF:UpdateDispelOverlay(child)

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -599,7 +599,9 @@ local function TriggerAuraUpdateForUnit(unit)
             DF:UpdateMyBuffIndicator(ourFrame)
         end
         if DF.UpdateMissingBuffIcon then
-            DF:UpdateMissingBuffIcon(ourFrame)
+            -- forceUpdate=true: bypass the cache equality check so a zone-transition
+            -- cache wipe can't leave a stale "missing" icon after rebuffing.
+            DF:UpdateMissingBuffIcon(ourFrame, true)
         end
         if DF.UpdateDispelOverlay then
             DF:UpdateDispelOverlay(ourFrame)

--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -790,7 +790,7 @@ end
 -- Per-frame throttle tracking for missing buff updates (kept for UpdateAllMissingBuffIcons)
 local missingBuffThrottle = {}
 
-function DF:UpdateMissingBuffIcon(frame)
+function DF:UpdateMissingBuffIcon(frame, forceUpdate)
     if not frame or not frame.unit or not frame.missingBuffFrame then return end
     
     -- PERF TEST: Skip if disabled
@@ -881,9 +881,14 @@ function DF:UpdateMissingBuffIcon(frame)
         end
     end
     
-    -- CACHING: Check if the missing buff state changed
+    -- CACHING: Check if the missing buff state changed.
+    -- Skip when forceUpdate is true (called from a real UNIT_AURA event via
+    -- TriggerAuraUpdateForUnit) — a zone transition can wipe the cache to nil
+    -- while the icon is still showing, leaving cachedMissing == missingSpellID
+    -- (both nil) even though the visual is stale. Forcing the update here
+    -- ensures the visual always matches what UnitHasBuff returns on events.
     local cachedMissing = missingBuffCache[frame]
-    if cachedMissing == missingSpellID then
+    if not forceUpdate and cachedMissing == missingSpellID then
         -- No change - skip all visual updates
         return
     end
@@ -983,10 +988,6 @@ end
 
 -- Update missing buff icons for all frames (called on a timer, out of combat only)
 function DF:UpdateAllMissingBuffIcons()
-    -- Clear caches so display-setting changes (border toggle, color, etc.) re-render
-    wipe(missingBuffCache)
-    wipe(missingBuffThrottle)
-    
     -- Check if in test mode - use test update functions instead
     if DF.testMode or DF.raidTestMode then
         if DF.UpdateAllTestMissingBuff then
@@ -994,13 +995,22 @@ function DF:UpdateAllMissingBuffIcons()
         end
         return
     end
-    
-    -- Throttle updates to avoid spam (0.1 second minimum between updates)
+
+    -- Throttle updates to avoid spam (0.1 second minimum between updates).
+    -- IMPORTANT: This check must come BEFORE the cache wipe below. If we wipe
+    -- the cache and then return early (throttled), the cache becomes desynced
+    -- from the visual state: the icon is still showing but missingBuffCache[frame]
+    -- is now nil. The next UNIT_AURA call then sees nil==nil (buff present, cache
+    -- also nil) and takes the early-return path, leaving a stale icon on screen.
     local now = GetTime()
     if DF.lastMissingBuffUpdate and (now - DF.lastMissingBuffUpdate) < 0.1 then
         return
     end
     DF.lastMissingBuffUpdate = now
+
+    -- Clear caches so display-setting changes (border toggle, color, etc.) re-render
+    wipe(missingBuffCache)
+    wipe(missingBuffThrottle)
     
     local function updateFrame(frame)
         if frame and frame:IsShown() then


### PR DESCRIPTION
## Root cause

On zone transitions (e.g. entering a delve solo from a party), `missingBuffCache` is wiped to `nil` while the missing-buff icon is still showing. The next `UNIT_AURA` event for the same unit sees `nil == nil` (cached == current) and takes the early-return path — so the icon never clears even after rebuffing.

## Fix

Added a `forceUpdate` parameter to `UpdateMissingBuffIcon`. When `true`, the cache equality check is bypassed entirely. Two call sites in `TriggerAuraUpdateForUnit` (`Features/Auras.lua`) now pass `forceUpdate = true` — the main frame fan-out and the pinned-frame fan-out — so both frames clear correctly on the next `UNIT_AURA` after rebuffing.

The bulk-scan path (`UpdateAllMissingBuffIcons`) continues to use the cache as intended.

### Bonus fix

Reordered the throttle check before the cache wipe in `UpdateAllMissingBuffIcons`. Previously a throttled call would wipe `missingBuffCache` but skip re-populating it, leaving stale `nil` entries while icons were still showing.

## Testing

- 2-player party, Power Word: Fortitude self-buffed
- Enter a delve solo (real party member stays outside, NPC companion joins)
- Confirm missing buff icon appears on player frame (and pinned frame if one is set up for the same unit)
- Rebuff once — icon clears on both frames without needing remove + rebuff or `/reload`