### PR TITLE
fix: search callback gap for sliders, dropdowns, colour pickers, and toggle switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * (Range Fading) Fix out-of-range members briefly flashing at full alpha when joining a group or when the roster reshuffles. (PR #84 by Krathe)
 * (Reset Page) Fix Buffs and Debuffs Enable toggles not resetting, plus name truncation and the minimap button now refresh live after a profile reset. (PR #83 by Krathe)
 * (Resource Bar) Fix a 1-pixel gap appearing on one side when "Match Health Bar Width" is on with Pixel Perfect. (PR #80 by Krathe)
+* (Search) Fix sliders, dropdowns, colour pickers, and toggle switches edited from search results not firing their setting-specific update. (PR #100 by Krathe)
 * (Test Mode) Fix locking frames turning off test mode when it was already active. (PR #87 by Krathe)
 
 ## [4.3.9]

--- a/Features/Search.lua
+++ b/Features/Search.lua
@@ -644,9 +644,10 @@ function Search:CreateInlineSlider(parent, entry)
                 input:SetText(string.format("%d", value))
             end
         end
+        if entry.callback then entry.callback() end
         DF:ThrottledUpdateAll()
     end)
-    
+
     input:SetScript("OnEnterPressed", function(self)
         local val = tonumber(self:GetText())
         if val then
@@ -658,6 +659,7 @@ function Search:CreateInlineSlider(parent, entry)
             suppressCallback = false
         end
         self:ClearFocus()
+        if entry.callback then entry.callback() end
         DF:UpdateAll()
     end)
     
@@ -709,6 +711,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 local a = hasAlpha and ColorPickerFrame:GetColorAlpha() or (c.a or 1)
                 db[dbKey] = {r = r, g = g, b = b, a = a}
                 UpdateSwatch()
+                if entry.callback then entry.callback() end
                 DF:UpdateAll()
             end,
             hasOpacity = hasAlpha,
@@ -717,6 +720,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 if a and db[dbKey] then
                     db[dbKey].a = a
                     UpdateSwatch()
+                    if entry.callback then entry.callback() end
                     DF:UpdateAll()
                 end
             end,
@@ -724,6 +728,7 @@ function Search:CreateInlineColorPicker(parent, entry)
                 if restore then
                     db[dbKey] = {r = restore.r, g = restore.g, b = restore.b, a = restore.a or restore.opacity or 1}
                     UpdateSwatch()
+                    if entry.callback then entry.callback() end
                     DF:UpdateAll()
                 end
             end,
@@ -787,6 +792,7 @@ function Search:CreateInlineDropdown(parent, entry)
         db[dbKey] = key
         btnText:SetText(display)
         list:Hide()
+        if entry.callback then entry.callback() end
         DF:UpdateAll()
     end
     
@@ -1251,7 +1257,7 @@ function Search:RegisterCheckbox(label, dbKey, keywords, customGetSet)
     })
 end
 
-function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords)
+function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
@@ -1260,25 +1266,28 @@ function Search:RegisterSlider(label, dbKey, minVal, maxVal, step, keywords)
         maxVal = maxVal,
         step = step,
         keywords = keywords,
+        callback = callback,
     })
 end
 
-function Search:RegisterDropdown(label, dbKey, values, keywords)
+function Search:RegisterDropdown(label, dbKey, values, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
         widgetType = "dropdown",
         values = values,
         keywords = keywords,
+        callback = callback,
     })
 end
 
-function Search:RegisterColorPicker(label, dbKey, hasAlpha, keywords)
+function Search:RegisterColorPicker(label, dbKey, hasAlpha, keywords, callback)
     return self:Register({
         label = label,
         dbKey = dbKey,
         widgetType = "colorpicker",
         hasAlpha = hasAlpha,
         keywords = keywords,
+        callback = callback,
     })
 end

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -2231,7 +2231,7 @@ function GUI:CreateToggleSwitch(parent, labelA, labelB, dbTable, dbKey, valueA, 
 
     -- Search registration
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterCheckbox(labelA .. " / " .. labelB, dbKey, nil, false)
+        container.searchEntry = DF.Search:RegisterCheckbox(labelA .. " / " .. labelB, dbKey, nil, false, callback)
     end
 
     UpdateVisuals()
@@ -2730,7 +2730,7 @@ function GUI:CreateSlider(parent, label, minVal, maxVal, step, dbTable, dbKey, c
     
     -- SEARCH: Register this setting with slider metadata
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterSlider(label, dbKey, minVal, maxVal, step, nil)
+        container.searchEntry = DF.Search:RegisterSlider(label, dbKey, minVal, maxVal, step, nil, callback)
     end
     
     -- Expose label for dynamic updates
@@ -2922,7 +2922,7 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
     
     -- SEARCH: Register this setting
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterColorPicker(label, dbKey, hasAlpha, nil)
+        container.searchEntry = DF.Search:RegisterColorPicker(label, dbKey, hasAlpha, nil, callback)
     end
     
     return container
@@ -3130,7 +3130,7 @@ function GUI:CreateDropdown(parent, label, options, dbTable, dbKey, callback)
     
     -- SEARCH: Register this setting
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, options, nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, options, nil, callback)
     end
     
     return container
@@ -3694,7 +3694,7 @@ function GUI:CreateTextureDropdown(parent, label, dbTable, dbKey, callback, cust
     -- SEARCH: Register this setting (use current texture list)
     if DF.Search and dbKey and type(dbKey) == "string" then
         local currentOptions = customOptions or DF:GetTextureList()
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, currentOptions, nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, currentOptions, nil, callback)
     end
     
     return container
@@ -4000,7 +4000,7 @@ function GUI:CreateFontDropdown(parent, label, dbTable, dbKey, callback)
     
     -- SEARCH: Register this setting (use current font list)
     if DF.Search and dbKey and type(dbKey) == "string" then
-        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, DF:GetFontList(), nil)
+        container.searchEntry = DF.Search:RegisterDropdown(label, dbKey, DF:GetFontList(), nil, callback)
     end
     
     return container


### PR DESCRIPTION
## Summary

PR #98 fixed callback passthrough for checkboxes in search results. The same gap existed for every other search-registered widget type — any slider, dropdown, colour picker, or toggle switch whose dedicated update function isn't covered by `DF:UpdateAll()` would silently no-op when edited from the search panel.

## Changes

**`Features/Search.lua`**
- `RegisterSlider`, `RegisterDropdown`, `RegisterColorPicker` — each gains a `callback` parameter stored on the entry
- `CreateInlineSlider` — `OnValueChanged` and `OnEnterPressed` call `entry.callback` before `DF:ThrottledUpdateAll()` / `DF:UpdateAll()`
- `CreateInlineColorPicker` — `swatchFunc`, `opacityFunc`, and `cancelFunc` call `entry.callback` before `DF:UpdateAll()`
- `CreateInlineDropdown` — `Select()` calls `entry.callback` before `DF:UpdateAll()`

**`GUI/GUI.lua`**
- `CreateToggleSwitch`, `CreateSlider`, `CreateColorPicker`, `CreateDropdown`, `CreateTextureDropdown`, `CreateFontDropdown` — all forward `callback` to their respective `Search:Register*` call

Same pattern throughout as #98: `if entry.callback then entry.callback() end` before `DF:UpdateAll()`.