### PR TITLE
fix(aura designer): apply colour picker alpha to health bar indicator

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1032,9 +1032,12 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
     if not color then return end
 
     local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
+    local a = color[4] or color.a or 1
     local mode = string.lower(config.mode or "replace")
-    -- Replace: full opacity overlay; Tint: blend slider controls mix strength
-    local blend = (mode == "replace") and 1 or (config.blend or 0.5)
+    -- Replace: colour picker alpha controls overlay (and underlying bar) opacity.
+    -- Tint:    overlay opacity = blend slider × colour picker alpha (alpha scales
+    --          tint intensity so the class colour shows through more at low alpha).
+    local blend = (mode == "replace") and a or ((config.blend or 0.5) * a)
 
     -- Store on state so UpdateAuraDesignerAppearance / UpdateHealthBarAppearance
     -- can access these for OOR handling and the replace/tint mode gate.
@@ -1073,7 +1076,10 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
         if mode == "replace" then
             local hbTex = healthBar:GetStatusBarTexture()
             if hbTex then
-                hbTex:SetVertexColor(r, g, b)
+                -- Fade the underlying bar texture with the same alpha so the bar
+                -- itself becomes transparent at low alpha (without this the solid
+                -- texture shows through and the overlay's alpha has no visual effect).
+                hbTex:SetVertexColor(r, g, b, a)
             end
         else
             -- Tint mode: the underlying bar must show its normal colour through the overlay.

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -2063,11 +2063,14 @@ local function RefreshPreviewEffects()
         if auraCfg.healthbar.mode == "Replace" then
             framePreview.healthFill:SetVertexColor(clr.r, clr.g, clr.b, clr.a or 1)
         else
-            -- Tint: blend original green with the configured color
-            local r = 0.18 * (1 - blend) + clr.r * blend
-            local g = 0.80 * (1 - blend) + clr.g * blend
-            local b = 0.44 * (1 - blend) + clr.b * blend
-            framePreview.healthFill:SetVertexColor(r, g, b, 0.85)
+            -- Tint: blend original green with the configured color, scaled by alpha
+            -- so dragging the colour picker's alpha visibly weakens the tint
+            -- (matches ApplyHealthBar in Indicators.lua: overlay = blend × alpha).
+            local effBlend = blend * (clr.a or 1)
+            local r = 0.18 * (1 - effBlend) + clr.r * effBlend
+            local g = 0.80 * (1 - effBlend) + clr.g * effBlend
+            local b = 0.44 * (1 - effBlend) + clr.b * effBlend
+            framePreview.healthFill:SetVertexColor(r, g, b, 1)
         end
     end
 
@@ -2818,17 +2821,18 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
     elseif typeKey == "healthbar" then
         -- Appearance
         AddGroup(L["Appearance"], function(g)
-            local blendSlider
             g:AddWidget(GUI:CreateDropdown(parent, L["Mode"], HEALTHBAR_MODE_OPTIONS, proxy, "mode", function()
-                if blendSlider then
-                    local isReplace = (proxy.mode or "Replace") == "Replace"
-                    if isReplace then blendSlider:Hide() else blendSlider:Show() end
-                end
+                -- Rebuild so the Blend % slider's hideOn re-evaluates and the
+                -- group's height recomputes for the new visible-widget set.
+                DF:AuraDesigner_RefreshPage()
             end), 54)
             g:AddWidget(GUI:CreateColorPicker(parent, L["Color"], proxy, "color", true, RPL, RPL, true), 28)
-            blendSlider = GUI:CreateSlider(parent, L["Blend %"], 0, 1, 0.05, proxy, "blend")
+            local blendSlider = GUI:CreateSlider(parent, L["Blend %"], 0, 1, 0.05, proxy, "blend")
+            -- hideOn is re-evaluated on every LayoutChildren pass, so the slider
+            -- stays correctly hidden in Replace mode across GUI reopens. A manual
+            -- :Hide() would be clobbered by LayoutChildren's unconditional :Show().
+            blendSlider.hideOn = function() return (proxy.mode or "Replace") == "Replace" end
             g:AddWidget(blendSlider, 54)
-            if (proxy.mode or "Replace") == "Replace" then blendSlider:Hide() end
             g:AddWidget(GUI:CreateCheckbox(parent, L["Show When Missing"], proxy, "showWhenMissing", function()
                 DF.AuraDesigner.Engine:ForceRefreshAllFrames()
             end), 28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
+* (Aura Designer) Fix the colour picker's alpha not affecting the health bar indicator on live frames, and fix the Blend % slider reappearing in Replace mode after closing and reopening the GUI.
 * (Click Casting) Fix keyboard binds occasionally firing your action bar spell instead of the click-cast spell while the cursor is still on the frame. The mouseover-state guard now requires both checks to agree the cursor has actually left before clearing bindings.
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
 * (Debuffs) Fix debuff icons remaining visible on frames after a unit dies. (PR #85 by Krathe)


### PR DESCRIPTION
## Summary

Two Aura Designer fixes around the health bar indicator's colour picker.

**Alpha not applied on live frames (both Replace and Tint modes)**
`ApplyHealthBar` hardcoded the overlay alpha to `1` in Replace mode and used only `config.blend` in Tint mode — the colour picker's alpha (`color.a`) was never read. Live frames stayed at full opacity regardless of the alpha slider. The preview had the same issue in Tint mode only (hardcoded `0.85`); Replace-mode preview already honoured `clr.a` which is why it worked there.

- Replace: overlay alpha = colour picker alpha, and the underlying bar texture is faded with the same alpha. Without fading the texture too, the solid bar shows through and the overlay's alpha has no visual effect.
- Tint: overlay alpha = `blend × alpha`. Blend % still controls tint strength; alpha further weakens it so the class colour bleeds through more at low alpha.
- Preview Tint: mix factor and final alpha now mirror the live-frame formula.

**Blend % slider reappears in Replace mode after GUI reopen**
The manual `blendSlider:Hide()` in `BuildTypeContent` is called from `buildFn`, then `AddGroup` immediately runs `group:LayoutChildren()` which unconditionally calls `widget:Show()` on every child without a `hideOn` callback. The hide gets clobbered.

Switched to the existing `widget.hideOn = function() ... end` mechanism — it's re-evaluated on every layout pass, so visibility is correct on every GUI open. Mode dropdown now triggers `AuraDesigner_RefreshPage()` so the group height recomputes when the slider shows/hides.

## Test plan

- [x] Replace mode, drag alpha → live bar fades, preview fades.
- [x] Tint mode, drag alpha → live overlay weakens, preview weakens.
- [x] Replace mode → Blend % hidden. Close + reopen GUI → still hidden.
- [x] Toggle Mode dropdown Replace ↔ Tint → Blend % appears/disappears cleanly.