### PR TITLE
feat(aura designer): add Default button to colour pickers

### DIFF
--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -623,6 +623,34 @@ local TYPE_DEFAULTS = {
         durationHideAboveEnabled = false, durationHideAboveThreshold = 10,
         frameLevel = 30, frameStrata = "INHERIT",
     },
+    -- Frame-level types: mirror the inline literals in EnsureTypeConfig so the
+    -- colour-picker Default button (and any other consumer of __dfDefaults) can
+    -- resolve a default value for keys like "color" and "expiringColor".
+    healthbar = {
+        mode = "Replace", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
+        expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+        expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
+        expiringPulsate = false,
+        showWhenMissing = false,
+    },
+    nametext = {
+        color = {r = 1, g = 1, b = 1, a = 1},
+        expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+        expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
+        showWhenMissing = false,
+    },
+    healthtext = {
+        color = {r = 1, g = 1, b = 1, a = 1},
+        expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+        expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
+        showWhenMissing = false,
+    },
+    framealpha = {
+        alpha = 0.5,
+        expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+        expiringAlpha = 1.0,
+        showWhenMissing = false,
+    },
 }
 
 -- ============================================================
@@ -803,7 +831,12 @@ local GLOBAL_DEFAULT_MAP = {
 -- Create a proxy table that maps flat key access to an indicator instance
 -- Fallback chain: instance value → global defaults → TYPE_DEFAULTS
 local function CreateInstanceProxy(auraName, indicatorID)
-    return setmetatable({ _skipOverrideIndicators = true }, {
+    -- Resolve current type to expose TYPE_DEFAULTS to GUI:CreateColorPicker's
+    -- Default button. Type changes rebuild the panel (RefreshPage) which makes
+    -- a fresh proxy, so stashing at construction time is safe.
+    local _inst = GetIndicatorByID(auraName, indicatorID)
+    local _typeDefaults = _inst and TYPE_DEFAULTS[_inst.type] or nil
+    return setmetatable({ _skipOverrideIndicators = true, __dfDefaults = _typeDefaults }, {
         __index = function(_, k)
             local inst = GetIndicatorByID(auraName, indicatorID)
             if inst then
@@ -851,7 +884,9 @@ end
 -- Create a proxy table that maps flat key access to nested aura config
 local function CreateProxy(auraName, typeKey)
     local defaults = TYPE_DEFAULTS[typeKey]
-    return setmetatable({ _skipOverrideIndicators = true }, {
+    -- Expose defaults to GUI:CreateColorPicker so its Default button can resolve
+    -- AD-specific keys (color/expiringColor/etc.) that aren't in PartyDefaults.
+    return setmetatable({ _skipOverrideIndicators = true, __dfDefaults = defaults }, {
         __index = function(_, k)
             local auraCfg = GetSpecAuras()[auraName]
             if auraCfg and auraCfg[typeKey] then
@@ -3120,8 +3155,9 @@ local function BuildGlobalView(parent)
     local rawDefaults = adDB.defaults
     -- Proxy so every write triggers a full preview rebuild
     -- (global defaults affect ALL indicators, need full teardown/rebuild)
-    -- Falls back to GLOBAL_DEFAULTS_FALLBACK for keys missing from existing profiles
-    local defaults = setmetatable({ _skipOverrideIndicators = true }, {
+    -- Falls back to GLOBAL_DEFAULTS_FALLBACK for keys missing from existing profiles.
+    -- __dfDefaults exposes the fallback table to GUI:CreateColorPicker's Default button.
+    local defaults = setmetatable({ _skipOverrideIndicators = true, __dfDefaults = GLOBAL_DEFAULTS_FALLBACK }, {
         __index = function(_, k)
             local v = rawDefaults[k]
             if v ~= nil then return v end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 * (Aura Designer) Banner controls no longer overlap when the settings window is narrow. (PR #81 by Krathe)
+* (Aura Designer) Colour pickers now offer a Default button that resets to the configured default, matching the rest of the addon.
 * (Click Casting) Fix keyboard binds occasionally firing your action bar spell instead of the click-cast spell while the cursor is still on the frame. The mouseover-state guard now requires both checks to agree the cursor has actually left before clearing bindings.
 * (Class Power) Fix Size, Colors, Position, and Show for Roles section headers showing as floating labels when Class Power Pips is disabled. (PR #82 by Krathe)
 * (Debuffs) Fix debuff icons remaining visible on frames after a unit dies. (PR #85 by Krathe)

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -2902,7 +2902,11 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
         end
         
         -- Attach default colour so the picker can offer a Default button
-        local defaultVal = (DF.PartyDefaults and DF.PartyDefaults[dbKey])
+        -- dbTable.__dfDefaults is set by callers (e.g. Aura Designer proxies) that
+        -- store their defaults outside DF.PartyDefaults / DF.RaidDefaults. Read via
+        -- rawget so proxies' __index doesn't see this lookup as a regular setting.
+        local defaultVal = (dbTable and rawget(dbTable, "__dfDefaults") and dbTable.__dfDefaults[dbKey])
+                        or (DF.PartyDefaults and DF.PartyDefaults[dbKey])
                         or (DF.RaidDefaults  and DF.RaidDefaults[dbKey])
         -- Fallback: power bar colours use WoW's PowerBarColor table as their default
         if not defaultVal and PowerBarColor and dbKey then


### PR DESCRIPTION
## Summary

Colour pickers in Aura Designer (indicator settings, frame-level effects, the Global view) had no Default button because `GUI:CreateColorPicker`'s lookup only inspected `DF.PartyDefaults` / `DF.RaidDefaults`. AD stores its defaults in its own `TYPE_DEFAULTS` table (plus an inline copy in `EnsureTypeConfig` for frame-level types) and a `GLOBAL_DEFAULTS_FALLBACK` table for the global view, so AD picker keys (`color`, `expiringColor`, `durationColor`, `stackColor`, `fillColor`, `bgColor`, `borderColor`) never resolved a default.

## Approach

Extend `CreateColorPicker` to also consult `dbTable.__dfDefaults[dbKey]` (read via `rawget` so proxies' `__index` isn't invoked for the lookup). Each AD proxy now stashes its defaults table at construction:

- `CreateProxy` → `TYPE_DEFAULTS[typeKey]`
- `CreateInstanceProxy` → `TYPE_DEFAULTS[instance.type]` (resolved at construction; type changes rebuild the panel so the proxy is fresh)
- `BuildGlobalView`'s defaults proxy → `GLOBAL_DEFAULTS_FALLBACK`

Adds `healthbar` / `nametext` / `healthtext` / `framealpha` entries to `TYPE_DEFAULTS` (mirroring the inline literals in `EnsureTypeConfig`) so frame-level pickers also resolve a default. `EnsureTypeConfig` is unchanged for now — refactoring those inline literals to consume `TYPE_DEFAULTS` would be a separate cleanup.

No call-site changes — all 20+ AD `CreateColorPicker` calls automatically pick up the Default button and ElvUI's native-picker Default integration.

## Test plan

- [x] Health Bar → Colour → Default button appears and resets to white.
- [x] Health Bar → Expiring Colour → Default resets to red.
- [x] Icon indicator → Duration Text Colour / Stack Text Colour / Expiring Colour → Default works for each.
- [x] Bar indicator → Fill / Background / Border / Expiring Colour → Default works for each.
- [x] Global view → Duration Text Colour / Stack Text Colour → Default resets to white.
- [x] ElvUI's native picker (when in use) shows an enabled Default button paste the same value.
- [x] Existing pickers outside AD (party/raid settings) still resolve their defaults via PartyDefaults/RaidDefaults — no regressions.