### PR TITLE
feat: add /df attached diagnostic to list foreign frame attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * (Click Casting) Added a "Disable only while flying" option to the Profiles panel. Disables click-casting only when airborne (including druid flight form), while keeping it active on ground mounts. Mutually exclusive with the existing "Disable while mounted/flying" option. (PR #96 by Krathe, suggested by JPEscher)
 * (Colour Picker) Added a Default button to the DF colour picker that resets the colour to its configured default value. Also populates ElvUI's Default button on the native picker for DF settings. (PR #95 by Krathe)
 * **Reduced Max Health bar** — a new sub-bar appears on the right edge of party and raid frames when a unit's maximum health has been temporarily reduced (e.g. by certain Mythic+ affixes or boss debuffs), showing exactly how much of the bar is locked out. Customise it under **Health Bar → Reduced Max Health**: enable/disable, choose a texture and colour, set a blend mode, and toggle whether the health bar visually shrinks to fit (Clip Health Bar) or the reduced section overlays it.
+* Added a `/df attached` command that lists other addons attaching castbars, cooldowns or auras to your frames — handy for telling apart DF features from another addon's.
 
 ### Bug Fixes
 

--- a/Core.lua
+++ b/Core.lua
@@ -4303,6 +4303,13 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 else
                     print("|cffff0000DandersFrames:|r Header info not available")
                 end
+            elseif msg == "attached" or msg == "attachments" then
+                -- List other addons anchored/parented to DF unit frames
+                if DF.ScanFrameAttachments then
+                    DF:ScanFrameAttachments()
+                else
+                    print("|cffff0000DandersFrames:|r Attachment scan not available")
+                end
             elseif msg == "debugheaders" then
                 -- Toggle header debug mode
                 DF.debugHeaders = not DF.debugHeaders

--- a/DandersFrames.toc
+++ b/DandersFrames.toc
@@ -66,6 +66,9 @@ Debug\DebugConsole.lua
 # OnUpdate registry full coverage of all DF every-frame handlers)
 Debug\Profiler.lua
 
+# Foreign-attachment scan (/df attached) — diagnoses other addons anchored to our frames
+Debug\AttachmentScan.lua
+
 # GUI System
 GUI\IconLib.lua
 GUI\GUI.lua

--- a/Debug/AttachmentScan.lua
+++ b/Debug/AttachmentScan.lua
@@ -24,6 +24,7 @@ local format = string.format
 local tinsert, tsort = table.insert, table.sort
 local pcall = pcall
 local EnumerateFrames = EnumerateFrames
+local issecretvalue = issecretvalue or function() return false end
 
 -- Known addons keyed by a lowercase substring found in their frame names.
 -- Best-effort only — extend as we see new culprits in bug reports.
@@ -275,12 +276,18 @@ function DF:ScanFrameAttachments()
                 end
             else
                 -- Anchored (SetPoint) to a DF frame without re-parenting.
-                local np = f:GetNumPoints() or 0
-                for i = 1, np do
-                    local ok, _, relTo = pcall(f.GetPoint, f, i)
-                    if ok and relTo and dfSet[relTo] then
-                        record(dfSet[relTo], f, "anchored")
-                        break
+                -- In combat, GetNumPoints/GetPoint return secret values for
+                -- protected frames — a secret can't be a for-loop limit. Skip
+                -- those (foreign castbar/cooldown frames aren't protected, so
+                -- they're still scanned); guard relTo the same way.
+                local np = f:GetNumPoints()
+                if type(np) == "number" and not issecretvalue(np) then
+                    for i = 1, np do
+                        local ok, _, relTo = pcall(f.GetPoint, f, i)
+                        if ok and relTo and not issecretvalue(relTo) and dfSet[relTo] then
+                            record(dfSet[relTo], f, "anchored")
+                            break
+                        end
                     end
                 end
             end

--- a/Debug/AttachmentScan.lua
+++ b/Debug/AttachmentScan.lua
@@ -58,40 +58,88 @@ local function DerivePrefix(name)
     -- Leading alphabetic run, stopping at first underscore or digit.
     local prefix = name:match("^(%a+)")
     if not prefix or #prefix < 3 then return nil end
-    -- Generic container words aren't addon names on their own.
+    -- Generic container / root words aren't addon names on their own.
+    -- (GetDebugName of an anonymous frame yields its parent path, often
+    -- "UIParent…", which would otherwise produce a misleading guess.)
     local lower = prefix:lower()
     if lower == "frame" or lower == "button" or lower == "container"
-       or lower == "ui" or lower == "status" then
+       or lower == "ui" or lower == "status" or lower == "uiparent"
+       or lower == "worldframe" then
         return nil
     end
     return prefix
 end
 
+-- Addons we never attribute to: ourselves (we touch some foreign-adjacent
+-- frames) and Blizzard's UI namespace (taint of "Blizzard_*" isn't a useful
+-- third-party answer here).
+local IGNORE_ADDON = { DandersFrames = true }
+
+-- Taint owner of a global variable, or nil. A frame created with a global name
+-- has that global written from its creating addon's code, tainting it.
+local function GlobalTaint(name)
+    if not name or name == "" then return nil end
+    local ok, isSecure, addon = pcall(issecurevariable, name)
+    if ok and not isSecure and addon and addon ~= "" and not IGNORE_ADDON[addon] then
+        return addon
+    end
+    return nil
+end
+
+-- First non-ignored addon taint among a frame's Lua-set fields, or nil.
+-- issecurevariable(frame, key) reports which addon last wrote that field, so an
+-- addon that stashes config/state on its (even anonymous) frame is identifiable.
+local function FieldTaint(frame)
+    local n = 0
+    for k in pairs(frame) do
+        if type(k) == "string" then
+            local ok, isSecure, addon = pcall(issecurevariable, frame, k)
+            if ok and not isSecure and addon and addon ~= "" and not IGNORE_ADDON[addon] then
+                return addon
+            end
+        end
+        n = n + 1
+        if n >= 80 then break end   -- bound the scan
+    end
+    return nil
+end
+
 -- Best-effort source addon for a frame.
 -- Returns: displayName, confident. displayName is nil only when nothing resolved.
---
--- Primary method (no curated list needed): a globally-named frame's global was
--- written by its creating addon, which taints that variable. issecurevariable
--- reports the tainting addon's name — e.g. "Party1SpellBar" -> "BetterBlizzFrames".
 local function GuessAddon(frame)
     local name = frame:GetName()
 
-    -- 1. Taint ownership of the frame's global. Most reliable; real folder name.
+    -- 1. The frame's own global-name taint. Most reliable; real folder name.
     if name and name ~= "" and _G[name] == frame then
-        local ok, isSecure, taintAddon = pcall(issecurevariable, name)
-        if ok and not isSecure and taintAddon and taintAddon ~= "" then
-            return taintAddon, true
-        end
+        local a = GlobalTaint(name)
+        if a then return a, true end
     end
 
+    -- 2. The frame's own field taint (addon stashed state on the anchor frame).
+    local a = FieldTaint(frame)
+    if a then return a, true end
+
+    -- 3. Walk a few parent levels and check each ancestor's global-name and
+    --    field taint. Catches anonymous frames whose owning addon set fields on
+    --    a (possibly also anonymous) parent container — e.g. Northern Sky's
+    --    private-aura frames are parented to its NSRTFrame.
+    local p, guard = frame:GetParent(), 0
+    while p and guard < 5 do
+        if p == UIParent or p == WorldFrame or p:IsForbidden() then break end
+        local pn = p:GetName()
+        local pa = (pn and _G[pn] == p and GlobalTaint(pn)) or FieldTaint(p)
+        if pa then return pa, true end
+        p = p:GetParent()
+        guard = guard + 1
+    end
+
+    -- 4. Name / debug-name heuristics: curated list, then leading-token guess.
     local names = {}
     if name and name ~= "" then names[#names + 1] = name end
     if frame.GetDebugName then
         local ok, dn = pcall(frame.GetDebugName, frame)
         if ok and dn and dn ~= "" then names[#names + 1] = dn end
     end
-    -- 2. Curated list — canonicalises names that don't match the folder
-    --    (e.g. ElvUF -> ElvUI) and covers frames with no global taint.
     for _, s in ipairs(names) do
         local low = s:lower()
         for _, entry in ipairs(KNOWN_ADDONS) do
@@ -100,7 +148,6 @@ local function GuessAddon(frame)
             end
         end
     end
-    -- 3. Last resort: leading token of the frame's own name.
     for _, s in ipairs(names) do
         local prefix = DerivePrefix(s)
         if prefix then return prefix, false end

--- a/Debug/AttachmentScan.lua
+++ b/Debug/AttachmentScan.lua
@@ -1,0 +1,271 @@
+local addonName, DF = ...
+
+-- ============================================================
+-- ATTACHMENT SCAN (diagnostic)
+-- Lists frames from OTHER addons that are anchored to, or parented
+-- onto, DandersFrames unit frames. Helps users tell DF's own
+-- features apart from castbars / cooldowns / auras that another
+-- addon has attached to our frames.
+--
+-- Read-only and run on demand via `/df attached`. WoW has no
+-- "frame -> owning addon" API, so addon attribution is a best-effort
+-- name heuristic; unknown frames are reported with their type and
+-- attach method so the user can investigate.
+--
+-- Reliable case: a frame anchored (SetPoint) to a DF frame whose own
+-- parent chain is NOT inside DF -> definitely foreign.
+-- Limitation: a foreign frame RE-PARENTED onto a DF frame is
+-- indistinguishable from a DF-created child without ownership tagging,
+-- so we only flag re-parented frames that carry a non-DF name.
+-- ============================================================
+
+local pairs, ipairs = pairs, ipairs
+local format = string.format
+local tinsert, tsort = table.insert, table.sort
+local pcall = pcall
+local EnumerateFrames = EnumerateFrames
+
+-- Known addons keyed by a lowercase substring found in their frame names.
+-- Best-effort only — extend as we see new culprits in bug reports.
+local KNOWN_ADDONS = {
+    { pat = "quartz",     name = "Quartz" },
+    { pat = "weakauras",  name = "WeakAuras" },
+    { pat = "plater",     name = "Plater" },
+    { pat = "omnicc",     name = "OmniCC" },
+    { pat = "minicc",     name = "MiniCC" },
+    { pat = "details",    name = "Details!" },
+    { pat = "bigwigs",    name = "BigWigs" },
+    { pat = "littlewigs", name = "LittleWigs" },
+    { pat = "cell",       name = "Cell" },
+    { pat = "elvuf",      name = "ElvUI" },
+    { pat = "elvui",      name = "ElvUI" },
+    { pat = "grid2",      name = "Grid2" },
+    { pat = "vuhdo",      name = "VuhDo" },
+    { pat = "clique",     name = "Clique" },
+    { pat = "gladius",    name = "Gladius" },
+    { pat = "sarena",     name = "sArena" },
+    { pat = "tellmewhen", name = "TellMeWhen" },
+    { pat = "nugrunning", name = "NugRunning" },
+    { pat = "hekili",     name = "Hekili" },
+    { pat = "exrt",       name = "MethodRaidTools/exRT" },
+    { pat = "w-method",   name = "MethodRaidTools" },
+}
+
+-- Derive a probable addon name from a frame name's leading token, e.g.
+-- "MiniCC_Container_57" -> "MiniCC", "QuartzCastBarplayer" -> "Quartz".
+-- Returns nil for names too short/generic to be meaningful.
+local function DerivePrefix(name)
+    -- Leading alphabetic run, stopping at first underscore or digit.
+    local prefix = name:match("^(%a+)")
+    if not prefix or #prefix < 3 then return nil end
+    -- Generic container words aren't addon names on their own.
+    local lower = prefix:lower()
+    if lower == "frame" or lower == "button" or lower == "container"
+       or lower == "ui" or lower == "status" then
+        return nil
+    end
+    return prefix
+end
+
+-- Best-effort source addon for a frame.
+-- Returns: displayName, confident. displayName is nil only when nothing resolved.
+--
+-- Primary method (no curated list needed): a globally-named frame's global was
+-- written by its creating addon, which taints that variable. issecurevariable
+-- reports the tainting addon's name — e.g. "Party1SpellBar" -> "BetterBlizzFrames".
+local function GuessAddon(frame)
+    local name = frame:GetName()
+
+    -- 1. Taint ownership of the frame's global. Most reliable; real folder name.
+    if name and name ~= "" and _G[name] == frame then
+        local ok, isSecure, taintAddon = pcall(issecurevariable, name)
+        if ok and not isSecure and taintAddon and taintAddon ~= "" then
+            return taintAddon, true
+        end
+    end
+
+    local names = {}
+    if name and name ~= "" then names[#names + 1] = name end
+    if frame.GetDebugName then
+        local ok, dn = pcall(frame.GetDebugName, frame)
+        if ok and dn and dn ~= "" then names[#names + 1] = dn end
+    end
+    -- 2. Curated list — canonicalises names that don't match the folder
+    --    (e.g. ElvUF -> ElvUI) and covers frames with no global taint.
+    for _, s in ipairs(names) do
+        local low = s:lower()
+        for _, entry in ipairs(KNOWN_ADDONS) do
+            if low:find(entry.pat, 1, true) then
+                return entry.name, true
+            end
+        end
+    end
+    -- 3. Last resort: leading token of the frame's own name.
+    for _, s in ipairs(names) do
+        local prefix = DerivePrefix(s)
+        if prefix then return prefix, false end
+    end
+    return nil, false
+end
+
+-- True for a WoW widget (frame/region), false for plain Lua tables.
+local function IsWidget(v)
+    return type(v) == "table" and type(v.GetObjectType) == "function"
+        and type(v.GetParent) == "function"
+end
+
+-- Build the set of DF frames: headers, unit buttons, the documented
+-- sub-elements other addons commonly anchor to, AND every widget DF stores
+-- as a field on a unit button. The last part matters because DF parents some
+-- of its own overlays (highlight borders, Aura Designer borders) to UIParent
+-- to avoid clipping — those aren't reachable by an ancestor walk, but they ARE
+-- referenced from the button (frame.dfSelectionHighlight, frame.dfAD_border…).
+-- Returns set = { [frame] = "label" }.
+local function BuildDFFrameSet()
+    local set = {}
+
+    local SUBS = {
+        healthBar = ".healthBar", powerBar = ".powerBar", castBar = ".castBar",
+        contentOverlay = ".contentOverlay", border = ".border",
+        background = ".background", nameText = ".nameText", healthText = ".healthText",
+    }
+
+    -- Collect widgets DF stashed on the button: direct fields (frame.dfFoo) and
+    -- one level into table fields (frame.dfAD_customBorders = { ... }).
+    local function collectOwned(frame, label)
+        for k, v in pairs(frame) do
+            if IsWidget(v) then
+                if not set[v] then set[v] = label .. "#" .. tostring(k) end
+            elseif type(v) == "table" then
+                for _, vv in pairs(v) do
+                    if IsWidget(vv) and not set[vv] then
+                        set[vv] = label .. "#" .. tostring(k)
+                    end
+                end
+            end
+        end
+    end
+
+    local function addUnit(frame, label)
+        if not frame then return end
+        set[frame] = label
+        for key, suffix in pairs(SUBS) do
+            local sub = frame[key]
+            if sub then set[sub] = label .. suffix end
+        end
+        collectOwned(frame, label)
+    end
+
+    if DF.IteratePartyFrames then
+        DF:IteratePartyFrames(function(f, _, unit) addUnit(f, unit) end)
+    end
+    if DF.IterateRaidFrames then
+        DF:IterateRaidFrames(function(f, _, unit) addUnit(f, unit) end)
+    end
+    if DF.IterateArenaFrames then
+        DF:IterateArenaFrames(function(f, _, unit) addUnit(f, "arena:" .. unit) end)
+    end
+
+    -- Headers / containers so the ancestor walk still recognises DF
+    -- descendants whose unit button wasn't iterated (e.g. hidden frames).
+    local roots = { DF.partyHeader, DF.partyContainer, DF.arenaHeader }
+    if DF.raidSeparatedHeaders then
+        for _, h in pairs(DF.raidSeparatedHeaders) do roots[#roots + 1] = h end
+    end
+    if DF.FlatRaidFrames and DF.FlatRaidFrames.header then
+        roots[#roots + 1] = DF.FlatRaidFrames.header
+    end
+    for _, h in ipairs(roots) do
+        if h and not set[h] then set[h] = (h.GetName and h:GetName()) or "DFHeader" end
+    end
+
+    return set
+end
+
+-- Walk the parent chain; true if any ancestor (or the frame itself) is a DF frame.
+local function IsInDFTree(frame, dfSet)
+    local f, guard = frame, 0
+    while f and guard < 80 do
+        if dfSet[f] then return true end
+        f = f:GetParent()
+        guard = guard + 1
+    end
+    return false
+end
+
+function DF:ScanFrameAttachments()
+    local dfSet = BuildDFFrameSet()
+
+    local results = {}   -- [label] = { { otype, name, addon, kind }, ... }
+    local total = 0
+
+    local function record(label, foreign, kind)
+        local addon, curated = GuessAddon(foreign)
+        results[label] = results[label] or {}
+        tinsert(results[label], {
+            otype   = foreign:GetObjectType() or "?",
+            name    = foreign:GetName(),
+            addon   = addon,
+            curated = curated,
+            kind    = kind,
+        })
+        total = total + 1
+    end
+
+    local scanned = 0
+    local f = EnumerateFrames()
+    while f do
+        scanned = scanned + 1
+        if not f:IsForbidden() and not IsInDFTree(f, dfSet) then
+            local parent = f:GetParent()
+            if parent and dfSet[parent] then
+                -- Re-parented onto a DF frame. Only report if it carries a
+                -- non-DF name (anonymous re-parents can't be told apart from
+                -- DF's own anonymous children, so we skip those).
+                local nm = f:GetName()
+                if nm and not nm:find("Danders", 1, true) then
+                    record(dfSet[parent], f, "parented")
+                end
+            else
+                -- Anchored (SetPoint) to a DF frame without re-parenting.
+                local np = f:GetNumPoints() or 0
+                for i = 1, np do
+                    local ok, _, relTo = pcall(f.GetPoint, f, i)
+                    if ok and relTo and dfSet[relTo] then
+                        record(dfSet[relTo], f, "anchored")
+                        break
+                    end
+                end
+            end
+        end
+        f = EnumerateFrames(f)
+    end
+
+    print(format("|cff00ff00DandersFrames:|r foreign-attachment scan — %d frames scanned", scanned))
+    if total == 0 then
+        print("  No other addons appear to be attached to DandersFrames unit frames.")
+        print("  (Note: a foreign frame re-parented onto ours with no name can't be detected.)")
+        return
+    end
+
+    local labels = {}
+    for label in pairs(results) do labels[#labels + 1] = label end
+    tsort(labels)
+
+    for _, label in ipairs(labels) do
+        print("|cffffd100" .. label .. ":|r")
+        for _, e in ipairs(results[label]) do
+            local who
+            if e.addon and e.curated then
+                who = e.addon                       -- confident, from curated list
+            elseif e.addon then
+                who = e.addon .. "|cffaaaaaa?|r"     -- guessed from frame name
+            else
+                who = "|cffaaaaaaunknown addon|r"
+            end
+            local nm = e.name or "<anonymous>"
+            print(format("    %s  —  %s [%s, %s]", who, nm, e.otype, e.kind))
+        end
+    end
+    print(format("  %d attachment(s) found across %d frame(s).", total, #labels))
+end


### PR DESCRIPTION
## Summary

Users regularly report castbars / cooldowns / auras stuck to their DF frames and assume they're a DF feature, when they're actually from another addon (Quartz, OmniCC, BetterBlizzFrames, WeakAuras, Northern Sky, etc.). This adds a read-only, on-demand command to identify the culprit.

`/df attached` enumerates every frame and reports any that are **anchored to** (or re-parented onto) a DF unit frame or one of its sub-elements, grouped by frame (`party1`, `raid3`, `party1.healthBar`…). Each line shows the source addon, the frame name, its type, and the attach method.

## How attribution works

WoW has no official frame→addon API, so attribution is resolved in order:

1. **Global-name taint:** a globally-named frame's global was written by its creating addon, which taints that variable. `issecurevariable(name)` reports the tainting addon — e.g. `Party1SpellBar` → `BetterBlizzFrames`. Real folder name, no curated entry required.
2. **Field taint:** `issecurevariable(frame, key)` reports which addon last wrote a Lua field, so an addon that stashes state on its anchor frame is identifiable even when the frame is anonymous.
3. **Parent walk:** check up to 5 ancestors' global-name and field taint. Catches anonymous frames whose owner set fields on a parent container — e.g. Northern Sky's private-aura anchors are nameless and parented to its own anonymous `NSRTFrame`, which resolves to `NorthernSkyRaidTools`.
4. **Curated list:** canonicalises names that don't match the folder (e.g. `ElvUF` → `ElvUI`).
5. **Name prefix (last resort):** the frame name's leading token, shown with a grey `?` to mark it as a guess. `UIParent`/`WorldFrame` and generic words are blocklisted so an unresolved frame shows "unknown addon" rather than a bad guess.

Blizzard-created frames report secure (no taint) and fall through correctly. We never attribute to `DandersFrames` itself, and the parent walk stops at `UIParent`/`WorldFrame`/forbidden frames. The field scan is bounded (80 keys).

## Avoiding false positives

DF parents some of its own overlays (highlight borders, Aura Designer borders) to `UIParent` to avoid clipping, so a parent-chain check alone would flag them as foreign. The scan instead collects the widget references DF stashes on each unit button (`frame.dfSelectionHighlight`, `frame.dfAD_border`, …) and treats those as ours. Verified clean (0 attachments) with all other addons disabled.

## Cost

Purely on-demand. At load the module only defines a function and a constant table — **no** events, hooks, timers, or frame creation. The enumeration, taint lookups, and printing run once when the command is invoked, then stop. No persistent state.

## Limitations (noted in the command output)

- A foreign frame *re-parented* onto ours with **no name** can't be distinguished from DF's own anonymous children, so those are skipped. Named re-parents and all anchored frames are caught.
- A fully anonymous frame whose owner set no fields anywhere up its parent chain falls back to "unknown addon".

## Test plan

- [x] All other addons disabled → reports 0 attachments.
- [x] BetterBlizzFrames party castbars on → `Party1SpellBar` resolves to `BetterBlizzFrames` via global taint.
- [x] MiniCC on → `MiniCC_Container_*` resolves to `MiniCC`.
- [x] Northern Sky raid-frame private auras on → anonymous anchors resolve to `NorthernSkyRaidTools` via parent-walk field taint.
- [x] DF's own highlight / Aura Designer overlays are not reported.