### PR TITLE
fix(heal prediction): refresh on health change; consolidate settings GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * (Frame Movers) Fix the orange and blue frame mover outlines rendering above the settings GUI, not following the raid frames when clicking Edit on an Auto Layout, and the position panel X/Y values not refreshing on Auto Layout edit. (PR #93 by Krathe)
 * (Global Fonts) Fix the Affected Elements list missing entries and being clipped. (PR #76 by Krathe)
 * (Global Fonts) Fix the font dropdown showing the previous profile's font after switching profiles. (PR #77 by Krathe)
+* (Heal Prediction) Fix the incoming-heal bar not keeping its size accurate as a unit's health changes while being healed.
 * (Leader / Assist Icon) Fix the leader and assist icons not appearing on frames straight away when someone is given assist or the group leader changes.
 * (Missing Buff Indicators) Fix a missing buff icon staying on your own frame after entering a delve and rebuffing. (PR #99 by Krathe)
 * (Missing Buff Indicators) Fix stale icons remaining on frames after leaving a group. (PR #75 by Krathe)

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -1172,6 +1172,15 @@ function DF:UpdateHealthFast(frame)
         DF:UpdateAbsorb(frame)
     end
 
+    -- Heal prediction is health-dependent for the same reason: the calculator
+    -- clamps incoming heals to missing/max health, so the displayed amount
+    -- changes as current health changes even with no new heal event. Refresh
+    -- only when a bar is actively shown so idle frames (the common case — no
+    -- incoming heals) cost just a single IsShown() check, not a full update.
+    if frame.dfHealPredictionBar and frame.dfHealPredictionBar:IsShown() then
+        DF:UpdateHealPrediction(frame)
+    end
+
     -- ========================================
     -- REDUCED MAX HEALTH BAR
     -- ========================================

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4046,11 +4046,15 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         -- ===== SETTINGS GROUP (Column 1) =====
         local settingsGroup = GUI:CreateSettingsGroup(self.child, 280)
         settingsGroup:AddWidget(GUI:CreateHeader(self.child, L["Heal Prediction"]), 40)
-        settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Enable Heal Prediction"], db, "healPredictionEnabled", function() 
+        settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Enable Heal Prediction"], db, "healPredictionEnabled", function()
             self:RefreshStates()
-            DF:UpdateAllFrames() 
+            DF:UpdateAllFrames()
         end), 30)
-        
+
+        local overhealCheckbox = settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Overheal"], db, "healPredictionShowOverheal", function() DF:UpdateAllFrames() end), 30)
+        overhealCheckbox.disableOn = function(d) return not d.healPredictionEnabled end
+        overhealCheckbox.tooltip = L["When enabled, shows incoming heals even if they would overheal."]
+
         local modeOptions = { OVERLAY= L["Attached to Health"], FLOATING= L["Floating Bar"] }
         local modeDropdown = settingsGroup:AddWidget(GUI:CreateDropdown(self.child, L["Display Mode"], modeOptions, db, "healPredictionMode", function()
             self:RefreshStates()
@@ -4061,26 +4065,16 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         local textureOptions = DF:GetTextureList()
         local texDropdown = settingsGroup:AddWidget(GUI:CreateTextureDropdown(self.child, L["Texture"], db, "healPredictionTexture", function() DF:UpdateAllFrames() end, textureOptions), 55)
         texDropdown.disableOn = function(d) return not d.healPredictionEnabled end
-        
+
+        local myColor = settingsGroup:AddWidget(GUI:CreateColorPicker(self.child, L["Heal Prediction Color"], db, "healPredictionMyColor", true, nil, function() DF:UpdateAllFrames() end, true), 35)
+        myColor.disableOn = function(d) return not d.healPredictionEnabled end
+
         local blendOptions = { BLEND= L["Normal (BLEND)"], ADD= L["Additive (ADD)"] }
         local blendDropdown = settingsGroup:AddWidget(GUI:CreateDropdown(self.child, L["Blend Mode"], blendOptions, db, "healPredictionBlendMode", function() DF:UpdateAllFrames() end), 55)
         blendDropdown.disableOn = function(d) return not d.healPredictionEnabled end
-        
+
         Add(settingsGroup, nil, 1)
-        
-        -- ===== APPEARANCE GROUP (Column 2) =====
-        local appearanceGroup = GUI:CreateSettingsGroup(self.child, 280)
-        appearanceGroup:AddWidget(GUI:CreateHeader(self.child, L["Appearance"]), 40)
-        
-        local overhealCheckbox = appearanceGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Overheal"], db, "healPredictionShowOverheal", function() DF:UpdateAllFrames() end), 30)
-        overhealCheckbox.disableOn = function(d) return not d.healPredictionEnabled end
-        overhealCheckbox.tooltip = L["When enabled, shows incoming heals even if they would overheal."]
-        
-        local myColor = appearanceGroup:AddWidget(GUI:CreateColorPicker(self.child, L["Heal Prediction Color"], db, "healPredictionMyColor", true, nil, function() DF:UpdateAllFrames() end, true), 35)
-        myColor.disableOn = function(d) return not d.healPredictionEnabled end
-        
-        Add(appearanceGroup, nil, 2)
-        
+
         -- ===== FLOATING POSITION GROUP (Column 1, conditional) =====
         local floatingGroup = GUI:CreateSettingsGroup(self.child, 280)
         floatingGroup:AddWidget(GUI:CreateHeader(self.child, L["Floating Bar Position"]), 40)


### PR DESCRIPTION
## Summary

Two related changes to the incoming-heals (Heal Prediction) feature.

**Behaviour — refresh on health change.** The heal-prediction calculator clamps incoming heals to missing/max health, so the *displayed* amount depends on current health. The high-frequency `UNIT_HEALTH` path (`UpdateHealthFast`) skipped heal prediction entirely, relying on the fill-texture anchor to reposition the bar. As a result, while a unit was being healed the bar's **extent** went stale as its health changed, until the next `UNIT_HEAL_PREDICTION` event corrected it.

This change refreshes heal prediction from `UpdateHealthFast`, mirroring the clamped-absorb refresh that already exists a few lines above (`UpdateAbsorb` re-runs on health change in clamped ATTACHED mode for the same reason).

**Perf:** guarded on the bar actually being shown, so a unit with no incoming heals (the common case — most of a raid at any moment) costs a single `IsShown()` boolean check per `UNIT_HEALTH`. The full update only runs while a heal is actively displayed on that unit.

**GUI — consolidate the Heal Prediction page.** Folded the separate \"Appearance\" group into the main Heal Prediction group and reordered to: Enable → Show Overheal → Display Mode → Texture → Heal Prediction Colour → Blend Mode. (Floating Bar Position/Anchor groups are unchanged and still appear only in Floating mode.)

## Test plan

- [x] Heal a damaged unit and watch the bar track correctly as its health changes (no stale extent).
- [x] Unit with no incoming heals — verified no extra work beyond the `IsShown()` check.
- [x] Settings page renders as a single group in the new order; Floating mode still shows its position/anchor groups.
- [x] Toggling Enable still greys out the dependent controls.