### PR TITLE
fix(gui): rebuild settings page on data changes, not just tab switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * (Resource Bar) Fix a 1-pixel gap appearing on one side when "Match Health Bar Width" is on with Pixel Perfect. (PR #80 by Krathe)
 * (Search) Fix settings edited from search results not firing their setting-specific update for any widget type (checkboxes, sliders, dropdowns, colour pickers, toggle switches) — e.g. the minimap button toggle had no effect when used from search. (PR #98 by Krathe)
 * (Settings) Reduce FPS loss when dragging or scrolling the settings window by caching each settings page after its first build. (PR #101 by Krathe)
+* (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change.
 * (Test Mode) Fix locking frames turning off test mode when it was already active. (PR #87 by Krathe)
 
 ## [4.3.9]

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -8096,7 +8096,8 @@ function DF:CreateGUI()
             end
             
             GUI.Pages[name]:Show()
-            GUI.Pages[name]:Refresh()
+            -- Tab switching uses the cache-aware path so revisiting a tab is cheap.
+            GUI.Pages[name]:RefreshCached()
             if GUI.Pages[name].RefreshStates then GUI.Pages[name]:RefreshStates() end
             -- Reapply picker overlays if in picker mode
             if DF.settingsPickerMode and DF.ApplyPickerOverlaysToCurrentPage then
@@ -8450,19 +8451,21 @@ function DF:CreateGUI()
             self:RefreshStates()
         end
 
-        -- Invalidate this page's cache so the next Refresh() triggers a full rebuild.
+        -- Invalidate this page's cache so the next RefreshCached() rebuilds.
         page.Invalidate = function(self)
             self.cacheValid = false
             self.builtForMode = nil
         end
 
-        page.Refresh = function(self)
+        -- Cache-aware refresh — used ONLY by tab switching. If the cached build
+        -- is still valid for the current mode and enabled/disabled state, run the
+        -- cheap visibility/layout pass; otherwise rebuild. This is the perf path
+        -- that makes revisiting a tab cheap.
+        page.RefreshCached = function(self)
             local db = DF.db[GUI.SelectedMode]
             -- Guard against nil db (e.g., when "clicks" mode is selected)
             if not db then return end
 
-            -- Cache hit: mode matches, build is valid, and the tab's
-            -- enabled/disabled banner state hasn't changed since last build.
             local isDisabled = GUI:IsTabDisabledForCurrentMode(self.tabName)
             if self.cacheValid
                and self.builtForMode == GUI.SelectedMode
@@ -8473,6 +8476,17 @@ function DF:CreateGUI()
 
             -- Cache miss: build fresh for this mode.
             -- DoBuild sets cacheValid and calls RefreshStates() before returning.
+            DoBuild(self)
+        end
+
+        -- Refresh() ALWAYS rebuilds. This is its historical contract: callers
+        -- invoke it after mutating data (adding/removing list items, reset/copy/
+        -- sync, profile changes, etc.) and rely on the page being reconstructed.
+        -- Only tab switching uses the cache, via RefreshCached().
+        page.Refresh = function(self)
+            local db = DF.db[GUI.SelectedMode]
+            -- Guard against nil db (e.g., when "clicks" mode is selected)
+            if not db then return end
             DoBuild(self)
         end
 


### PR DESCRIPTION
## Summary

Regression from the settings page-caching change ([#101](https://github.com/DanderBot/DandersFrames/pull/101)). That change made `page:Refresh()` cache-aware — when the cache was valid for the current mode it only ran the cheap `RefreshStates()` visibility/layout pass and skipped rebuilding.

The problem: `Refresh()`'s long-standing contract was *"rebuild the page"*, and many flows call `pageFrame:Refresh()` / `RefreshCurrentPage()` after **mutating data** and rely on a rebuild — e.g. adding an auto layout, reset/copy/sync, profile add/remove, wizard steps, and search-applied settings. After #101 those changes didn't appear until a `/reload` cleared the cache.

#101 only added cache invalidation for one specific case (Pinned Frames frame-type switch), so every other data-mutation path silently stopped updating live.

## Fix

- Restore `Refresh()` to **always rebuild** (its historical contract). All data-mutation callers get correct behaviour again with no per-callsite changes.
- Add a dedicated cache-aware entry point `RefreshCached()` and point **only tab switching** (`SelectTab`) at it — so revisiting a tab stays cheap (the actual perf win #101 targeted).

The drag/scroll perf path is untouched: it never calls `page:Refresh()` (it uses a deferred layout-only refresh — see the comment at `GUI.lua:778`), and the trash-frame reparenting + `SetClipsChildren` optimisations from #101 are unchanged.

## Test plan

- [x] Auto Layouts → add a layout → appears immediately (no reload).
- [x] Reset/Copy/Sync a page, add/remove a profile, wizard steps, applying a setting from search → all update live.
- [x] Rapidly switching tabs and dragging/scrolling the settings window remain smooth (cache + clipping intact).