### PR TITLE
fix(gui): sync sidebar category states when switching profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * (Resource Bar) Fix a 1-pixel gap appearing on one side when "Match Health Bar Width" is on with Pixel Perfect. (PR #80 by Krathe)
 * (Search) Fix settings edited from search results not firing their setting-specific update for any widget type (checkboxes, sliders, dropdowns, colour pickers, toggle switches) — e.g. the minimap button toggle had no effect when used from search. (PR #98 by Krathe)
 * (Settings) Reduce FPS loss when dragging or scrolling the settings window by caching each settings page after its first build. (PR #101 by Krathe)
+* (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open.
 * (Test Mode) Fix locking frames turning off test mode when it was already active. (PR #87 by Krathe)
 
 ## [4.3.9]

--- a/Core.lua
+++ b/Core.lua
@@ -5280,6 +5280,12 @@ function DF:FullProfileRefresh()
         DF.GUI:InvalidateAllPages()
     end
     if DF.GUIFrame and DF.GUIFrame:IsShown() then
+        -- Re-sync sidebar category expand/collapse state to the new profile
+        -- (categories read their state only at creation, so this is needed to
+        -- reflect the switch without a /reload).
+        if DF.GUI and DF.GUI.RefreshCategoryStates then
+            DF.GUI:RefreshCategoryStates()
+        end
         if DF.GUI and DF.GUI.RefreshCurrentPage then
             DF.GUI:RefreshCurrentPage()
         end

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -8348,7 +8348,20 @@ function DF:CreateGUI()
         local totalHeight = math.abs(y) + 20
         GUI.tabContainer:SetHeight(totalHeight)
     end
-    
+
+    -- Re-sync each category's expanded state from the current profile's saved
+    -- state and relayout the sidebar. Categories read their state once at
+    -- creation, so a profile switch needs this to reflect the new profile's
+    -- expanded/collapsed tabs without a /reload.
+    function GUI:RefreshCategoryStates()
+        local saved = DF.db and DF.db.party and DF.db.party.guiExpandedCategories
+        for name, cat in pairs(self.Categories) do
+            cat.expanded = (saved and saved[name]) or false
+            if cat.arrow then cat.arrow:SetText(cat.expanded and "-" or "+") end
+        end
+        self:UpdateTabLayout()
+    end
+
     -- Store category order
     GUI.CategoryOrder = {}
     


### PR DESCRIPTION
## Summary

Switching profiles with the settings window open didn't update the sidebar's expanded/collapsed category state to match the new profile — it stayed on the old profile's state until a `/reload`.

Sidebar categories read their expand/collapse state from the profile **once, at creation**. `FullProfileRefresh` rebuilds the current page's content but never re-syncs the categories or relays out the sidebar, so the state went stale.

This is a long-standing issue, not related to the recent page-cache work — `FullProfileRefresh` only ever refreshed page content, never the sidebar.

## Fix

- Add `GUI:RefreshCategoryStates()` — re-reads each category's expanded state from the active profile, updates the +/- arrows, and relays out the sidebar.
- Call it from `FullProfileRefresh` when the settings window is open, alongside the existing page refresh.

## Test plan

- [x] Two profiles with different expanded/collapsed categories → switching between them updates the sidebar immediately, no reload.
- [x] Active page content still refreshes correctly on profile switch.