### PR TITLE
fix(pets): re-anchor attached pets to owner after custom sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* (Pet Frames) Fix pet frames not attaching to the correct owner when custom sorting is enabled.
 * (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change. (PR #106 by Krathe)
 * (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open. (PR #107 by Krathe)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * (Pet Frames) Fix pet frames not attaching to the correct owner when custom sorting is enabled.
+* (Pet Frames) Fix pet frames reappearing after being turned off until a reload.
 * (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change. (PR #106 by Krathe)
 * (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open. (PR #107 by Krathe)
 

--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -167,6 +167,12 @@ function SecureSort:CreateHandler()
         if DF and DF.FireAPICallback then
             DF:FireAPICallback("OnFramesSorted", sortType)
         end
+        -- Sorting reassigns unit tokens to different buttons, so a pet's owner
+        -- unit may now live on a different frame. Re-anchor pets to their
+        -- current owner frame (cheap; only repositions, no rebuild).
+        if DF and DF.UpdateAllPetFramePositions then
+            DF:UpdateAllPetFramePositions()
+        end
     end
     
     -- Initialize the secure environment with our base tables

--- a/Frames/Pets.lua
+++ b/Frames/Pets.lua
@@ -318,6 +318,16 @@ end
 function DF:SetPetFrameVisible(frame, visible)
     if not frame then return end
 
+    -- Never show a pet when the feature is disabled for this mode. Pet/owner
+    -- UNIT_HEALTH events route through here and would otherwise re-show a pet
+    -- that was just toggled off, until a /reload.
+    if visible then
+        local db = DF:GetFrameDB(frame)
+        if not (db and db.petEnabled) then
+            visible = false
+        end
+    end
+
     if visible then
         -- Mark as visible - range system will set appropriate alpha
         frame.dfPetHidden = false

--- a/Frames/Pets.lua
+++ b/Frames/Pets.lua
@@ -688,9 +688,16 @@ function DF:PositionPetFrame(frame)
         return
     end
     
-    -- ATTACHED mode - position relative to owner
+    -- ATTACHED mode - position relative to owner.
+    -- Re-resolve the current owner frame: custom sorting reassigns unit tokens
+    -- to different buttons, so the frame captured at pet creation can be stale.
+    -- Anchor to whichever frame currently shows the owner unit. (Test mode keeps
+    -- its dedicated test owner frame.)
+    if not (DF.testMode or DF.raidTestMode) and frame.ownerUnit and DF.GetFrameForUnit then
+        frame.ownerFrame = DF:GetFrameForUnit(frame.ownerUnit) or frame.ownerFrame
+    end
     if not frame.ownerFrame then return end
-    
+
     local anchor = db.petAnchor or "BOTTOM"
     local offsetX = db.petOffsetX or 0
     local offsetY = db.petOffsetY or -2


### PR DESCRIPTION
## Summary

In **Attached to Owner** mode, pet frames didn't attach to the correct owner when **custom sorting** was enabled. With sorting off they attached correctly.

## Root cause

A pet captures its owner frame **once**, at creation (`InitializePetFrames` → `CreatePetFrame`). DF's secure sort reassigns unit tokens to different buttons (see the header's "same player, different unit slot" handler in `Headers.lua`), so the captured frame becomes stale — the pet stays anchored to the button that *used* to be its owner. With sorting off, the unit→button mapping is stable, so the stale reference happens to stay correct.

Two gaps:
1. `PositionPetFrame` anchored to the stale `frame.ownerFrame` rather than resolving where the owner unit lives now.
2. A pure sort doesn't fire `GROUP_ROSTER_UPDATE` (the existing pet-reposition trigger), and the unit-reassignment path returns early without touching pets.

## Fix

- **`PositionPetFrame`** re-resolves the live owner frame from the owner unit via `DF:GetFrameForUnit` before anchoring (test mode keeps its dedicated test owner). Pets anchor *relative* to the owner button, so once pointed at the correct button they follow it automatically.
- **Reposition on sort completion**: call the existing lightweight `DF:UpdateAllPetFramePositions()` from SecureSort's `NotifySortComplete` hook, which fires after sorting + positioning finishes.

Contained to `Frames/Pets.lua` + `Features/SecureSort.lua`; no secure-frame changes; reuses existing helpers. The roster-change reposition path is unchanged.

## Test plan

- [x] Attached-to-Owner + custom sorting ON → pets sit under their correct owners.
- [x] Re-sort the group → pets follow owners to new positions.
- [x] Sorting OFF → still correct (unchanged path).
- [x] Raid pets with sorting; test mode pets unaffected.