### PR TITLE
fix(settings): make minimap & player-frame toggles global, hide Visibility tab in raid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* (Settings) Fix the Show Minimap Button and Hide Blizzard Player Frame toggles doing nothing when changed in Raid settings. They are now single global options on the Settings page, and the Visibility tab (whose options only apply to party/solo frames) is hidden in Raid mode.
 * (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change. (PR #106 by Krathe)
 * (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open. (PR #107 by Krathe)
 

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -113,6 +113,21 @@ function GUI:UpdateTabAvailability()
             btn:SetBackdropColor(0, 0, 0, 0)
         end
     end
+
+    -- Refresh the sidebar so party-only tabs (e.g. Visibility) hide/show for
+    -- the current mode.
+    if GUI.UpdateTabLayout then GUI:UpdateTabLayout() end
+
+    -- If the active tab just became hidden (party-only while in raid), move to a
+    -- safe always-present tab so the user isn't left on a hidden/empty page.
+    if not GUI._redirectingTab and GUI.SelectedMode == "raid" and GUI.CurrentPageName then
+        local cur = GUI.Tabs[GUI.CurrentPageName]
+        if cur and cur.partyOnly and GUI.SelectTab then
+            GUI._redirectingTab = true
+            GUI.SelectTab("general_settings")
+            GUI._redirectingTab = false
+        end
+    end
 end
 
 -- Track currently open dropdown menu (only one can be open at a time)
@@ -8331,11 +8346,16 @@ function DF:CreateGUI()
                 
                 if cat.expanded then
                     for _, btn in ipairs(cat.children) do
-                        btn:Show()
-                        btn:ClearAllPoints()
-                        btn:SetPoint("TOPLEFT", 0, y)
-                        btn:SetPoint("TOPRIGHT", 0, y)
-                        y = y - 28
+                        -- Party-only tabs are hidden entirely in raid mode.
+                        if btn.partyOnly and GUI.SelectedMode == "raid" then
+                            btn:Hide()
+                        else
+                            btn:Show()
+                            btn:ClearAllPoints()
+                            btn:SetPoint("TOPLEFT", 0, y)
+                            btn:SetPoint("TOPRIGHT", 0, y)
+                            y = y - 28
+                        end
                     end
                 else
                     for _, btn in ipairs(cat.children) do

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -917,6 +917,7 @@ L["Medium"] = true
 L["Medium Health (50%)"] = true
 L["Min Stacks to Show"] = true
 L["Minimal"] = true
+L["Minimap"] = true
 L["Minimum Log Level"] = true
 L["Missing Buff Alpha"] = true
 L["Missing Buffs"] = true

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -381,7 +381,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
     -- Display > Visibility
     local pageVisibility = CreateSubTab("display", "display_visibility", L["Visibility"])
     BuildPage(pageVisibility, function(self, db, Add, AddSpace, AddSyncPoint)
-        Add(CreateCopyButton(self.child, {"soloMode", "hidePlayerFrame", "hideDefaultPlayerFrame", "showMinimapButton", "restedIndicator"}, L["Visibility"], "display_visibility"), 25, 2)
+        Add(CreateCopyButton(self.child, {"soloMode", "hidePlayerFrame", "restedIndicator"}, L["Visibility"], "display_visibility"), 25, 2)
 
         -- ===== FRAME DISPLAY GROUP (Column 1) =====
         local frameDisplayGroup = GUI:CreateSettingsGroup(self.child, 280)
@@ -392,10 +392,6 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             DF:UpdateDefaultPlayerFrame()
         end), 30)
         soloMode.hideOn = function() return GUI.SelectedMode == "raid" end
-        
-        frameDisplayGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Minimap Button"], db, "showMinimapButton", function()
-            DF:UpdateMinimapButton()
-        end), 30)
         
         local restedIndicator = frameDisplayGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Rested Indicator"], db, "restedIndicator", function()
             DF:UpdateRestedIndicator()
@@ -435,13 +431,12 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         hidePlayer.hideOn = function() return GUI.SelectedMode == "raid" end
         hidePlayer.tooltip = L["Removes your player frame from the DandersFrames party display."]
 
-        local hideDefaultPlayer = frameDisplayGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Hide Blizzard Player Frame"], db, "hideDefaultPlayerFrame", function()
-            DF:UpdateDefaultPlayerFrame()
-        end), 30)
-        hideDefaultPlayer.tooltip = L["Hides the default Blizzard player portrait and health bar."]
-
         Add(frameDisplayGroup, nil, 1)
     end)
+    -- The Visibility tab is entirely party/solo-oriented, so hide it in raid mode.
+    if GUI.Tabs and GUI.Tabs["display_visibility"] then
+        GUI.Tabs["display_visibility"].partyOnly = true
+    end
     
     -- Display > Tooltips (moved from General)
     local pageTooltips = CreateSubTab("display", "display_tooltips", L["Tooltips"])
@@ -1272,6 +1267,16 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         ), 30)
         disableRaidCheck.tooltip = L["Hides and unregisters all events on the default Blizzard raid frames so they consume no performance."]
 
+        local disablePlayerCheck = blizzardGroup:AddWidget(GUI:CreateCheckbox(
+            self.child, L["Hide Blizzard Player Frame"],
+            nil, nil,
+            function() DF:UpdateDefaultPlayerFrame() end,
+            makeBlizGet("hideDefaultPlayerFrame"),
+            makeBlizSet("hideDefaultPlayerFrame", function() DF:UpdateDefaultPlayerFrame() end),
+            "hideDefaultPlayerFrame"
+        ), 30)
+        disablePlayerCheck.tooltip = L["Hides the default Blizzard player portrait and health bar."]
+
         -- Visual divider + small caption to separate the related sub-option
         -- (Show Side Menu only applies once a Blizzard frame is disabled)
         local divider = CreateFrame("Frame", nil, self.child)
@@ -1297,6 +1302,17 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         sideMenuCheck.tooltip = L["Shows the ping wheel & party management menu when Blizzard frames are disabled."]
 
         Add(blizzardGroup, nil, 1)
+
+        -- ===== MINIMAP GROUP (Column 1) =====
+        -- The minimap button is a single global UI element (no mode), so it lives
+        -- here rather than the per-mode Visibility page. Reads party-canonical and
+        -- writes both dbs so it stays consistent regardless of selected mode.
+        local minimapGroup = GUI:CreateSettingsGroup(self.child, 280)
+        minimapGroup:AddWidget(GUI:CreateHeader(self.child, L["Minimap"]), 40)
+        minimapGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Minimap Button"], nil, nil, function()
+            DF:UpdateMinimapButton()
+        end, makeBlizGet("showMinimapButton"), makeBlizSet("showMinimapButton"), "showMinimapButton"), 30)
+        Add(minimapGroup, nil, 1)
 
         -- ===== SETTINGS PANEL APPEARANCE GROUP (Column 2, Top) =====
         -- Controls the look of this settings panel itself — does NOT affect


### PR DESCRIPTION
## Summary

The **Show Minimap Button** and **Hide Blizzard Player Frame** toggles lived on the per‑mode **Visibility** page, but both control single global UI elements. Their readers (`UpdateMinimapButton`, `UpdateDefaultPlayerFrame`) use `DF:GetDB()` = the **party** db, so the raid copies wrote values nothing ever read — toggling either in Raid settings did nothing.

## Changes

- Move both toggles to the **Settings** page as single global options, using the existing read‑party / write‑both pattern (the same `makeBlizGet`/`makeBlizSet` helpers the Blizzard frame toggles already use). "Hide Blizzard Player Frame" joins the **Blizzard Frames** group; the minimap toggle gets a small **Minimap** group.
- Removed both from the Visibility page and its Copy list.
- With those gone, every remaining Visibility setting (Solo Mode, Rested Indicator, Hide Self from Party Frames) is party/solo‑only, so the **Visibility tab is now hidden in Raid mode**:
  - The tab is flagged `partyOnly`.
  - `UpdateTabLayout` skips party‑only tabs when the selected mode is raid.
  - `UpdateTabAvailability` re‑lays out the sidebar on mode switch and, if the active tab just became hidden, redirects to the always‑present **Settings** tab so you're never left on an empty/orphaned page.

## Test plan

- [x] Settings → Blizzard Frames → Hide Blizzard Player Frame works (global toggle).
- [x] Settings → Minimap → Show Minimap Button works from either mode.
- [x] Visibility tab hidden in Raid, present in Party with its party/solo settings.
- [x] On Visibility tab in Party → switch to Raid → redirected to Settings; switch back → Visibility returns.
- [x] No leftover per‑mode minimap/player toggles on the Visibility page.