### PR TITLE
fix(boss-debuffs): clear stale private aura anchors on roster change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* (Boss Debuffs) Fix private aura anchors remaining bound to the previous occupant of a unit slot after a roster change, causing icons to not appear on replacement players for the rest of the session. (PR #112 by Krathe)
 * (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change. (PR #106 by Krathe)
 * (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open. (PR #107 by Krathe)
 

--- a/Features/PrivateAuras.lua
+++ b/Features/PrivateAuras.lua
@@ -957,10 +957,13 @@ function DF:UpdateAllPrivateAuraAnchors()
 
     local function setupIfNeeded(frame)
         if frame and frame.unit then
-            local anchors = frameAnchors[frame]
-            if not anchors or #anchors == 0 then
-                DF:SetupPrivateAuraAnchors(frame)
-            end
+            -- Always clear before re-registering: if the frame was previously
+            -- anchored (anchors > 0) but the unit slot was reassigned to a new
+            -- player, the existing anchors are stale. Unconditional teardown
+            -- mirrors the ElvUI/Grid2 pattern and guarantees clean state on
+            -- every roster-change trigger.
+            DF:ClearPrivateAuraAnchors(frame)
+            DF:SetupPrivateAuraAnchors(frame)
         end
     end
 

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -684,10 +684,13 @@ function DF:InitializeHeaderChild(frame)
             -- occupant's faded appearance. dfInRange is immediately repopulated
             -- by UpdateRange below for accurate OOR state before first render.
             self.dfInRange = nil
-            -- Clear private aura unit tracking so next reanchor won't skip
-            if not actualUnit then
-                self.bossDebuffAnchoredUnit = nil
-            end
+            -- Clear private aura unit tracking so next reanchor won't skip.
+            -- Always nil here — if the unit token is unchanged but a new player
+            -- occupies the slot (same-token/new-GUID fall-through from LEVEL 1),
+            -- the idempotency guard in ReanchorPrivateAuras would otherwise
+            -- short-circuit on the matching token string and leave anchors bound
+            -- to the previous occupant for the rest of the session.
+            self.bossDebuffAnchoredUnit = nil
             -- Cache new unit's GUID
             if actualUnit then
                 -- Clear stale aura/range data that may belong to old occupant of this slot


### PR DESCRIPTION
## Summary

- **Root cause (Headers.lua):** `bossDebuffAnchoredUnit` was only cleared when `not actualUnit`. A same-token/new-GUID transition (e.g. player leaves, different player joins the same slot) fell through to `ReanchorPrivateAuras` with the old token still set, so the idempotency guard short-circuited and left anchors bound to the departed player for the rest of the session.
- **Defence-in-depth (PrivateAuras.lua):** `UpdateAllPrivateAuraAnchors` previously skipped frames that already had anchors. It now always tears down and rebuilds, matching the clear-before-register pattern used by other implementations. This ensures any anchor that slips through Fix 1 is corrected on the next roster update.

## Test plan

- [x] Join a group containing players in raid/party frames with private auras active (e.g. a boss encounter with targeted debuffs)
- [x] Have a player leave and a different player join the same slot — confirm the new player's frame shows private aura icons correctly
- [x] Relog / reload mid-session and confirm anchors remain correct
- [x] Confirm no Lua errors related to private aura setup