### PR TITLE
fix(test mode): correct grouped grow-from-end positioning in vertical layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * (Settings) Fix changes such as adding an auto layout not appearing in the settings window until a reload, caused by the page-caching change. (PR #106 by Krathe)
 * (Settings) Fix the sidebar's expanded/collapsed categories not updating to match the new profile when switching profiles with the settings window open. (PR #107 by Krathe)
+* (Test Mode) Fix grouped raid frames in vertical layout with Players Grow From set to End: frames no longer overflow below the anchor box, and the column growth direction is no longer inverted, so test mode now matches live frames. (PR #113 by Krathe)
 
 ## [4.3.10]
 

--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -3683,11 +3683,20 @@ function SecureSort:CalculateRaidGroupPosition(groupNum, posInGroup, playersInGr
     -- Apply row/column growth direction (use full 8-group grid so Row 1 never jumps)
     local fullRowsCols = math.ceil(8 / groupsPerRowCol)
     local groupRowGrowth = lp.groupRowGrowth or "START"
-    -- XOR with playerAnchor: with TOPLEFT (playerAnchor=START) the row index
-    -- increases downward, so groupRowGrowth=END needs to flip rcIndex. With
-    -- BOTTOMLEFT (playerAnchor=END) y already grows upward, so the flip needs
-    -- to invert direction to avoid double-flipping when both are END. (#876)
-    local needsRowFlip = (groupRowGrowth == "END") ~= ((lp.playerAnchor or "START") == "END")
+    -- The XOR with playerAnchor only applies in horizontal mode. There, rcIndex
+    -- maps to the Y (row) axis, and playerAnchor=END triggers the test-mode
+    -- BOTTOMLEFT conversion that already flips Y — so the rcIndex flip must be
+    -- counter-inverted to avoid double-flipping when both are END. (#876)
+    -- In vertical mode rcIndex maps to the X (column) axis, there is no Y-flip
+    -- conversion, and playerAnchor=END only right-aligns within a group row, so
+    -- the flip must depend on groupRowGrowth alone — matching the live secure
+    -- snippet (Headers.lua), which flips purely on groupRowGrowth=="END".
+    local needsRowFlip
+    if lp.horizontal then
+        needsRowFlip = (groupRowGrowth == "END") ~= ((lp.playerAnchor or "START") == "END")
+    else
+        needsRowFlip = (groupRowGrowth == "END")
+    end
     if needsRowFlip then
         rcIndex = fullRowsCols - rcIndex + 1
     end
@@ -3880,7 +3889,14 @@ function SecureSort:PositionRaidFrameToGroupSlot(frame, groupNum, posInGroup, pl
     -- offset to its BOTTOMLEFT equivalent so the visible layout matches live.
     -- (#875)
     local lp = layoutParams
-    local useBottomLeft = lp and lp.testMode and (lp.playerAnchor or "START") == "END"
+    -- The BOTTOMLEFT conversion below only applies in horizontal mode, where
+    -- playerAnchor=END means players stack upward inside a tall 5-frame group.
+    -- In vertical mode playerAnchor=END only right-aligns a partial group row
+    -- (handled via groupX in CalculateRaidGroupPosition); the vertical axis is
+    -- the group-stacking axis and must stay TOPLEFT-anchored. Without the
+    -- horizontal guard the conversion fires in vertical mode and pushes every
+    -- group below the container. (#875 context, vertical-mode regression)
+    local useBottomLeft = lp and lp.testMode and lp.horizontal and (lp.playerAnchor or "START") == "END"
 
     local bx, by = x, y
     if useBottomLeft then


### PR DESCRIPTION
## Summary

Two test-mode-only fixes in the grouped raid positioner (`Features/SecureSort.lua`), both scoped to **vertical layout with Players Grow From = End**, so test frames match what the live secure snippet renders.

- **Overflow fix** — `PositionRaidFrameToGroupSlot`'s `BOTTOMLEFT` conversion only makes sense in horizontal mode (where End means players stack upward inside a tall group). It was also firing in vertical mode, where End merely right-aligns a partial group row, which pushed every group below the container/anchor box. Now gated on `lp.horizontal`.
- **Column-flip fix** — the `needsRowFlip` XOR in `CalculateRaidGroupPosition` inverted the column growth direction in vertical mode. The XOR counter-flips the `BOTTOMLEFT` Y-conversion, which only exists in horizontal mode, so in vertical mode the flip must depend on `groupRowGrowth` alone — matching the live snippet (which flips purely on `groupRowGrowth == "END"`).

Horizontal-mode behavior is unchanged.

## Test plan

- [ ] Test mode, group layout, **vertical** (Arrange Groups In: Rows), **Players Grow From: End** — groups stay inside the anchor box (no overflow below).
- [ ] Same config, multiple group columns (lower Groups Per Column) — toggling Columns Grow From Left/Right matches live and is not inverted.
- [ ] Regression: horizontal layout (Arrange Groups In: Columns) + grow-from-end + Rows Grow From Top/Bottom unchanged.