### PR TITLE
Missing Buff: don't flag uncastable cross-faction targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * (Test Mode) The separate **Status / Ready** and **Role / Leader** preview toggles are now a single **Icons** toggle, matching the live status-icon grouping. (by Krathe)
 * (Auto Layouts) The **override tooltip and `/df overrides` now read clearly** — each changed setting shows as a breadcrumb path with its value, only values that differ from global are listed, Text Designer elements show their names, and the override counts agree across the badge, status line and chat. (by Krathe)
 * (Aura Designer) Expiring health-bar highlights now **pulse in unison** across all frames — and tint and replace modes share one pulse engine — instead of each frame pulsing on its own timing. (by Krathe)
+* (Missing Buff) The missing-buff icon no longer flags a **cross-faction group member in the open world** as needing a buff you can't actually cast on them — it only appears where the buff is castable (e.g. inside instances). (by Krathe)
 
 ### Bug Fixes
 

--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -809,7 +809,19 @@ function DF:UpdateMissingBuffIcon(frame, forceUpdate)
         missingBuffCache[frame] = nil
         return
     end
-    
+
+    -- Hide when we can't actually cast a beneficial spell on them — e.g. a
+    -- cross-faction group member in the open world, where a "buff missing"
+    -- icon is just noise because the buff is uncastable. UnitCanAssist flips
+    -- to true inside instances where buffing them IS possible, so the icon
+    -- only shows when it's actionable (mirrors Range.lua's cross-faction
+    -- handling; the reaction funcs return clean, non-secret booleans).
+    if not UnitCanAssist("player", unit) then
+        frame.missingBuffFrame:Hide()
+        missingBuffCache[frame] = nil
+        return
+    end
+
     -- Check for missing buffs
     local missingSpellID = nil
     local missingIcon = nil


### PR DESCRIPTION
Small, self-contained tweak to the Missing Buff icon.

**Problem:** With cross-faction grouping, an opposite-faction party/raid member shows a "buff missing" icon in the open world even though the buff can't be cast on them there — noise that never clears.

**Fix:** Gate the icon on `UnitCanAssist("player", unit)`. When a helpful action isn't possible (open-world cross-faction) the icon stays hidden; it reappears where the buff *is* castable, e.g. inside instances. This mirrors the existing cross-faction handling in `Range.lua`, and `UnitCanAssist` returns a clean (non-secret) boolean.

The guard sits alongside the existing dead/offline/out-of-range/non-player bails in `UpdateMissingBuffIcon`, so same-faction members are completely unaffected.

Branches off `main` — independent, touches only `UpdateMissingBuffIcon`.
