### PR TITLE
Aura Designer: fade border-effect indicator out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * (Targeted Spells) The targeted list no longer appears in **test mode** when the feature is disabled. (by Krathe)
 * (Aura Designer) The replace-mode health-bar highlight no longer **flickers** on phased or out-of-range units. (by Krathe)
 * (Aura Designer) The replace-mode health-bar highlight no longer **bleeds over the frame border** when a unit is out of range. (by Krathe)
+* (Aura Designer) The border-effect indicator (colour **and** animation) now **fades out of range** like the other indicators, instead of staying at full brightness. (by Krathe)
 * (AFK Timer) The elapsed-time countdown no longer **shifts left/right** as it ticks. (by Krathe)
 * (Test Mode) Replaced several test-mode buff/debuff preview icons that pointed at art removed in Midnight, so they no longer render blank. (by Krathe)
 * (Text Designer) Text element edits now update **test-mode frames** live, not just real units. (by Krathe)

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -111,6 +111,28 @@ local function ApplyOORAlpha(element, inRange, inAlpha, oorAlpha)
     end
 end
 
+-- Out-of-range fade for an AD border-type widget (the whole-frame border
+-- indicator + per-aura custom borders). These hang off the FRAME, not a faded
+-- element, so element-specific OOR mode has to dim them explicitly. Fading the
+-- widget cascades to its edges, overlay effects and LCG glows (all children).
+-- dfRangeAlpha is the numeric factor DF_PULSATE's per-frame tick multiplies into
+-- its own SetAlpha; a secret inRange can't yield a numeric factor, so it's left
+-- at 1 (SetAlphaFromBoolean still fades every non-DF_PULSATE effect).
+local function FadeADBorderWidget(b, inRange, oorAlpha, secretRange)
+    if not b then return end
+    b.dfRangeAlpha = secretRange and 1 or (inRange and 1.0 or oorAlpha)
+    ApplyOORAlpha(b, inRange, 1.0, oorAlpha)
+end
+
+-- Frame-level mode: the frame cascade does the fade, so the widget stays at full
+-- alpha and dfRangeAlpha resets to 1 (so a DF_PULSATE pulse isn't double-dimmed
+-- after toggling out of element-specific OOR mode).
+local function ResetADBorderWidget(b)
+    if not b then return end
+    b.dfRangeAlpha = 1
+    b:SetAlpha(1.0)
+end
+
 -- Check if unit is dead or offline
 local function IsDeadOrOffline(frame)
     local unit = frame.unit
@@ -1179,6 +1201,16 @@ function DF:UpdateAuraDesignerAppearance(frame)
                 end
             end
         end
+        -- Border-type indicator(s) — the whole-frame AD border and any per-aura
+        -- custom borders hang off the FRAME, not a faded element, so they need
+        -- explicit dimming here (see FadeADBorderWidget).
+        local secretRange = issecretvalue and issecretvalue(inRange)
+        FadeADBorderWidget(frame.dfAD_border, inRange, oorAlpha, secretRange)
+        if frame.dfAD_customBorders then
+            for _, b in pairs(frame.dfAD_customBorders) do
+                FadeADBorderWidget(b, inRange, oorAlpha, secretRange)
+            end
+        end
         -- AD health bar OOR fade. Compute the OOR-aware effective blend once, then
         -- apply it to whichever layer the active mode uses:
         --   replace → the real health bar texture's FRAME alpha (single layer)
@@ -1248,6 +1280,12 @@ function DF:UpdateAuraDesignerAppearance(frame)
             for _, bar in pairs(frame.dfAD_bars) do
                 if bar then bar:SetAlpha(bar.dfBaseAlpha or 1.0) end
             end
+        end
+        -- Border-type indicator(s): frame-level mode fades via the frame cascade,
+        -- so reset the widget to full alpha (see ResetADBorderWidget).
+        ResetADBorderWidget(frame.dfAD_border)
+        if frame.dfAD_customBorders then
+            for _, b in pairs(frame.dfAD_customBorders) do ResetADBorderWidget(b) end
         end
         -- AD health bar: frame-level mode — the frame cascade handles OOR alpha, so
         -- the effective blend is always the configured blend. Apply to whichever

--- a/Frames/Border.lua
+++ b/Frames/Border.lua
@@ -1105,7 +1105,12 @@ function Border:StartAnimation(border, spec)
             border._dfPulsatePhase = ph
             local wave = (1 - math.cos(ph * 2 * math.pi)) * 0.5
             -- Fade between 0.05 (dim trough) and 1.0 (full) — a gentle pulse.
-            border:SetAlpha(0.05 + 0.95 * wave)
+            -- DF_PULSATE is the one effect that drives the widget's OWN alpha each
+            -- frame, so it would clobber the range system's out-of-range fade
+            -- (which dims the widget via SetAlpha). Multiply by dfRangeAlpha (set
+            -- by the OOR appearance pass; defaults to 1 when in range / unset) so
+            -- the pulse rides on top of the OOR dim instead of overwriting it.
+            border:SetAlpha((0.05 + 0.95 * wave) * (border.dfRangeAlpha or 1))
         end)
         border.activeAnimation = anim.type
         return


### PR DESCRIPTION
**Bug:** In element-specific out-of-range mode, the Aura Designer's border-effect indicator (both its colour and any animation) stayed at full brightness when a unit went out of range, while every other indicator faded.

**Cause:** That mode pins the frame's own alpha at 1.0 and dims each element individually. The fade pass looped the AD icons/squares/bars, but the border-type indicator (and per-aura custom borders) hang off the *frame* itself rather than a faded element, so nothing dimmed them. (Frame-level OOR mode was unaffected — the frame cascade covered it.)

**Fix:** Fade the border widget directly in the OOR pass — its edges, overlay effects (Wipe/Ripple/etc.) and LCG glows all inherit the widget alpha. `DF_PULSATE` drives the widget alpha itself each frame, so its tick now multiplies by a stored range factor so the pulse rides on top of the OOR dim instead of overwriting it.

Branches off `main` — independent, no dependency on #130.
