### PR TITLE
Aura Designer: add Tint Entire Bar option to health-bar tint mode

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1287,6 +1287,11 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
     -- Store on state so UpdateAuraDesignerAppearance / UpdateHealthBarAppearance
     -- can access these for OOR handling and the replace/tint mode gate.
     state.healthbarMode     = mode
+    -- Tint mode only: when set, the tint overlay covers the WHOLE bar (including
+    -- the missing-health portion) instead of tracking current health. Read by
+    -- UpdateADTintHealth. Meaningless in replace mode (the real bar IS the
+    -- indicator, so tinting "missing health" would just hide health loss).
+    state.healthbarTintWholeBar = (mode == "tint") and (config.tintWholeBar and true or false) or false
     state.healthbarR        = r
     state.healthbarG        = g
     state.healthbarB        = b
@@ -1534,6 +1539,7 @@ function Indicators:RevertHealthBar(frame)
     -- Clear tracked color and blend so stale values don't affect the next
     -- aura that claims this frame's health bar indicator.
     state.healthbarMode          = nil
+    state.healthbarTintWholeBar  = nil
     state.healthbarCurrentR      = nil
     state.healthbarCurrentG      = nil
     state.healthbarCurrentB      = nil
@@ -1560,6 +1566,15 @@ function DF:UpdateADTintHealth(frame, skipSmooth)
     -- Allow being called before Show() (skipSmooth path from ApplyHealthBar)
     if not overlay then return end
     if not skipSmooth and not overlay:IsShown() then return end
+
+    -- Whole-bar tint: fill the overlay completely so the tint covers the missing-
+    -- health portion too, rather than tracking current health. Orientation is
+    -- irrelevant at 100% fill, and we don't need the unit's health, so return early.
+    if frame.dfAD.healthbarTintWholeBar then
+        overlay:SetMinMaxValues(0, 1)
+        overlay:SetValue(1)
+        return
+    end
 
     local unit = frame.unit
     if not unit or not UnitExists(unit) then return end

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -678,6 +678,7 @@ local function EnsureTypeConfig(auraName, typeKey)
         elseif typeKey == "healthbar" then
             auraCfg[typeKey] = {
                 mode = "Replace", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
+                tintWholeBar = false,
                 expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
                 expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
                 expiringPulsate = false,
@@ -1023,6 +1024,7 @@ local TYPE_DEFAULTS = {
     },
     healthbar = {
         mode = "Replace", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
+        tintWholeBar = false,
         expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
         expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
         expiringPulsate = false,
@@ -2474,6 +2476,11 @@ local function RefreshPreviewEffects()
     if auraCfg.healthbar and framePreview.healthFill then
         local clr = auraCfg.healthbar.color or {r = 1, g = 1, b = 1, a = 1}
         local blend = auraCfg.healthbar.blend or 0.5
+        -- Default the missing-health region back to plain dark; the tint branch
+        -- below overrides it when "Tint Entire Bar" is on.
+        if framePreview.missingHealth then
+            framePreview.missingHealth:SetColorTexture(0, 0, 0, 0.4)
+        end
         if auraCfg.healthbar.mode == "Replace" then
             framePreview.healthFill:SetVertexColor(clr.r, clr.g, clr.b, clr.a or 1)
         else
@@ -2485,6 +2492,11 @@ local function RefreshPreviewEffects()
             local g = 0.80 * (1 - effBlend) + clr.g * effBlend
             local b = 0.44 * (1 - effBlend) + clr.b * effBlend
             framePreview.healthFill:SetVertexColor(r, g, b, 1)
+            -- Tint Entire Bar: paint the same tint hue over the (dark) missing-
+            -- health region so the preview shows the colour spanning the full bar.
+            if auraCfg.healthbar.tintWholeBar and framePreview.missingHealth then
+                framePreview.missingHealth:SetColorTexture(clr.r * effBlend, clr.g * effBlend, clr.b * effBlend, 0.4 + 0.25 * effBlend)
+            end
         end
     end
 
@@ -3477,6 +3489,12 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
             -- :Hide() would be clobbered by LayoutChildren's unconditional :Show().
             blendSlider.hideOn = function() return (proxy.mode or "Replace") == "Replace" end
             g:AddWidget(blendSlider, 54)
+            -- Tint-mode only: tint the WHOLE bar (incl. missing health) instead of
+            -- just the current-health portion. Hidden in Replace mode (there the bar
+            -- IS the indicator, so this would hide health loss). Same hideOn as Blend.
+            local wholeBarCheck = GUI:CreateCheckbox(parent, L["Tint Entire Bar"], proxy, "tintWholeBar", RPL)
+            wholeBarCheck.hideOn = function() return (proxy.mode or "Replace") == "Replace" end
+            g:AddWidget(wholeBarCheck, 28)
             g:AddWidget(GUI:CreateCheckbox(parent, L["Show When Missing"], proxy, "showWhenMissing", function()
                 DF.AuraDesigner.Engine:ForceRefreshAllFrames()
             end), 28)
@@ -4317,6 +4335,9 @@ local function CreateFramePreview(parent, yOffset, rightPanelRef)
     end
     missingHealth:SetWidth(FRAME_W * 0.28)
     missingHealth:SetColorTexture(0, 0, 0, 0.4)
+    -- Exposed so the preview can tint the missing-health region when the
+    -- health-bar indicator is in Tint mode with "Tint Entire Bar" enabled.
+    container.missingHealth = missingHealth
 
     -- Power bar (only if enabled in settings)
     if showPower then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * (Test Mode) The separate **Status / Ready** and **Role / Leader** preview toggles are now a single **Icons** toggle, matching the live status-icon grouping. (by Krathe)
 * (Auto Layouts) The **override tooltip and `/df overrides` now read clearly** — each changed setting shows as a breadcrumb path with its value, only values that differ from global are listed, Text Designer elements show their names, and the override counts agree across the badge, status line and chat. (by Krathe)
 * (Aura Designer) Expiring health-bar highlights now **pulse in unison** across all frames — and tint and replace modes share one pulse engine — instead of each frame pulsing on its own timing. (by Krathe)
+* (Aura Designer) The health-bar indicator's **Tint** mode has a new **Tint Entire Bar** option — tint the whole bar including the missing-health portion, instead of only the filled part. (by Krathe)
 
 ### Bug Fixes
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1823,6 +1823,7 @@ L["Texture & Colors"] = true
 L["Threshold Mode"] = true
 L["Timing"] = true
 L["Tint"] = true
+L["Tint Entire Bar"] = true
 L["Track Highest Duration"] = true
 L["Track Lowest Duration"] = true
 L["Trigger Mode"] = true


### PR DESCRIPTION
Adds a small option to the Aura Designer **Health Bar** indicator.

In **Tint** mode the colour overlay tracks current health, so it only tints the *filled* portion of the bar. The new **Tint Entire Bar** checkbox fills the overlay across the whole bar — including the missing-health portion — so the tint colour spans the full bar.

It's an overlay-only effect, so the option is shown only in Tint mode (hidden in Replace, where tinting missing health would mask health loss). Default **off**, so existing setups are unchanged; no migration needed (absent key → previous behaviour). The in-GUI live preview tints the missing-health region too.

Branches off `main` — independent.
