### PR TITLE
Aura Designer: add Background Color effect

### DIFF
--- a/AuraDesigner/Engine.lua
+++ b/AuraDesigner/Engine.lua
@@ -112,6 +112,7 @@ local INDICATOR_TYPES = {
     { key = "bar",        placed = true  },
     { key = "border",     placed = false },
     { key = "healthbar",  placed = false },
+    { key = "background",  placed = false },
     { key = "nametext",   placed = false },
     { key = "healthtext", placed = false },
     { key = "framealpha", placed = false },

--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -667,6 +667,7 @@ function Indicators:BeginFrame(frame)
     local state = EnsureFrameState(frame)
     state.border = false
     state.healthbar = false
+    state.background = false
     state.nametext = false
     state.healthtext = false
     state.framealpha = false
@@ -743,6 +744,8 @@ function Indicators:Apply(frame, typeKey, config, auraData, defaults, auraName, 
         self:ApplyBorder(frame, config, auraData, auraName)
     elseif typeKey == "healthbar" then
         self:ApplyHealthBar(frame, config, auraData)
+    elseif typeKey == "background" then
+        self:ApplyBackground(frame, config, auraData)
     elseif typeKey == "nametext" then
         self:ApplyNameText(frame, config, auraData)
     elseif typeKey == "healthtext" then
@@ -801,6 +804,8 @@ function Indicators:ApplyTest(frame, typeKey, config, auraData, defaults, auraNa
         self:ApplyBorder(frame, config, auraData, auraName)
     elseif typeKey == "healthbar" then
         self:ApplyHealthBar(frame, config, auraData)
+    elseif typeKey == "background" then
+        self:ApplyBackground(frame, config, auraData)
     elseif typeKey == "nametext" then
         self:ApplyNameText(frame, config, auraData)
     elseif typeKey == "healthtext" then
@@ -849,6 +854,11 @@ function Indicators:EndFrame(frame)
         self:RevertHealthBar(frame)
     end
 
+    -- Revert background colour
+    if not state.background then
+        self:RevertBackground(frame)
+    end
+
     -- Revert name text color
     if not state.nametext then
         self:RevertNameText(frame)
@@ -883,6 +893,7 @@ function Indicators:HideAll(frame)
     self:RevertBorder(frame)
     self:RevertCustomBorders(frame)
     self:RevertHealthBar(frame)
+    self:RevertBackground(frame)
     self:RevertNameText(frame)
     self:RevertHealthText(frame)
     self:RevertFrameAlpha(frame)
@@ -1548,6 +1559,152 @@ function Indicators:RevertHealthBar(frame)
     if DF.UpdateHealthBarAppearance then
         DF:UpdateHealthBarAppearance(frame)
     end
+end
+
+-- ============================================================
+-- BACKGROUND COLOUR INDICATOR
+-- A solid colour overlay laid over the frame background, BELOW the health/
+-- missing bars, so the colour shows through wherever the background shows
+-- (the missing-health area + padding) and the health fill naturally covers it.
+-- Mirrors the health-bar TINT overlay: colour + blend ride SetStatusBarColor's
+-- alpha; OOR fade rides the same channel; the per-element AnimationGroup pulse
+-- (shared with icons/squares) rides the overlay's frame alpha — a separate
+-- channel, so the two multiply cleanly. No UpdateBackgroundAppearance yield is
+-- needed (this is an independent layer above the real background).
+-- ============================================================
+
+local function GetOrCreateADBgOverlay(frame)
+    local state = frame.dfAD
+    if state and state.bgOverlay then return state.bgOverlay end
+    if not frame.background then return nil end
+
+    -- Frame level == frame's own level: above the BACKGROUND-layer background
+    -- texture, below the +1 health/missing bars. SetValue(1) keeps it full.
+    local overlay = CreateFrame("StatusBar", nil, frame)
+    overlay:SetAllPoints(frame.background)
+    overlay:SetFrameLevel(frame:GetFrameLevel())
+    overlay:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
+    overlay:SetMinMaxValues(0, 1)
+    overlay:SetValue(1)
+    overlay:Hide()
+
+    if state then state.bgOverlay = overlay end
+    return overlay
+end
+
+function Indicators:ApplyBackground(frame, config, auraData)
+    local state = EnsureFrameState(frame)
+    if state.background then return end
+    state.background = true
+
+    if not frame.background then return end
+    local color = config.color
+    if not color then return end
+
+    local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
+    local a = color[4] or color.a or 1
+    local mode = string.lower(config.mode or "tint")
+    -- Replace: the colour-picker alpha IS the overlay opacity (covers the bg).
+    -- Tint:    overlay opacity = blend slider × colour alpha (bg shows through).
+    local blend = (mode == "replace") and a or ((config.blend or 0.5) * a)
+
+    state.bgMode         = mode
+    state.bgR, state.bgG, state.bgB = r, g, b
+    state.bgBlend        = blend
+    state.bgCurrentR, state.bgCurrentG, state.bgCurrentB = r, g, b
+    state.bgCurrentBlend = blend
+    state.bgOOR          = false
+    -- bgEffectiveBlend is NOT reset here so the OOR fade survives UNIT_AURA re-applies.
+
+    local overlay = GetOrCreateADBgOverlay(frame)
+    if not overlay then return end
+
+    -- Use OOR-aware blend if already established (preserves OOR fade on re-apply).
+    local initialBlend = state.bgEffectiveBlend or blend
+    overlay:SetStatusBarColor(r, g, b, initialBlend)
+    overlay:SetAlpha(1)
+    overlay:Show()
+
+    -- ===== Expiring + pulse =====
+    local expiringEnabled = config.expiringEnabled
+    if expiringEnabled == nil then expiringEnabled = false end
+    local expiringPulsate = config.expiringPulsate or false
+    overlay.dfAD_expiringPulsate = expiringPulsate
+    if expiringPulsate then
+        GetOrCreatePulseAnim(overlay)
+    elseif overlay.dfAD_pulse and overlay.dfAD_pulse:IsPlaying() then
+        overlay.dfAD_pulse:Stop()
+        overlay:SetAlpha(1)
+    end
+
+    if expiringEnabled then
+        local ec = config.expiringColor or {r = 1, g = 0.2, b = 0.2}
+        local oc = {r = r, g = g, b = b}
+        local ea = ec.a or ec[4] or 1
+        local expiringBlend = (mode == "replace") and ea or ((config.blend or 0.5) * ea)
+        RegisterExpiring(overlay, {
+            unit = frame.unit,
+            auraInstanceID = auraData and auraData.auraInstanceID,
+            threshold = config.expiringThreshold or 30,
+            duration = auraData and auraData.duration,
+            expirationTime = auraData and auraData.expirationTime,
+            blend = blend,
+            expiringBlend = expiringBlend,
+            colorCurve = BuildExpiringColorCurve(config.expiringThreshold or 30, ec, oc, config.expiringThresholdMode),
+            thresholdMode = config.expiringThresholdMode,
+            color = ec, originalColor = oc,
+            applyResult = function(el, result, entry)
+                local adState = frame.dfAD
+                local isExp = IsColorExpiring(result, entry.originalColor)
+                local curBlend = (isExp and entry.expiringBlend) or entry.blend
+                local effectiveBlend = (adState and adState.bgOOR
+                    and (adState.bgEffectiveBlend or curBlend)) or curBlend
+                if adState then
+                    adState.bgCurrentR, adState.bgCurrentG, adState.bgCurrentB = result.r, result.g, result.b
+                    adState.bgCurrentBlend = curBlend
+                end
+                el:SetStatusBarColor(result.r, result.g, result.b, effectiveBlend)
+                UpdatePulseState(el, isExp)
+            end,
+            applyManual = function(el, isExp, entry)
+                local c = isExp and entry.color or entry.originalColor
+                local cr, cg, cb = c.r or 1, c.g or 1, c.b or 1
+                local adState = frame.dfAD
+                local curBlend = (isExp and entry.expiringBlend) or entry.blend
+                local effectiveBlend = (adState and adState.bgOOR
+                    and (adState.bgEffectiveBlend or curBlend)) or curBlend
+                if adState then
+                    adState.bgCurrentR, adState.bgCurrentG, adState.bgCurrentB = cr, cg, cb
+                    adState.bgCurrentBlend = curBlend
+                end
+                el:SetStatusBarColor(cr, cg, cb, effectiveBlend)
+                UpdatePulseState(el, isExp)
+            end,
+        })
+    else
+        UnregisterExpiring(overlay)
+    end
+end
+
+function Indicators:RevertBackground(frame)
+    local state = frame and frame.dfAD
+    if not state then return end
+    if state.bgOverlay then
+        UnregisterExpiring(state.bgOverlay)
+        if state.bgOverlay.dfAD_pulse and state.bgOverlay.dfAD_pulse:IsPlaying() then
+            state.bgOverlay.dfAD_pulse:Stop()
+        end
+        state.bgOverlay:SetAlpha(1)
+        state.bgOverlay:Hide()
+        state.bgOverlay:SetStatusBarColor(1, 1, 1, 1)
+    end
+    state.bgMode          = nil
+    state.bgCurrentR      = nil
+    state.bgCurrentG      = nil
+    state.bgCurrentB      = nil
+    state.bgCurrentBlend  = nil
+    state.bgOOR           = nil
+    state.bgEffectiveBlend = nil
 end
 
 -- Update tint overlay fill to match current health.

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -42,6 +42,7 @@ local INDICATOR_TYPES = {
     { key = "bar",        label = L["Bar"],              placed = true  },
     { key = "border",     label = L["Border"],           placed = false },
     { key = "healthbar",  label = L["Health Bar Color"], placed = false },
+    { key = "background", label = L["Background Color"],  placed = false },
     { key = "nametext",   label = L["Name Text Color"],  placed = false },
     { key = "healthtext", label = L["Health Text Color"], placed = false },
     { key = "framealpha", label = L["Frame Alpha"],      placed = false },
@@ -683,6 +684,14 @@ local function EnsureTypeConfig(auraName, typeKey)
                 expiringPulsate = false,
                 showWhenMissing = false,
             }
+        elseif typeKey == "background" then
+            auraCfg[typeKey] = {
+                mode = "Tint", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
+                expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+                expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
+                expiringPulsate = false,
+                showWhenMissing = false,
+            }
         elseif typeKey == "nametext" then
             auraCfg[typeKey] = {
                 color = {r = 1, g = 1, b = 1, a = 1},
@@ -1023,6 +1032,13 @@ local TYPE_DEFAULTS = {
     },
     healthbar = {
         mode = "Replace", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
+        expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
+        expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
+        expiringPulsate = false,
+        showWhenMissing = false,
+    },
+    background = {
+        mode = "Tint", color = {r = 1, g = 1, b = 1, a = 1}, blend = 0.5,
         expiringEnabled = false, expiringThreshold = 30, expiringThresholdMode = "PERCENT",
         expiringColor = {r = 1, g = 0.2, b = 0.2, a = 1},
         expiringPulsate = false,
@@ -1749,11 +1765,12 @@ local effectCardPool = {}   -- Reusable card frames
 -- the new Effects tab. Replaces the old per-aura view.
 -- ============================================================
 
-local FRAME_LEVEL_TYPE_KEYS = { "border", "healthbar", "nametext", "healthtext", "framealpha", "sound" }
+local FRAME_LEVEL_TYPE_KEYS = { "border", "healthbar", "background", "nametext", "healthtext", "framealpha", "sound" }
 
 local FRAME_LEVEL_LABELS = {
     border     = L["Border"],
     healthbar  = L["Health Bar"],
+    background  = L["Background"],
     nametext   = L["Name Text"],
     healthtext = L["Health Text"],
     framealpha = L["Frame Alpha"],
@@ -1772,6 +1789,7 @@ local BADGE_COLORS = {
     bar        = { r = 0.94, g = 0.71, b = 0.24 },  -- Orange
     border     = { r = 0.80, g = 0.50, b = 0.80 },  -- Purple
     healthbar  = { r = 0.94, g = 0.31, b = 0.31 },  -- Red
+    background = { r = 0.40, g = 0.55, b = 0.65 },  -- Slate
     nametext   = { r = 0.72, g = 0.72, b = 0.94 },  -- Light blue
     healthtext = { r = 0.72, g = 0.72, b = 0.94 },  -- Light blue
     framealpha = { r = 0.60, g = 0.60, b = 0.60 },  -- Grey
@@ -2486,6 +2504,22 @@ local function RefreshPreviewEffects()
             local b = 0.44 * (1 - effBlend) + clr.b * effBlend
             framePreview.healthFill:SetVertexColor(r, g, b, 1)
         end
+    end
+
+    -- Background color (recolours the frame background — shows through the
+    -- missing-health area, like the runtime overlay that sits behind the bars).
+    if auraCfg.background and framePreview.healthBg then
+        local clr = auraCfg.background.color or {r = 1, g = 1, b = 1, a = 1}
+        if auraCfg.background.mode == "Replace" then
+            local a = clr.a or 1
+            framePreview.healthBg:SetColorTexture(clr.r, clr.g, clr.b, 0.4 + 0.6 * a)
+        else
+            local blend = (auraCfg.background.blend or 0.5) * (clr.a or 1)
+            -- Blend the configured colour over the dark default background.
+            framePreview.healthBg:SetColorTexture(clr.r * blend, clr.g * blend, clr.b * blend, 0.4 + 0.4 * blend)
+        end
+    elseif framePreview.healthBg then
+        framePreview.healthBg:SetColorTexture(0, 0, 0, 0.4)
     end
 
     -- Name text color
@@ -3491,6 +3525,32 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
             g:AddWidget(GUI:CreateCheckbox(parent, L["Pulsate"], proxy, "expiringPulsate"), 24)
         end)
 
+    elseif typeKey == "background" then
+        -- Appearance — mirrors Health Bar Color. A colour overlay over the frame
+        -- background (visible in the missing-health area). Replace = opaque cover;
+        -- Tint = blend × colour alpha so the normal background shows through.
+        AddGroup(L["Appearance"], function(g)
+            g:AddWidget(GUI:CreateDropdown(parent, L["Mode"], HEALTHBAR_MODE_OPTIONS, proxy, "mode", function()
+                DF:AuraDesigner_RefreshPage()
+            end), 54)
+            g:AddWidget(GUI:CreateColorPicker(parent, L["Color"], proxy, "color", true, RPL, RPL, true), 28)
+            local blendSlider = GUI:CreateSlider(parent, L["Blend %"], 0, 1, 0.05, proxy, "blend")
+            blendSlider.hideOn = function() return (proxy.mode or "Tint") == "Replace" end
+            g:AddWidget(blendSlider, 54)
+            g:AddWidget(GUI:CreateCheckbox(parent, L["Show When Missing"], proxy, "showWhenMissing", function()
+                DF.AuraDesigner.Engine:ForceRefreshAllFrames()
+            end), 28)
+        end)
+        -- Expiring
+        AddGroup(L["Expiring"], function(g)
+            g:AddWidget(GUI:CreateCheckbox(parent, L["Expiring Color Override"], proxy, "expiringEnabled"), 28)
+            g:AddWidget(CreateExpiringThresholdRow(parent, proxy, contentWidth - 10), 54)
+            do local dpRow, dpH = CreateExpiringDurationPriorityRow(parent, auraName, typeKey, contentWidth - 10)
+            if dpRow then g:AddWidget(dpRow, dpH) end end
+            g:AddWidget(GUI:CreateColorPicker(parent, L["Expiring Color"], proxy, "expiringColor", true, RPL, RPL, true), 28)
+            g:AddWidget(GUI:CreateCheckbox(parent, L["Pulsate"], proxy, "expiringPulsate"), 24)
+        end)
+
     elseif typeKey == "nametext" then
         -- Appearance
         AddGroup(L["Appearance"], function(g)
@@ -4293,6 +4353,9 @@ local function CreateFramePreview(parent, yOffset, rightPanelRef)
         healthBg:SetPoint("BOTTOMRIGHT", mockFrame, "BOTTOMRIGHT", -1, 1)
     end
     healthBg:SetColorTexture(0, 0, 0, 0.4)
+    -- Exposed so the preview can tint the background when an AD Background Color
+    -- effect is configured.
+    container.healthBg = healthBg
 
     -- Health bar fill (72% health)
     local healthFill = mockFrame:CreateTexture(nil, "ARTWORK")
@@ -5445,9 +5508,12 @@ CreateEffectCard = function(parent, yPos, effect)
             -- multiple auras set the same frame effect, e.g. two health bar colors)
             local auraProxy = CreateAuraProxy(effect.auraName)
             local priSlider = GUI:CreateSlider(body, L["Priority"], 1, 10, 1, auraProxy, "priority")
-            priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 5, -(triggersH + 4))
+            -- Extra gap above (was +4) so the slider isn't squished against the
+            -- triggers / Add Trigger row, plus a little breathing room below before
+            -- the effect's Appearance group (increment 54 → 68).
+            priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 5, -(triggersH + 14))
             priSlider:SetWidth(bodyWidth - 10)
-            triggersH = triggersH + 54
+            triggersH = triggersH + 68
         end
 
         local _, bodyH = BuildTypeContent(body, effect.typeKey, effect.auraName, bodyWidth, proxy, triggersH, indicatorGroup, effect.indicatorID)
@@ -5544,6 +5610,7 @@ BuildEffectsTab = function()
     local FRAME_ITEMS = {
         { label = L["Border"],            type = "border"     },
         { label = L["Health Bar Color"],  type = "healthbar"  },
+        { label = L["Background Color"],  type = "background" },
         { label = L["Name Text Color"],   type = "nametext"   },
         { label = L["Health Text Color"], type = "healthtext" },
         { label = L["Frame Alpha"],       type = "framealpha" },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * (Fonts) Bundled **Roboto Mono** (SemiBold/Bold) — a monospaced option for perfectly static countdown text. (by Krathe)
 * (Icons) New **in-combat indicator** — a small crossed-swords icon lights up when a unit is in combat, so you can spot who's engaged at a glance. Off by default, with its own position and size controls. (by Krathe)
 * (Auto Layouts) Added `/df clearoverride <key|prefix|all>` to **remove a stuck per-layout override** directly — for overrides the settings UI can't reach (e.g. a pinned-players override while not in a raid). (by Krathe)
+* (Aura Designer) New **Background Color** effect — colour a frame's background when an aura is active (Replace or Tint), with the same Expiring colour override, Pulsate and out-of-range handling as the other effects. (by Krathe)
 
 ### Improvements
 
@@ -28,6 +29,7 @@
 * (Test Mode) The separate **Status / Ready** and **Role / Leader** preview toggles are now a single **Icons** toggle, matching the live status-icon grouping. (by Krathe)
 * (Auto Layouts) The **override tooltip and `/df overrides` now read clearly** — each changed setting shows as a breadcrumb path with its value, only values that differ from global are listed, Text Designer elements show their names, and the override counts agree across the badge, status line and chat. (by Krathe)
 * (Aura Designer) Expiring health-bar highlights now **pulse in unison** across all frames — and tint and replace modes share one pulse engine — instead of each frame pulsing on its own timing. (by Krathe)
+* (Aura Designer) Added breathing room between an effect's **trigger list and its Priority slider** so the frame-level effect panels no longer look cramped. (by Krathe)
 
 ### Bug Fixes
 

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -1232,6 +1232,28 @@ function DF:UpdateAuraDesignerAppearance(frame)
                 end
             end
         end
+
+        -- AD background colour overlay OOR fade. Mirrors the tint overlay: OOR
+        -- rides the colour alpha (SetStatusBarColor); the per-element pulse owns
+        -- the overlay's frame alpha on a separate channel, so the two multiply.
+        if adState and adState.background and adState.bgOverlay then
+            local br = adState.bgCurrentR or adState.bgR or 1
+            local bgc = adState.bgCurrentG or adState.bgG or 1
+            local bb = adState.bgCurrentB or adState.bgB or 1
+            local bBlend = adState.bgCurrentBlend or adState.bgBlend or 0.5
+            local bEff
+            if issecretvalue and issecretvalue(inRange) then
+                bEff = bBlend
+            elseif inRange then
+                bEff = bBlend
+                adState.bgOOR = false
+            else
+                bEff = oorAlpha
+                adState.bgOOR = true
+            end
+            adState.bgEffectiveBlend = bEff
+            adState.bgOverlay:SetStatusBarColor(br, bgc, bb, bEff)
+        end
     else
         -- Frame-level mode: restore each indicator's base alpha
         if frame.dfAD_icons then
@@ -1274,6 +1296,19 @@ function DF:UpdateAuraDesignerAppearance(frame)
                     if not adState.healthbarPulseOn then tintOverlay:SetAlpha(1.0) end
                 end
             end
+        end
+
+        -- AD background overlay: frame-level mode fades via the frame cascade
+        -- (the overlay is a child of the frame), so just keep the colour alpha at
+        -- the base blend rather than a stale OOR value.
+        if adState and adState.background and adState.bgOverlay then
+            local br = adState.bgCurrentR or adState.bgR or 1
+            local bgc = adState.bgCurrentG or adState.bgG or 1
+            local bb = adState.bgCurrentB or adState.bgB or 1
+            local bBlend = adState.bgCurrentBlend or adState.bgBlend or 0.5
+            adState.bgOOR = false
+            adState.bgEffectiveBlend = bBlend
+            adState.bgOverlay:SetStatusBarColor(br, bgc, bb, bBlend)
         end
     end
 end


### PR DESCRIPTION
Adds a new frame-level **Background Color** effect to the Aura Designer — colour a frame's background while an aura is active.

A solid overlay sits above the frame background and below the health/missing bars, so the colour shows through the missing-health area and is naturally covered by the health fill. Full parity with the **Health Bar Color** effect: **Replace / Tint** modes, **Expiring** colour override, **Pulsate**, and **out-of-range** fade, plus a live preview. Default off; no migration needed (absent config → effect simply off).

Also includes a small UI polish: a bit more spacing between a frame-level effect's **trigger list and its Priority slider**, which were cramped across all frame-level effect panels.

Branches off `main` — independent.
