### PR TITLE
Aura Designer: default new icon/square border inset to 0

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -2101,7 +2101,7 @@ function Indicators:ConfigureIcon(frame, config, defaults, auraName, priority)
     if borderEnabled == nil then borderEnabled = config.borderEnabled end
     if borderEnabled == nil then borderEnabled = true end
     local borderThickness = config.BorderSize  or config.borderThickness or 1
-    local borderInset     = config.BorderInset or config.borderInset     or 1
+    local borderInset     = config.BorderInset or config.borderInset     or 0
 
     local adBorder = GetOrCreateADIconBorder(icon)
     -- Border geometry: BorderSize is the band THICKNESS on its own — Inset no
@@ -2914,7 +2914,7 @@ function Indicators:ConfigureSquare(frame, config, defaults, auraName, priority)
     if borderEnabled == nil then borderEnabled = config.showBorder end
     if borderEnabled == nil then borderEnabled = true end
     local borderThickness = config.BorderSize  or config.borderThickness or 1
-    local borderInset     = config.BorderInset or config.borderInset     or 1
+    local borderInset     = config.BorderInset or config.borderInset     or 0
 
     local adBorder = GetOrCreateADSquareBorder(sq)
     adBorder.dfADIconSize  = borderThickness

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -585,7 +585,7 @@ local function EnsureTypeConfig(auraName, typeKey)
                 -- aura's icon sub-config; everything else (style, colour,
                 -- gradient, shadow, offset, blend) reads from TYPE_DEFAULTS
                 -- via proxy fall-through until the user overrides it.
-                ShowBorder = true, BorderSize = 1, BorderInset = 1,
+                ShowBorder = true, BorderSize = 1, BorderInset = 0,
                 hideSwipe = false,
                 -- Duration text
                 showDuration = gd.showDuration ~= false,
@@ -614,7 +614,7 @@ local function EnsureTypeConfig(auraName, typeKey)
                 size = gd.iconSize or 24, scale = gd.iconScale or 1.0, alpha = 1.0,
                 color = {r = 1, g = 1, b = 1, a = 1},
                 -- Border (canonical keys, Stage 5.2; legacy migrated on load)
-                ShowBorder = true, BorderSize = 1, BorderInset = 1,
+                ShowBorder = true, BorderSize = 1, BorderInset = 0,
                 hideSwipe = false,
                 -- Duration text
                 showDuration = gd.showDuration ~= false,
@@ -748,7 +748,7 @@ local TYPE_DEFAULTS = {
         -- see no visual change.  Style / Gradient* / Shadow* defaults seed
         -- CreateBorderControls' dropdowns and pickers so they read sensible
         -- values on first open.
-        ShowBorder = true, BorderSize = 1, BorderInset = 1,
+        ShowBorder = true, BorderSize = 1, BorderInset = 0,
         BorderColor             = {r = 0, g = 0, b = 0, a = 0.8},
         BorderStyle             = "SOLID",
         BorderBlendMode         = "BLEND",
@@ -853,7 +853,7 @@ local TYPE_DEFAULTS = {
         -- defaults to opaque black, matching the square's pre-migration
         -- hardcoded border so existing users see no change.  The rest seed
         -- CreateBorderControls' dropdowns / pickers on first open.
-        ShowBorder = true, BorderSize = 1, BorderInset = 1,
+        ShowBorder = true, BorderSize = 1, BorderInset = 0,
         BorderColor             = {r = 0, g = 0, b = 0, a = 1},
         BorderStyle             = "SOLID",
         BorderBlendMode         = "BLEND",


### PR DESCRIPTION
## Problem

New Aura Designer **icon** and **square** indicators defaulted their **Border Inset** to 1, so a freshly added indicator — and the reset-to-default button — sat 1px inset instead of flush against the icon edge. This was inconsistent with the **bar** and **border** indicator types, and with every main-frame border, which all default to 0.

## Fix

Set the icon and square inset default to 0 across the three places that have to agree, or the editor and the rendered result disagree:

- `TYPE_DEFAULTS` — drives the editor slider and reset-to-default
- the `EnsureTypeConfig` seed — the older per-type sub-config shape
- the render fallback in `Indicators.lua` (`config.BorderInset or … or 1` → `0`)

Border Offset X/Y were already 0. Existing indicators that stored an explicit inset are unaffected — only ones relying on the default shift 1 → 0 (a 1px change, and only where the inset was never customised).