### PR TITLE
Auto layouts: clean up orphaned legacy text overrides after Text Designer migration

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -4999,6 +4999,12 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 DF:MigrateTextDesignerFromLegacy()
             end
 
+            -- Strip orphaned legacy text overrides from raid auto-layouts now that
+            -- TD owns the built-in text (gated on migratedFromLegacy inside).
+            if DF.CleanupLegacyTextLayoutOverrides then
+                DF:CleanupLegacyTextLayoutOverrides()
+            end
+
             -- CRITICAL: Update power bars now that unit data is available
             -- At ADDON_LOADED, UnitPower() etc may return 0 before player is loaded
             -- Power bar updates don't require combat protection

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -130,7 +130,11 @@ local OVERRIDE_TAB_MAP = {
     {"debuffDisableMouse",  "general_integrations", L["Integrations"]},
     {"defensiveIconDisableMouse", "general_integrations", L["Integrations"]},
     {"targetedSpellDisableMouse", "general_integrations", L["Integrations"]},
-    -- Bars (specific text keys before generic "health" prefix)
+    -- Bars (specific text keys before generic "health" prefix).
+    -- healthTexture MUST precede healthText: it's the health BAR texture, but
+    -- a bare prefix match classifies it as health TEXT (and the legacy-text
+    -- cleanup would then delete a live override).
+    {"healthTexture",       "bars_health",          L["Health Bar"]},
     {"healthText",          "text_health",          L["Health Text"]},
     {"healthFont",          "text_health",          L["Health Text"]},
     {"health",              "bars_health",          L["Health Bar"]},
@@ -203,7 +207,38 @@ end
 -- (TD ignores these keys); it only declutters. Auto-layouts are raid-only, so we
 -- gate on the raid text config. Per-profile guard, idempotent.
 -- ============================================================
-local LEGACY_TEXT_TABS = { text_name = true, text_health = true, text_status = true }
+-- The DESTRUCTIVE strip decision uses its own boundary-checked matcher, NOT
+-- the display-oriented GetOverrideTabId prefix map: a bare prefix grab
+-- classifies healthTexture (the health BAR texture) as healthText — deleting a
+-- real, live override. A prefix only counts as a legacy text key when the key
+-- continues with an uppercase letter or digit (camelCase boundary) or ends
+-- exactly there; two legacy oddballs that don't share the prefixes are listed
+-- explicitly.
+local LEGACY_TEXT_KEY_PREFIXES = {
+    "nameText", "nameFont",
+    "healthText", "healthFont",
+    "statusText",
+}
+local LEGACY_TEXT_EXACT_KEYS = {
+    showHealthText = true,
+    nameColorClass = true,
+}
+local function IsLegacyTextOverrideKey(key)
+    if type(key) ~= "string" then return false end
+    -- Strip table-based suffix ("foo_3" → "foo"), mirroring GetOverrideTabId.
+    local baseKey = key:match("^(.+)_%d+$") or key
+    if LEGACY_TEXT_EXACT_KEYS[baseKey] then return true end
+    for _, prefix in ipairs(LEGACY_TEXT_KEY_PREFIXES) do
+        local n = #prefix
+        if baseKey:sub(1, n) == prefix then
+            local nextChar = baseKey:sub(n + 1, n + 1)
+            if nextChar == "" or nextChar:match("^[%u%d]") then
+                return true
+            end
+        end
+    end
+    return false
+end
 
 local function RaidTextMigrated()
     -- The TD legacy migration flags migratedFromLegacy on whatever owns raid text.
@@ -238,8 +273,7 @@ function DF:CleanupLegacyTextLayoutOverrides()
         if type(ov) ~= "table" then return end
         local toStrip
         for key in pairs(ov) do
-            local tabId = GetOverrideTabId(key)
-            if tabId and LEGACY_TEXT_TABS[tabId] then
+            if IsLegacyTextOverrideKey(key) then
                 toStrip = toStrip or {}
                 toStrip[#toStrip + 1] = key
             end

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -189,6 +189,75 @@ local function GetOverrideTabId(key)
     return nil, "Unknown"
 end
 
+-- ============================================================
+-- Cleanup: orphaned legacy built-in text overrides in auto-layouts
+-- The Text Designer migration took over the built-in Name / Health / Status
+-- text. A raid auto-layout edited BEFORE that migration can still carry those
+-- legacy text keys (nameFontSize, healthFontSize, statusText*, …) as overrides —
+-- now inert (IsLegacyTextHidden hides the legacy FontStrings), so they only
+-- clutter the override list beside the layout's textDesignerPreset. Strip them.
+--
+-- SAFETY: only runs once the raid TD has ACTUALLY migrated the legacy settings
+-- (migratedFromLegacy) — the values are preserved in Text Designer first, and we
+-- never strip while the legacy text is still live. Stripping is visually inert
+-- (TD ignores these keys); it only declutters. Auto-layouts are raid-only, so we
+-- gate on the raid text config. Per-profile guard, idempotent.
+-- ============================================================
+local LEGACY_TEXT_TABS = { text_name = true, text_health = true, text_status = true }
+
+local function RaidTextMigrated()
+    -- The TD legacy migration flags migratedFromLegacy on whatever owns raid text.
+    -- Preset build: the current raid preset, OR the canonical "Raid" preset the
+    -- migration always materialises (covers a raid mode repointed elsewhere).
+    -- Pre-preset build (alpha.6): inline db.raid.textDesigner.
+    if DF.GetTextDesignerPresets then
+        if DF.GetModeTextDesigner then
+            local td = DF:GetModeTextDesigner("raid")
+            if type(td) == "table" and td.migratedFromLegacy == true then return true end
+        end
+        local lib = DF:GetTextDesignerPresets()
+        local raidPreset = lib and lib["Raid"]
+        return type(raidPreset) == "table" and raidPreset.migratedFromLegacy == true
+    end
+    local rdb = DF.GetRaidDB and DF:GetRaidDB()
+    local td = rdb and rdb.textDesigner
+    return type(td) == "table" and td.migratedFromLegacy == true
+end
+
+function DF:CleanupLegacyTextLayoutOverrides()
+    local prof = DF._realProfile or DF.db
+    if not prof or prof._legacyTextOverrideCleanupV1 then return end
+    local autoDb = prof.raidAutoProfiles
+    if type(autoDb) ~= "table" then return end
+    -- Don't strip — or set the guard — until the legacy text is safely in TD; an
+    -- unmigrated profile is retried on its next login / profile switch.
+    if not RaidTextMigrated() then return end
+
+    local function stripLayout(layout)
+        local ov = layout and layout.overrides
+        if type(ov) ~= "table" then return end
+        local toStrip
+        for key in pairs(ov) do
+            local tabId = GetOverrideTabId(key)
+            if tabId and LEGACY_TEXT_TABS[tabId] then
+                toStrip = toStrip or {}
+                toStrip[#toStrip + 1] = key
+            end
+        end
+        if toStrip then for _, key in ipairs(toStrip) do ov[key] = nil end end
+    end
+
+    for _, ctKey in ipairs({ "instanced", "openWorld" }) do
+        local ct = autoDb[ctKey]
+        if type(ct) == "table" and type(ct.profiles) == "table" then
+            for _, layout in pairs(ct.profiles) do stripLayout(layout) end
+        end
+    end
+    if type(autoDb.mythic) == "table" then stripLayout(autoDb.mythic.profile) end
+
+    prof._legacyTextOverrideCleanupV1 = true
+end
+
 -- Groups override keys by tab, returns { [tabId] = { tabLabel, keys = {} } }, unknownKeys
 local function GroupOverridesByTab(overrides)
     -- A table-valued override (e.g. "raidGroupVisible") and its flat indexed

--- a/Profile.lua
+++ b/Profile.lua
@@ -286,6 +286,12 @@ function DF:SetProfile(name)
         DF:MigrateTextDesignerFromLegacy()
     end
 
+    -- Strip orphaned legacy text overrides from raid auto-layouts now that TD
+    -- owns the built-in text (gated on migratedFromLegacy inside).
+    if DF.CleanupLegacyTextLayoutOverrides then
+        DF:CleanupLegacyTextLayoutOverrides()
+    end
+
     -- Apply the profile — runtime state is already clear so the proxy reads
     -- the new profile directly with no stale overlay
     DF:FullProfileRefresh()


### PR DESCRIPTION
## Problem

The Text Designer migration took over the built-in Name / Health / Status text. A raid auto-layout that was edited **before** that migration can still carry those legacy text settings (`nameFontSize`, `healthFontSize`, `statusText*`, …) as per-layout overrides. They're now inert — `IsLegacyTextHidden` hides the legacy FontStrings — so they only clutter the override list (`/df overrides`, the override-details panel) without doing anything.

## Fix

`DF:CleanupLegacyTextLayoutOverrides` strips override keys categorised as Name / Health / Status Text from every raid auto-layout, reusing the existing `GetOverrideTabId` so the Text Designer entry itself is preserved.

**Gated for safety:** it only runs once the raid Text Designer has actually migrated the legacy settings (`migratedFromLegacy`), so the values are preserved in Text Designer first and it never strips while the legacy text is still live. Per-profile guard, idempotent; called right after the legacy migration at login and on profile switch. Stripping is visually inert — Text Designer ignores these keys — so it only declutters.