### PR TITLE
Status icons: fix AFK-cache crash on secret unit GUIDs

### DIFF
--- a/Frames/StatusIcons.lua
+++ b/Frames/StatusIcons.lua
@@ -745,7 +745,14 @@ local afkStartTimes = {}
 local afkStateCache = {}
 
 local function GetAFKKey(unit)
-    return UnitGUID(unit) or unit
+    -- A unit's GUID can be a SECRET value in 12.0, and a secret cannot be used as a
+    -- table key — doing so throws "cannot be indexed with secret keys" (this was
+    -- crashing UpdateAFKIcon / ClearAFKCache on live). Check accessibility BEFORE
+    -- any truthiness test on the GUID, and fall back to the unit token (a plain
+    -- string, never secret) for those units.
+    local guid = UnitGUID(unit)
+    if canaccessvalue(guid) and guid then return guid end
+    return unit
 end
 
 -- Format seconds as M:SS or H:MM:SS


### PR DESCRIPTION
## Problem

A unit's GUID can be a **secret** value in 12.0, and a secret value cannot be used as a table key. The AFK status caches are keyed by GUID (`afkStateCache[key]`, `afkStartTimes[key]`), so any unit whose GUID was secret crashed `UpdateAFKIcon` / `ClearAFKCache` with:

> attempted to perform indexed assignment on a table that cannot be indexed with secret keys

(reported 13× on live). The code already guarded `canaccessvalue` on the AFK/DND results, but never on the cache **key** itself.

## Fix

`GetAFKKey` now returns the GUID only when it is accessible (`canaccessvalue`, checked **before** any truthiness test on the GUID — a secret can't be evaluated in a boolean context) and falls back to the unit token, a plain string that is never secret, otherwise. Every cache read, write, and `ClearAFKCache` flows through `GetAFKKey`, so this one change covers them all. Normal units keep GUID-based keying (stable across unit-token reassignment); the rest get a safe key instead of a crash.