### PR TITLE
Sorting: stable tiebreak so group frames don't reshuffle mid-M+

### DIFF
--- a/Features/FlatRaidFrames.lua
+++ b/Features/FlatRaidFrames.lua
@@ -333,29 +333,50 @@ function FlatRaidFrames:BuildSortedNameList()
         end
     end
     
+    -- Per-element key for name comparisons: a unit's name can be SECRET in
+    -- combat (Midnight), and even ~= on a secret string throws. A secret (or
+    -- missing) name falls back to the unit token — plain and unique. Pure
+    -- per-element substitution keeps the comparator a consistent total order.
+    local issecretvalue = issecretvalue or function() return false end
+    local function NameKey(m)
+        local n = m.name
+        if n == nil or issecretvalue(n) then return tostring(m.unit) end
+        return n
+    end
+
     -- Sort function
     local function sortFunc(a, b)
         -- Sort by role priority first
         if a.rolePriority ~= b.rolePriority then
             return a.rolePriority < b.rolePriority
         end
-        
+
         -- Then by class if enabled
         if sortByClass then
             if a.classPriority ~= b.classPriority then
                 return a.classPriority < b.classPriority
             end
         end
-        
+
+        local nameA, nameB = NameKey(a), NameKey(b)
+
         -- Then alphabetically if enabled
         if sortAlphabetical then
             if sortAlphabetical == "ZA" then
-                return a.name > b.name
+                return nameA > nameB
             else
-                return a.name < b.name
+                return nameA < nameB
             end
         end
-        
+
+        -- Deterministic final tiebreak: equal-key members (same role,
+        -- Alphabetical off) have no defined order, and Lua's table.sort is NOT
+        -- stable — roster-driven re-sorts reshuffled same-role players
+        -- mid-encounter. Same fix as Headers.lua SortMembers; flat mode had
+        -- the identical bug.
+        if nameA ~= nameB then
+            return nameA < nameB
+        end
         return false
     end
     

--- a/Features/Sort.lua
+++ b/Features/Sort.lua
@@ -15,6 +15,7 @@ local UnitGUID = UnitGUID
 local UnitGroupRolesAssigned = UnitGroupRolesAssigned
 local UnitClass = UnitClass
 local GetSpecializationInfoByID = GetSpecializationInfoByID
+local issecretvalue = issecretvalue or function() return false end
 
 -- NOTE: Previously used reusable tables here, but that caused bugs when
 -- SortFrameList was called while iterating over a previous result.
@@ -182,12 +183,20 @@ function Sort:CompareUnits(unitA, unitB, db)
         end
     end
     
+    -- Name key for the alphabetical sort + tiebreak below. A unit's name can
+    -- be SECRET in combat (Midnight), and even ~= on a secret string throws —
+    -- a secret (or missing) name falls back to the unit token, which is plain
+    -- and unique. Pure per-unit substitution, so the comparator stays a
+    -- consistent total order for table.sort.
+    local nameA = UnitName(unitA)
+    local nameB = UnitName(unitB)
+    if nameA == nil or issecretvalue(nameA) then nameA = unitA end
+    if nameB == nil or issecretvalue(nameB) then nameB = unitB end
+
     -- Then sort alphabetically if enabled
     -- Supports "AZ", "ZA", or legacy true (treated as "AZ")
     local alpha = db.sortAlphabetical
     if alpha and alpha ~= false then
-        local nameA = UnitName(unitA) or ""
-        local nameB = UnitName(unitB) or ""
         if alpha == "ZA" then
             return nameA > nameB
         else
@@ -198,9 +207,7 @@ function Sort:CompareUnits(unitA, unitB, db)
     -- Deterministic final tiebreak: equal-key units need a stable order, or the
     -- unstable Lua table.sort reshuffles them on each re-sort (group-frame shuffle
     -- during M+ pulls). Mirrors Headers.lua SortMembers.
-    local tieA = UnitName(unitA) or ""
-    local tieB = UnitName(unitB) or ""
-    if tieA ~= tieB then return tieA < tieB end
+    if nameA ~= nameB then return nameA < nameB end
     return false
 end
 

--- a/Features/Sort.lua
+++ b/Features/Sort.lua
@@ -194,7 +194,13 @@ function Sort:CompareUnits(unitA, unitB, db)
             return nameA < nameB
         end
     end
-    
+
+    -- Deterministic final tiebreak: equal-key units need a stable order, or the
+    -- unstable Lua table.sort reshuffles them on each re-sort (group-frame shuffle
+    -- during M+ pulls). Mirrors Headers.lua SortMembers.
+    local tieA = UnitName(unitA) or ""
+    local tieB = UnitName(unitB) or ""
+    if tieA ~= tieB then return tieA < tieB end
     return false
 end
 
@@ -267,7 +273,12 @@ function Sort:CompareTestData(dataA, dataB, db)
             return nameA < nameB
         end
     end
-    
+
+    -- Deterministic final tiebreak (see CompareUnits) so test-mode sorting is
+    -- stable across re-sorts too.
+    local tieA = dataA.name or ""
+    local tieB = dataB.name or ""
+    if tieA ~= tieB then return tieA < tieB end
     return false
 end
 

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -4863,6 +4863,17 @@ function DF:BuildSortedNameList(members, db, selfPosition, includesPlayer)
         end
     end
     
+    -- Per-element key for name comparisons: a unit's name can be SECRET in
+    -- combat (Midnight), and even ~= on a secret string throws. A secret (or
+    -- missing) name falls back to the unit token — plain and unique. The
+    -- substitution is a pure per-element function, so the comparator stays a
+    -- consistent total order for table.sort.
+    local function NameKey(m)
+        local n = m.name
+        if n == nil or issecretvalue(n) then return tostring(m.unit) end
+        return n
+    end
+
     -- Sort function: Role -> Class -> Alphabetical
     local function SortMembers(a, b)
         if a.rolePriority ~= b.rolePriority then
@@ -4871,11 +4882,12 @@ function DF:BuildSortedNameList(members, db, selfPosition, includesPlayer)
         if sortByClass and a.classPriority ~= b.classPriority then
             return a.classPriority < b.classPriority
         end
-        if sortAlphabetical and a.name ~= b.name then
+        local nameA, nameB = NameKey(a), NameKey(b)
+        if sortAlphabetical and nameA ~= nameB then
             if sortAlphabetical == "ZA" then
-                return a.name > b.name
+                return nameA > nameB
             else
-                return a.name < b.name
+                return nameA < nameB
             end
         end
         -- Deterministic final tiebreak. Without one, members with equal sort keys
@@ -4885,8 +4897,8 @@ function DF:BuildSortedNameList(members, db, selfPosition, includesPlayer)
         -- Break ties by name (invariant for the session, and realm-qualified in the
         -- nameList so cross-realm names don't collide) so every re-sort of the same
         -- roster produces an identical order and the secure header never reorders.
-        if a.name ~= b.name then
-            return a.name < b.name
+        if nameA ~= nameB then
+            return nameA < nameB
         end
         return false
     end

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -4878,9 +4878,19 @@ function DF:BuildSortedNameList(members, db, selfPosition, includesPlayer)
                 return a.name < b.name
             end
         end
+        -- Deterministic final tiebreak. Without one, members with equal sort keys
+        -- (same role, Alphabetical off) have no defined order, and Lua's table.sort
+        -- is NOT stable — so a roster-driven re-sort mid-encounter reshuffles
+        -- same-role players, making the group frames rearrange during M+ pulls.
+        -- Break ties by name (invariant for the session, and realm-qualified in the
+        -- nameList so cross-realm names don't collide) so every re-sort of the same
+        -- roster produces an identical order and the secure header never reorders.
+        if a.name ~= b.name then
+            return a.name < b.name
+        end
         return false
     end
-    
+
     -- Sort non-player members
     table.sort(sortedMembers, SortMembers)
     


### PR DESCRIPTION
## Problem

Group/raid frame order rearranges itself during M+ pulls. The sort comparator (`SortMembers` in `BuildSortedNameList`) ends with `return false` for members with **equal sort keys** — same role with Alphabetical off, or tied names — and Lua's `table.sort` is not stable. A roster-driven re-sort during an encounter (pet summon/dismiss, role/assist churn → `GROUP_ROSTER_UPDATE`) can then land same-role players in a different order, changing the rebuilt nameList. The secure header faithfully applies the new order via its Hide/Show cycle, and the frames visibly shuffle.

(The skip-if-unchanged guard on the header attribute is intact and not the cause — it was applying a genuinely different nameList. The non-determinism is upstream of it.)

## Fix

Add a deterministic final tiebreak by name so every re-sort of the same roster yields an identical order. Name is invariant for the session and realm-qualified in the nameList, so distinct players never tie:

- `Frames/Headers.lua` `SortMembers` — the live nameList path; covers the player too, which is re-sorted through the same comparator in SORTED mode.
- `Features/Sort.lua` `CompareUnits` + `CompareTestData` — same `return false` pattern (legacy/test path).

## Trade-off

With **Alphabetical off**, members of the same role now order by name (previously undefined/arbitrary) instead of reshuffling. That's the deterministic behaviour required to stop the churn.