### PR TITLE
Sorting: fix crash from secret unit GUIDs used as cache keys

### DIFF
--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -121,6 +121,16 @@ SecureSort.specCache = {}
 SecureSort.inspectQueue = {}
 SecureSort.inspectInProgress = false
 
+-- A unit's GUID can be a SECRET value in 12.0 (e.g. M+ encounters) and a secret
+-- cannot be used as a table key — doing so throws "cannot be indexed with secret
+-- keys". The inspect queue is keyed by GUID and matched back against the GUID
+-- delivered by INSPECT_READY, so a unit-token fallback would never match; instead
+-- we skip queuing/handling units whose GUID isn't accessible.
+local issecretvalue = issecretvalue or function() return false end
+local function canaccessvalue(v)
+    return v ~= nil and not issecretvalue(v)
+end
+
 -- ============================================================
 -- DEBUG UTILITIES
 -- ============================================================
@@ -2303,13 +2313,14 @@ function SecureSort:QueueInspect(unit)
     if not UnitIsPlayer(unit) then return end
     if UnitIsUnit(unit, "player") then return end  -- Don't inspect self
     
+    -- canaccessvalue also covers the nil case (a secret GUID can't be a table key)
     local guid = UnitGUID(unit)
-    if not guid then return end
-    
+    if not canaccessvalue(guid) then return end
+
     -- Don't queue if already cached
     local name = GetCacheableName(unit)
     if name and self.specCache[name] then return end
-    
+
     -- Add to queue
     self.inspectQueue[guid] = unit
     
@@ -2373,6 +2384,9 @@ end
 
 -- Handle INSPECT_READY event
 function SecureSort:OnInspectReady(guid)
+    -- A secret GUID can't be a table key (and could never have been queued), so
+    -- it can't be one of ours — skip before indexing the queue with it.
+    if not canaccessvalue(guid) then return end
     -- Only process if this was an inspect WE initiated (guid is in our queue)
     local unit = self.inspectQueue[guid]
     if not unit then

--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -2344,8 +2344,12 @@ function SecureSort:ProcessInspectQueue()
         return
     end
     
-    -- Verify unit still exists and matches GUID
-    if not UnitExists(unit) or UnitGUID(unit) ~= guid then
+    -- Verify unit still exists and matches GUID. The unit's LIVE GUID can have
+    -- become secret since queuing (combat) — comparing a secret value throws,
+    -- so an inaccessible live GUID counts as a mismatch (identity can't be
+    -- verified; drop the entry and move on).
+    local liveGuid = UnitGUID(unit)
+    if not UnitExists(unit) or not canaccessvalue(liveGuid) or liveGuid ~= guid then
         self.inspectQueue[guid] = nil
         C_Timer.After(0.1, function() self:ProcessInspectQueue() end)
         return
@@ -2394,8 +2398,10 @@ function SecureSort:OnInspectReady(guid)
         return
     end
     
-    -- Process our queued inspect
-    if UnitExists(unit) and UnitGUID(unit) == guid then
+    -- Process our queued inspect. Same live-GUID secrecy guard as
+    -- ProcessInspectQueue: comparing a secret value throws.
+    local liveGuid = UnitGUID(unit)
+    if UnitExists(unit) and canaccessvalue(liveGuid) and liveGuid == guid then
         local specID = GetInspectSpecialization(unit)
         if specID and specID > 0 then
             self:CacheUnitSpec(unit, specID)

--- a/Features/Sort.lua
+++ b/Features/Sort.lua
@@ -16,6 +16,15 @@ local UnitGroupRolesAssigned = UnitGroupRolesAssigned
 local UnitClass = UnitClass
 local GetSpecializationInfoByID = GetSpecializationInfoByID
 
+-- A unit's GUID can be a SECRET value in 12.0 (e.g. M+ encounters) and a secret
+-- cannot be used as a table key — doing so throws "cannot be indexed with secret
+-- keys". Fall back to the unit token (always a plain string) when the GUID isn't
+-- accessible so cache lookups never crash.
+local issecretvalue = issecretvalue or function() return false end
+local function canaccessvalue(v)
+    return v ~= nil and not issecretvalue(v)
+end
+
 -- NOTE: Previously used reusable tables here, but that caused bugs when
 -- SortFrameList was called while iterating over a previous result.
 -- Now we return fresh tables each time. The garbage is minimal.
@@ -58,10 +67,12 @@ Sort.UnitCache = {}
 function Sort:GetUnitRole(unit)
     if not unit or not UnitExists(unit) then return "DAMAGER" end
     
-    -- Check cache first
+    -- Check cache first. The GUID can be a secret value that can't be used as a
+    -- table key, so fall back to the unit token when it isn't accessible.
     local guid = UnitGUID(unit)
-    if guid and self.UnitCache[guid] then
-        return self.UnitCache[guid].role
+    local cacheKey = (canaccessvalue(guid) and guid) or unit
+    if self.UnitCache[cacheKey] then
+        return self.UnitCache[cacheKey].role
     end
     
     -- Get assigned role
@@ -111,9 +122,9 @@ function Sort:GetUnitRole(unit)
     end
     
     -- Cache the result
-    if guid then
-        self.UnitCache[guid] = self.UnitCache[guid] or {}
-        self.UnitCache[guid].role = role
+    if cacheKey then
+        self.UnitCache[cacheKey] = self.UnitCache[cacheKey] or {}
+        self.UnitCache[cacheKey].role = role
     end
     
     return role

--- a/Features/Sort.lua
+++ b/Features/Sort.lua
@@ -67,11 +67,14 @@ Sort.UnitCache = {}
 function Sort:GetUnitRole(unit)
     if not unit or not UnitExists(unit) then return "DAMAGER" end
     
-    -- Check cache first. The GUID can be a secret value that can't be used as a
-    -- table key, so fall back to the unit token when it isn't accessible.
+    -- Check cache first. The GUID can be a secret value that can't be used as
+    -- a table key — in that case SKIP the cache entirely (recompute fresh).
+    -- Don't fall back to the unit token as a key: token-keyed entries go stale
+    -- the moment the roster shifts (raid5 becomes a different player and would
+    -- briefly show the previous player's role until the next cache clear).
     local guid = UnitGUID(unit)
-    local cacheKey = (canaccessvalue(guid) and guid) or unit
-    if self.UnitCache[cacheKey] then
+    local cacheKey = canaccessvalue(guid) and guid or nil
+    if cacheKey and self.UnitCache[cacheKey] then
         return self.UnitCache[cacheKey].role
     end
     


### PR DESCRIPTION
## Problem

`UnitGUID` can return a **secret** value in 12.0 (e.g. M+ encounters), and a secret value cannot be used as a Lua table key — using one throws `attempted to perform indexed assignment on a table that cannot be indexed with secret keys`. Two sort caches keyed by GUID were unguarded:

- `Sort.UnitCache` (role cache)
- `SecureSort.inspectQueue`

This is the same crash class as the AFK-cache fix in #141, in a different code path.

## Fix

- **`Sort.UnitCache`** — fall back to the unit token when the GUID is inaccessible (`canaccessvalue(guid) and guid or unit`), mirroring the StatusIcons AFK-cache fix. The token is a plain string and stable for the session.
- **`SecureSort.inspectQueue`** — skip queuing/handling units whose GUID is secret. The queue is matched back against the GUID delivered by `INSPECT_READY`, so a unit-token fallback would never match and would leak entries; skipping is the correct guard there.