### PR TITLE
Resource bar: honour Color Mode on power-type change (shapeshift)

### DIFF
--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -872,15 +872,13 @@ function DF:UpdateUnitFrame(frame, source)
                 frame.dfPowerBar:SetMinMaxValues(0, maxPower)
                 frame.dfPowerBar:SetValue(power)
 
-                local _, classToken = UnitClass(unit)
-                local classColor = db.resourceBarClassColor and classToken and DF:GetClassColor(classToken)
-                if classColor then
-                    frame.dfPowerBar:SetStatusBarColor(classColor.r, classColor.g, classColor.b, 1)
-                else
-                    local powerType, powerToken = UnitPowerType(unit)
-                    local powerColor = DF:GetPowerColor(powerToken, powerType)
-                    frame.dfPowerBar:SetStatusBarColor(powerColor.r, powerColor.g, powerColor.b, 1)
-                end
+                -- Colour via the shared resolver (resourceBarColorMode: Power /
+                -- Class / Custom), so this matches DF:UpdateResourceBar and the
+                -- UNIT_DISPLAYPOWER path. The old inline check read only the legacy
+                -- resourceBarClassColor boolean, which ignored a "Class" pick made
+                -- via the new Color Mode dropdown.
+                local cr, cg, cb = DF:GetResourceBarColor(unit, db)
+                frame.dfPowerBar:SetStatusBarColor(cr, cg, cb, 1)
                 frame.dfPowerBar:Show()
                 -- Let the appearance system handle alpha (OOR, dead, element-specific)
                 if DF.UpdatePowerBarAppearance then
@@ -1250,16 +1248,13 @@ function DF:UpdatePower(frame)
     frame.dfPowerBar:SetMinMaxValues(0, maxPower)
     frame.dfPowerBar:SetValue(power)
 
-    -- Update color
-    local _, classToken = UnitClass(unit)
-    local classColor = db.resourceBarClassColor and classToken and DF:GetClassColor(classToken)
-    if classColor then
-        frame.dfPowerBar:SetStatusBarColor(classColor.r, classColor.g, classColor.b, 1)
-    else
-        local powerType, powerToken = UnitPowerType(unit)
-        local powerColor = DF:GetPowerColor(powerToken, powerType)
-        frame.dfPowerBar:SetStatusBarColor(powerColor.r, powerColor.g, powerColor.b, 1)
-    end
+    -- Update colour via the shared resolver so the UNIT_DISPLAYPOWER / shapeshift
+    -- path honours resourceBarColorMode (Power / Class / Custom), not just the
+    -- legacy resourceBarClassColor boolean. Previously a shapeshift fired this
+    -- handler and reverted a "Class" bar back to power colour, because the inline
+    -- legacy check didn't see a "Class" pick made via the new Color Mode dropdown.
+    local cr, cg, cb = DF:GetResourceBarColor(unit, db)
+    frame.dfPowerBar:SetStatusBarColor(cr, cg, cb, 1)
     frame.dfPowerBar:Show()
 end
 

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -3535,8 +3535,16 @@ function DF:UpdateTestPowerBar(frame, testData)
         powerToken = "ENERGY"
     end
 
-    local classColor = db.resourceBarClassColor and testData.class and DF:GetClassColor(testData.class)
-    if classColor then
+    -- Mirror DF:GetResourceBarColor's mode resolution (Power / Class / Custom),
+    -- but using the mock unit's testData since there's no real unit to query.
+    -- Reads resourceBarColorMode (not just the legacy resourceBarClassColor
+    -- boolean) so the preview reflects a "Class" pick from the Color Mode dropdown.
+    local mode = db.resourceBarColorMode or (db.resourceBarClassColor and "CLASS" or "POWER_TYPE")
+    local classColor = mode == "CLASS" and testData.class and DF:GetClassColor(testData.class)
+    if mode == "CUSTOM" then
+        local c = db.resourceBarCustomColor or {r = 0, g = 0.5, b = 1}
+        bar:SetStatusBarColor(c.r or 0, c.g or 0.5, c.b or 1, 1)
+    elseif classColor then
         bar:SetStatusBarColor(classColor.r, classColor.g, classColor.b, 1)
     else
         local powerColor = DF:GetPowerColor(powerToken)


### PR DESCRIPTION
When the resource bar's **Color Mode** is set to **Class**, the bar shows the class colour — but after shapeshifting (or any power-type change) it reverted to the power-type colour until the next full frame update. The same happened the other way around.

**Cause:** the live power-update path read the legacy `resourceBarClassColor` boolean inline instead of going through the `resourceBarColorMode` resolver, so a `UNIT_DISPLAYPOWER` change re-applied the default power colour.

**Fix:** route the power update through `DF:GetResourceBarColor(unit, db)` (the tri-state Power / Class / Custom resolver) in both the inline render and `UpdatePower`. Test mode is made mode-aware to match.