### PR TITLE
Missing Buff: offer Class/Role colour for the border

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1407,7 +1407,8 @@ function DF:LightweightUpdateMissingBuff()
             -- the locally pixel-perfected value. Icon insets by visible
             -- border thickness so artwork doesn't overlap edges.
             if frame.missingBuffBorder then
-                local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { iconMode = true })
+                -- unit/frame let BuildSpec resolve Class/Role colour.
+                local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { unit = frame.unit, frame = frame, iconMode = true })
                 spec.enabled = showBorder
                 spec.size    = borderSize
                 DF.Border:Apply(frame.missingBuffBorder, spec)
@@ -2377,7 +2378,7 @@ function DF:LightweightUpdateMissingBuffBorderColor()
             -- live drag-update consistent so dragging the picker on a
             -- gradient or class-coloured border updates correctly.
             DF.Border:Apply(frame.missingBuffBorder,
-                DF.Border:BuildSpec(db, "missingBuffIcon", { iconMode = true }))
+                DF.Border:BuildSpec(db, "missingBuffIcon", { unit = frame.unit, frame = frame, iconMode = true }))
         end
     end
 

--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -890,7 +890,9 @@ function DF:UpdateMissingBuffIcon(frame, forceUpdate)
         end
 
         if frame.missingBuffBorder then
-            local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { iconMode = true })
+            -- unit/frame let BuildSpec resolve Class/Role colour (the missing-buff
+            -- icon sits on a unit frame, so its border can show whose buff it is).
+            local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { unit = frame.unit, frame = frame, iconMode = true })
             spec.enabled = showBorder
             spec.size    = borderSize
             DF.Border:Apply(frame.missingBuffBorder, spec)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -5596,14 +5596,16 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         -- include set tailored for a "needs attention" alert: alpha / inset /
         -- offset / blendMode / gradient / shadow / animate (matches the
         -- Defensive Icon — Border Offset nudges the band relative to the icon).
-        -- Skipped: class / role / colour-by-time / colour-by-type (alert colour,
-        -- not the unit's identity, and no aura-state context here).
+        -- Class/Role colour offered too: the missing-buff icon sits on a unit
+        -- frame, so its border can communicate WHOSE buff is missing at a glance.
+        -- Skipped: colour-by-time / colour-by-type (no aura-state context here).
         local borderGroup = GUI:CreateSettingsGroup(self.child, 280)
         borderGroup:AddWidget(GUI:CreateHeader(self.child, L["Border"]), 40)
         GUI:CreateBorderControls(borderGroup, db, "missingBuffIcon", {
             parent       = self.child,
             include      = { alpha = true, inset = true, offset = true, blendMode = true,
-                             gradient = true, shadow = true, animate = true },
+                             gradient = true, shadow = true, animate = true,
+                             classColor = true, roleColor = true },
             fullUpdate   = function() if DF.UpdateAllMissingBuffIcons then DF:UpdateAllMissingBuffIcons() end end,
             lightUpdate  = function() DF:LightweightUpdateMissingBuff() end,
             lightColors  = function() DF:LightweightUpdateMissingBuffBorderColor() end,

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -5019,7 +5019,8 @@ function DF:UpdateTestMissingBuff(frame)
         -- after the DF.Border migration (Create.lua builds frame.missingBuffBorder).
         local showBorder = db.missingBuffIconShowBorder ~= false
         if frame.missingBuffBorder then
-            local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { iconMode = true })
+            -- frame lets BuildSpec resolve Class/Role colour from test-unit data.
+            local spec = DF.Border:BuildSpec(db, "missingBuffIcon", { unit = frame.unit, frame = frame, iconMode = true })
             spec.enabled = showBorder
             spec.size    = borderSize
             DF.Border:Apply(frame.missingBuffBorder, spec)


### PR DESCRIPTION
The Missing Buff indicator's border could only be a static colour. This adds **Class** and **Role** colour options, consistent with the other border controls.

- Adds `classColor` / `roleColor` to the Missing Buff border controls.
- Passes unit/frame context into the border spec so the colour resolves per unit at render time.
- Covers both the live frames and test mode.