### PR TITLE
Defensive icons: fix position drift vs test mode at non-1 icon scale

### DIFF
--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -1048,9 +1048,23 @@ function DF:UpdateDefensiveBar(frame)
         local growth = db.defensiveBarGrowth or "RIGHT_DOWN"
         local wrap = db.defensiveBarWrap or 5
 
+        local userScale = scale  -- pre-pixel-perfect scale; drives the LAYOUT space
         if db.pixelPerfect then
             iconSize, scale, borderSize = DF:PixelPerfectSizeAndScaleForBorder(iconSize, scale, borderSize)
         end
+
+        -- Pixel-perfect folds the user's scale INTO the icon size and resets scale to
+        -- 1.0 (so the border lands on whole pixels). That changes the coordinate space
+        -- SetPoint offsets live in: the anchor offset + inter-icon spacing would then be
+        -- applied UNSCALED instead of at the user's scale, shifting the whole block —
+        -- e.g. a scale-0.6 bar with Offset Y -28 dropped a row lower than test mode,
+        -- which keeps SetScale(userScale). Re-scale the layout coords by the original
+        -- user scale so the block lands identically with or without pixel-perfect, and
+        -- matches test mode. (bug 951)
+        local layoutScale = (db.pixelPerfect and userScale) or 1.0
+        local layoutBaseX = baseX * layoutScale
+        local layoutBaseY = baseY * layoutScale
+        local layoutSpacing = spacing * layoutScale
 
         -- Parse compound growth direction (PRIMARY_SECONDARY)
         local primary, secondary = strsplit("_", growth)
@@ -1059,8 +1073,8 @@ function DF:UpdateDefensiveBar(frame)
 
         -- Calculate growth offsets using scaled size (same pattern as buff/debuff icons)
         local scaledSize = iconSize * scale
-        local primaryX, primaryY = GetDefensiveGrowthOffset(primary, iconSize, spacing)
-        local secondaryX, secondaryY = GetDefensiveGrowthOffset(secondary, iconSize, spacing)
+        local primaryX, primaryY = GetDefensiveGrowthOffset(primary, iconSize, layoutSpacing)
+        local secondaryX, secondaryY = GetDefensiveGrowthOffset(secondary, iconSize, layoutSpacing)
 
         local count = 0
         local adIDs = frame.dfAD_activeInstanceIDs  -- Aura Designer dedup
@@ -1091,7 +1105,7 @@ function DF:UpdateDefensiveBar(frame)
 
                     icon:SetScale(scale)
                     icon:ClearAllPoints()
-                    icon:SetPoint(anchor, frame, anchor, baseX + offsetX, baseY + offsetY)
+                    icon:SetPoint(anchor, frame, anchor, layoutBaseX + offsetX, layoutBaseY + offsetY)
 
                     -- Frame level
                     local frameLevel = db.defensiveIconFrameLevel or 0
@@ -1118,9 +1132,9 @@ function DF:UpdateDefensiveBar(frame)
                     local col = floor(idx / wrap)
                     local row = idx % wrap
                     local iconsInCol = math.min(wrap, count - (col * wrap))
-                    local centerOffset = (iconsInCol - 1) * (iconSize + spacing) / 2
-                    local x = baseX + (col * secX)
-                    local y = baseY - (row * (iconSize + spacing)) + centerOffset
+                    local centerOffset = (iconsInCol - 1) * (iconSize + layoutSpacing) / 2
+                    local x = layoutBaseX + (col * secX)
+                    local y = layoutBaseY - (row * (iconSize + layoutSpacing)) + centerOffset
                     icon:ClearAllPoints()
                     icon:SetPoint(anchor, frame, anchor, x, y)
                 end
@@ -1133,9 +1147,9 @@ function DF:UpdateDefensiveBar(frame)
                     local row = floor(idx / wrap)
                     local col = idx % wrap
                     local iconsInRow = math.min(wrap, count - (row * wrap))
-                    local centerOffset = (iconsInRow - 1) * (iconSize + spacing) / 2
-                    local x = baseX + (col * (iconSize + spacing)) - centerOffset
-                    local y = baseY + (row * secY)
+                    local centerOffset = (iconsInRow - 1) * (iconSize + layoutSpacing) / 2
+                    local x = layoutBaseX + (col * (iconSize + layoutSpacing)) - centerOffset
+                    local y = layoutBaseY + (row * secY)
                     icon:ClearAllPoints()
                     icon:SetPoint(anchor, frame, anchor, x, y)
                 end


### PR DESCRIPTION
With **Pixel-Perfect Scaling** on and a defensive **icon scale other than 1**, the live defensive bar rendered lower than test mode — a row lower with the reporting profile's Offset Y −28 / scale 0.6. It lined up at scale 1.0 but drifted below it.

**Cause:** the live renderer runs the icon through `PixelPerfectSizeAndScaleForBorder`, which folds the user's scale into the icon size and resets the icon's scale to `1.0` (so the border lands on whole pixels). The anchor offset (`defensiveIconX/Y`) and inter-icon spacing are passed to `SetPoint`, whose offsets live in the icon's *scaled* coordinate space — so with scale forced to `1.0`, `−28` rendered as a literal `−28` instead of `−28 × 0.6`. Test mode keeps `SetScale(userScale)`, so it stayed at the scaled value. Hence they matched at scale 1.0 and diverged below it. (Pixel-perfect off → both paths are already identical.)

**Fix:** keep the crisp-border pixel-perfect path, but re-scale the *layout* coordinates (anchor offset + spacing) by the original user scale when pixel-perfect folds it. Live now lands identically to test in both position and visual size, with or without pixel-perfect. Covers the main loop and both CENTER-growth passes.