### PR TITLE
Export: include the Text Designer table in the Text category

### DIFF
--- a/ExportCategories.lua
+++ b/ExportCategories.lua
@@ -490,6 +490,11 @@ DF.ExportCategories = {
     -- TEXT - Name, status, health text & fonts
     -- ===========================================
     text = {
+        -- Text Designer (whole-table, like the auraDesigner category below --
+        -- legacy name/health/status text is retired, so an export without
+        -- this table imports as completely blank frame text)
+        "textDesigner",
+
         -- Global Font Shadow Settings
         "fontShadowOffsetX",
         "fontShadowOffsetY",

--- a/Profile.lua
+++ b/Profile.lua
@@ -667,7 +667,7 @@ local function ResetTDForLegacyImport(payloads)
     for mode, payload in pairs(payloads) do
         if type(payload) == "table" and payload.textDesigner == nil
             and (payload.nameFont ~= nil or payload.nameFontSize ~= nil
-                or payload.healthTextEnabled ~= nil or payload.statusTextEnabled ~= nil) then
+                or payload.showHealthText ~= nil or payload.statusTextEnabled ~= nil) then
             local db = DF:GetDB(mode)
             local tdDB = db and DF.TextDesigner:EnsureDB(db)
             if tdDB then

--- a/Profile.lua
+++ b/Profile.lua
@@ -650,6 +650,36 @@ function DF:GetImportInfo(importData)
     return info
 end
 
+-- Old / pre-fix exports carry the LEGACY name/health/status text keys but no
+-- textDesigner table (the Text category exported only the legacy keys until
+-- the category list gained "textDesigner"). The legacy keys merge in fine,
+-- but nothing ever converts them: the TD migration only runs at login /
+-- profile switch and skips any mode already migrated — which every live
+-- profile is. With the legacy text widgets retired, the imported text would
+-- never render (blank frame text). For each mode whose imported payload was
+-- legacy-only, reset that mode's TD so an unforced
+-- MigrateTextDesignerFromLegacy rebuilds it from the just-imported legacy
+-- settings; modes whose payload carried a textDesigner table (or no text at
+-- all) keep their existing TD untouched. Returns true if any mode was reset.
+local function ResetTDForLegacyImport(payloads)
+    if not (DF.TextDesigner and DF.TextDesigner.EnsureDB) then return false end
+    local any = false
+    for mode, payload in pairs(payloads) do
+        if type(payload) == "table" and payload.textDesigner == nil
+            and (payload.nameFont ~= nil or payload.nameFontSize ~= nil
+                or payload.healthTextEnabled ~= nil or payload.statusTextEnabled ~= nil) then
+            local db = DF:GetDB(mode)
+            local tdDB = db and DF.TextDesigner:EnsureDB(db)
+            if tdDB then
+                tdDB.elements = {}
+                tdDB.migratedFromLegacy = nil
+                any = true
+            end
+        end
+    end
+    return any
+end
+
 -- Apply imported data with optional category/frame type filtering
 -- selectedCategories: table of category names to import, or nil for all in the data
 -- selectedFrameTypes: table like {party = true, raid = true}, or nil for all in the data
@@ -761,7 +791,29 @@ function DF:ApplyImportedProfile(importData, selectedCategories, selectedFrameTy
             DF.db.auraBlacklist = importData.auraBlacklist
         end
     end
-    
+
+    -- Legacy-text payloads → Text Designer (see ResetTDForLegacyImport).
+    -- Only when the text category was actually imported, and only for the
+    -- imported frame types — rebuilding from legacy keys that didn't merge
+    -- would convert the RECEIVER's stale legacy values instead.
+    local textImported = importInfo.isFullExport and not selectedCategories
+    if not textImported then
+        for _, cat in ipairs(selectedCategories or importInfo.detectedCategories or {}) do
+            if cat == "text" then
+                textImported = true
+                break
+            end
+        end
+    end
+    if textImported and DF.MigrateTextDesignerFromLegacy then
+        local payloads = {}
+        if selectedFrameTypes.party then payloads.party = importData.party end
+        if selectedFrameTypes.raid then payloads.raid = importData.raid end
+        if ResetTDForLegacyImport(payloads) then
+            DF:MigrateTextDesignerFromLegacy()
+        end
+    end
+
     -- Force DIRECT aura source mode — imported profiles may have BLIZZARD
     -- which is no longer supported.
     if DF.db.party then DF.db.party.auraSourceMode = "DIRECT" end
@@ -794,6 +846,14 @@ function DF:ImportProfile(str)
     end
     if newProfile.raid then
         DF.db.raid = newProfile.raid
+    end
+
+    -- Legacy-text payloads → Text Designer (see ResetTDForLegacyImport).
+    -- Wholesale replacement, so every imported mode is a candidate.
+    if DF.MigrateTextDesignerFromLegacy then
+        if ResetTDForLegacyImport({ party = newProfile.party, raid = newProfile.raid }) then
+            DF:MigrateTextDesignerFromLegacy()
+        end
     end
 
     -- Force DIRECT aura source mode — imported profiles may have BLIZZARD


### PR DESCRIPTION
**Symptom (live report):** importing a shared profile produced completely blank frame text — the sender's Text Designer config never arrived.

**Cause (two halves):**
1. Category-based profile export extracts only whitelisted keys per category, and `textDesigner` was never added to the **Text** category's key list when the Text Designer replaced the legacy name/health/status text elements (Aura Designer got its own whole-table category; TD didn't). Any export with a category selection — including ticking just "Text" — silently dropped the entire Text Designer table. The same key map also filters **import** merging, so even a full export imported with categories selected lost it.
2. Even though the legacy text keys DO travel, nothing converted them on arrival: `MigrateTextDesignerFromLegacy` only runs at login/profile switch and skips any mode already migrated — which every live profile is. So a legacy-only payload merged in as dead data, and with legacy text rendering retired, the result was blank text.

**Fixes:**
- `ExportCategories.lua`: add `"textDesigner"` to the `text` category key list (whole-table, same pattern as the `auraDesigner` category). Fixes both export extraction and import merge for new exports.
- `Profile.lua`: on import, each imported mode whose payload carries legacy text keys but no `textDesigner` table has its TD reset (elements + `migratedFromLegacy`) and the unforced migration re-run — rebuilding exactly those modes from the just-imported legacy settings, leaving the other mode's TD untouched. Gated on the text category actually being imported and the selected frame types, so unmerged payload keys can't trigger a rebuild from the receiver's stale legacy values. Covers the import dialog/Wago path and the legacy string-import path.

Net effect: new exports carry the Text Designer natively, and **existing export strings already in the wild now import correctly** — the legacy keys they carry are converted to Text Designer elements on arrival.