### PR TITLE
12.0.7 readiness: feature-detect MenuUtil tooltip + DoReadyCheck move

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -5961,14 +5961,27 @@ function DF:CreateAddonCompartment()
             end
         end,
         funcOnEnter = function(button)
-            MenuUtil.ShowTooltip(button, function(tooltip)
+            -- 12.0.7 deprecates MenuUtil.ShowTooltip/HideTooltip in favour of
+            -- the *Ex variants taking an explicit tooltip (the old ones only
+            -- survive behind the loadDeprecationFallbacks CVar). Feature-detect
+            -- so both 12.0.5 and 12.0.7 work.
+            local fill = function(tooltip)
                 tooltip:AddLine("DandersFrames")
                 tooltip:AddLine("|cffffffffLeft-Click:|r Open settings", 0.8, 0.8, 0.8)
                 tooltip:AddLine("|cffffffffRight-Click:|r Toggle solo mode", 0.8, 0.8, 0.8)
-            end)
+            end
+            if MenuUtil.ShowTooltipEx then
+                MenuUtil.ShowTooltipEx(button, GetAppropriateTooltip(), fill)
+            else
+                MenuUtil.ShowTooltip(button, fill)
+            end
         end,
         funcOnLeave = function(button)
-            MenuUtil.HideTooltip(button)
+            if MenuUtil.HideTooltipEx then
+                MenuUtil.HideTooltipEx(button, GetAppropriateTooltip())
+            else
+                MenuUtil.HideTooltip(button)
+            end
         end,
     })
 

--- a/Frames/Position.lua
+++ b/Frames/Position.lua
@@ -309,7 +309,16 @@ local PERM_MOVER_ACTIONS = {
     end },
     RELOAD_UI         = { label = L["Reload UI"],                  combatSafe = true,  fn = function() ReloadUI() end },
     RESET_POSITION    = { label = L["Reset Position"],             combatSafe = false, fn = function() DF:ResetPosition() end },
-    READY_CHECK       = { label = L["Ready Check"],                combatSafe = true,  fn = function() DoReadyCheck() end },
+    READY_CHECK       = { label = L["Ready Check"],                combatSafe = true,  fn = function()
+        -- 12.0.7 moves DoReadyCheck into C_PartyInfo and Blizzard migrated
+        -- their own callers with NO compat shim for the old global — prefer
+        -- the namespaced version, fall back to the global on 12.0.5.
+        if C_PartyInfo and C_PartyInfo.DoReadyCheck then
+            C_PartyInfo.DoReadyCheck()
+        else
+            DoReadyCheck()
+        end
+    end },
     PULL_TIMER        = { label = L["Pull Timer"],                 combatSafe = true,  fn = function()
         local db = DF:GetDB()
         C_PartyInfo.DoCountdown(db.permanentMoverPullTimerDuration or 10)


### PR DESCRIPTION
With addons disabled on the PTR, we audited the full 12.0.5 → 12.0.7 interface diff (generated API docs, secure templates, restricted environment, deprecation list) against everything the addon calls. The good news: `C_UnitAuras`, the secure group header layer, the secret-values predicates, and the Duration object pipeline are all unchanged or purely additive. Two call sites are affected by the patch, both fixed here with feature detection so the same code runs correctly on live today:

1. **`MenuUtil.ShowTooltip` / `HideTooltip` are deprecated in 12.0.7** (listed in `Deprecated_12_0_7.lua`) in favour of `ShowTooltipEx` / `HideTooltipEx` taking an explicit tooltip — the old names only survive behind the `loadDeprecationFallbacks` CVar. The addon-compartment tooltip now uses the Ex variants (+ `GetAppropriateTooltip()`) when present, falling back to the old API on 12.0.5 where the Ex variants don't exist.

2. **`DoReadyCheck` moves into `C_PartyInfo`** in 12.0.7, and Blizzard migrated their own UI callers with no compat shim for the old global. The permanent mover's Ready Check action now prefers `C_PartyInfo.DoReadyCheck`, falling back to the global on 12.0.5.

No behaviour change on live; both paths activate automatically when 12.0.7 ships.