### PR TITLE
Arena: don't hide late-loading teammates (incomplete-nameList fallback)

### DIFF
--- a/Features/FrameSort.lua
+++ b/Features/FrameSort.lua
@@ -175,18 +175,62 @@ end
 -- No IsVisible() guard: SetAttribute works on hidden frames, so we pre-set nameList
 -- even before the header is shown (e.g. after a reload in the arena prep room).
 -- The header picks it up as soon as it becomes visible.
+--
+-- LATE-JOIN GUARD (mirrors ApplyArenaHeaderSorting's incomplete handling):
+-- a teammate can EXIST before their name resolves (loading in during prep —
+-- common in non-rated arenas). A nameList missing them (nil/secret skipped)
+-- or carrying a literal "Unknown" token FILTERS their frame out, and nothing
+-- fixes it for the whole round (name resolution fires no roster event, and
+-- combat blocks attribute writes once the gates open). Names come from
+-- GetRaidRosterInfo — the source SecureGroupHeaderTemplate matches raid-kind
+-- nameList tokens against (realm-qualified, and usually resolved before the
+-- player object loads). If any member is still unresolved, show EVERYONE in
+-- INDEX order and let the arena sort retry re-request FrameSort's order once
+-- names resolve.
 local function SortArenaFrames(units)
     if not DF.arenaHeader then return false end
 
-    local nameList = UnitsToNameList(units)
-    if nameList == "" then return false end
+    wipe(namesBuf)
+    local complete = true
+    for i = 1, #units do
+        local unit = units[i]
+        local name
+        local raidIndex = unit:match("^raid(%d+)$")
+        if raidIndex then
+            name = GetRaidRosterInfo(tonumber(raidIndex))
+        else
+            name = GetUnitName(unit, true)
+        end
+        -- issecretvalue first: comparing/testing a secret value crashes.
+        if issecretvalue(name) or not name or name == UNKNOWNOBJECT then
+            complete = false
+        else
+            namesBuf[#namesBuf + 1] = name
+        end
+    end
 
+    if not complete or #namesBuf == 0 then
+        DF:Debug("FRAMESORT", "Arena nameList incomplete — using INDEX + retry")
+        DF.arenaHeader:SetAttribute("nameList", nil)
+        DF.arenaHeader:SetAttribute("sortMethod", "INDEX")
+        DF.arenaHeader:SetAttribute("groupBy", nil)
+        DF.arenaHeader:SetAttribute("groupingOrder", nil)
+        if DF.SetArenaSortIncomplete then
+            DF:SetArenaSortIncomplete(true)
+        end
+        return true
+    end
+
+    local nameList = tconcat(namesBuf, ",")
     DF:Debug("FRAMESORT", "Sorting arena frames:", nameList)
 
     DF.arenaHeader:SetAttribute("nameList", nameList)
     DF.arenaHeader:SetAttribute("sortMethod", "NAMELIST")
     DF.arenaHeader:SetAttribute("groupBy", nil)
     DF.arenaHeader:SetAttribute("groupingOrder", nil)
+    if DF.SetArenaSortIncomplete then
+        DF:SetArenaSortIncomplete(false)
+    end
     return true
 end
 

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -57,6 +57,47 @@ local function QueueRosterUpdate()
     rosterThrottleFrame:Show()  -- Showing already-shown frame = no-op
 end
 
+-- ============================================================
+-- ARENA SORT RETRY
+-- A friendly arena member can EXIST before their name has resolved
+-- (UnitName returns nil / UNKNOWNOBJECT while they're still loading in —
+-- common in non-rated arenas where players trickle in during prep). A
+-- nameList built in that window FILTERS the unresolved player out of the
+-- secure header, and nothing ever fixes it: name resolution fires no
+-- GROUP_ROSTER_UPDATE, and once the gates open combat blocks attribute
+-- writes for the rest of the round. When a build comes back incomplete,
+-- ApplyArenaHeaderSorting shows everyone in INDEX order instead and this
+-- retry loop re-sorts once the names resolve (UNIT_NAME_UPDATE nudges it
+-- too, but per the codebase's own experience that event is unreliable).
+-- ============================================================
+local arenaSortRetryPending = false
+local arenaSortRetryCount = 0
+local arenaNameListIncomplete = false
+
+local function SetArenaNameListIncomplete(v)
+    arenaNameListIncomplete = v
+    if not v then
+        arenaSortRetryCount = 0  -- complete build: re-arm the safety cap
+    end
+end
+
+local function ScheduleArenaSortRetry()
+    if arenaSortRetryPending then return end
+    if arenaSortRetryCount >= 24 then return end  -- ~12s safety cap
+    arenaSortRetryPending = true
+    arenaSortRetryCount = arenaSortRetryCount + 1
+    C_Timer.After(0.5, function()
+        arenaSortRetryPending = false
+        if not (DF.GetContentType and DF:GetContentType() == "arena") then return end
+        if InCombatLockdown() then
+            -- Replays via the existing combat-end queue.
+            DF.pendingSortingUpdate = true
+        elseif DF.ApplyArenaHeaderSorting then
+            DF:ApplyArenaHeaderSorting()
+        end
+    end)
+end
+
 -- Same pattern for role updates
 local roleThrottleFrame = CreateFrame("Frame")
 roleThrottleFrame:Hide()
@@ -6268,14 +6309,23 @@ end
 
 -- Build a sorted nameList for arena frames
 -- Same approach as BuildPartyNameList but iterates raid1-5 (arena uses raid units)
+-- Returns nameList, complete. `complete` is false when a member EXISTS but
+-- their name hasn't resolved yet (UnitName = nil / UNKNOWNOBJECT while they're
+-- still loading in — typical for non-rated arenas where players trickle into
+-- the prep room). An unresolved member is OMITTED rather than added as
+-- "Unknown": a literal "Unknown" entry never matches their real name, so the
+-- header would hide them for the whole round.
 function DF:BuildArenaNameList(selfPosition)
     local members = {}
-    
+    local complete = true
+
     for i = 1, 5 do
         local unit = "raid" .. i
         if UnitExists(unit) then
             local name, realm = UnitName(unit)
-            if name then
+            if not name or name == UNKNOWNOBJECT then
+                complete = false
+            else
                 local fullName = name
                 if realm and realm ~= "" then
                     fullName = name .. "-" .. realm
@@ -6288,15 +6338,20 @@ function DF:BuildArenaNameList(selfPosition)
             end
         end
     end
-    
+
     -- Use the unified sorting function (handles role, class, alphabetical,
     -- melee/ranged separation, realm stripping, and self-positioning)
-    return DF:BuildSortedNameList(members, DF:GetDB(), selfPosition, true)
+    return DF:BuildSortedNameList(members, DF:GetDB(), selfPosition, true), complete
 end
 
 -- Apply sorting to arena header (uses party settings)
 function DF:ApplyArenaHeaderSorting()
-    if InCombatLockdown() then return end
+    if InCombatLockdown() then
+        -- Don't drop the request (a round's combat lasts minutes — e.g. a
+        -- post-reload apply mid-round): replay on the combat-end queue.
+        DF.pendingSortingUpdate = true
+        return
+    end
     if not DF.arenaHeader then return end
 
     -- FrameSort integration: yield sorting entirely to FrameSort when active.
@@ -6358,7 +6413,8 @@ function DF:ApplyArenaHeaderSorting()
         DF.arenaHeader:SetAttribute("groupingOrder", roleOrderString)
         DF.arenaHeader:SetAttribute("groupBy", "ASSIGNEDROLE")
         DF.arenaHeader:SetAttribute("sortMethod", "NAME")
-        
+        SetArenaNameListIncomplete(false)  -- not a filtering mode
+
         if DF.debugHeaders then
             print("|cFF00FF00[DF Headers]|r   Arena using native role sorting")
         end
@@ -6372,36 +6428,52 @@ function DF:ApplyArenaHeaderSorting()
         DF.arenaHeader:SetAttribute("roleFilter", nil)
         DF.arenaHeader:SetAttribute("strictFiltering", nil)
         DF.arenaHeader:SetAttribute("sortMethod", "INDEX")
-        
+        SetArenaNameListIncomplete(false)  -- not a filtering mode
+
         -- Force header to re-evaluate by hiding and showing
         DF.arenaHeader:Hide()
         DF.arenaHeader:Show()
-        
+
         if DF.debugHeaders then
             print("|cFF00FF00[DF Headers]|r   Arena sorting disabled, using INDEX (cleared all attributes)")
         end
     else
         -- Use nameList for FIRST/LAST or any advanced sorting options
-        local nameList = DF:BuildArenaNameList(selfPosition)
-        
+        local nameList, complete = DF:BuildArenaNameList(selfPosition)
+
         -- Clear all filtering/grouping attributes
         DF.arenaHeader:SetAttribute("groupBy", nil)
         DF.arenaHeader:SetAttribute("groupingOrder", nil)
         DF.arenaHeader:SetAttribute("groupFilter", nil)
         DF.arenaHeader:SetAttribute("roleFilter", nil)
         DF.arenaHeader:SetAttribute("strictFiltering", nil)
-        
-        -- Set nameList and sortMethod
-        DF.arenaHeader:SetAttribute("nameList", nameList)
-        DF.arenaHeader:SetAttribute("sortMethod", "NAMELIST")
-        
+
+        if not complete then
+            -- Someone exists whose name hasn't resolved yet. A filtering
+            -- nameList would HIDE them — and nothing would fix it for the
+            -- whole round (name resolution fires no roster event, and combat
+            -- blocks attribute writes once the gates open). Show EVERYONE in
+            -- INDEX order for now and re-sort once the names resolve.
+            DF.arenaHeader:SetAttribute("nameList", nil)
+            DF.arenaHeader:SetAttribute("sortMethod", "INDEX")
+            SetArenaNameListIncomplete(true)
+            ScheduleArenaSortRetry()
+            if DF.debugHeaders then
+                print("|cFF00FF00[DF Headers]|r   Arena nameList INCOMPLETE (unresolved name) — using INDEX + retry")
+            end
+        else
+            -- Set nameList and sortMethod
+            DF.arenaHeader:SetAttribute("nameList", nameList)
+            DF.arenaHeader:SetAttribute("sortMethod", "NAMELIST")
+            SetArenaNameListIncomplete(false)
+            if DF.debugHeaders then
+                print("|cFF00FF00[DF Headers]|r   Arena using nameList mode:", nameList)
+            end
+        end
+
         -- Force header to re-evaluate
         DF.arenaHeader:Hide()
         DF.arenaHeader:Show()
-        
-        if DF.debugHeaders then
-            print("|cFF00FF00[DF Headers]|r   Arena using nameList mode:", nameList)
-        end
     end
 
     -- Schedule private aura reanchor after all attribute changes settle
@@ -8796,6 +8868,16 @@ headerChildEventFrame:SetScript("OnEvent", function(self, event, arg1)
                 end
             end
             tdRefresh(frame, pinnedFrame, "name")
+
+            -- Arena: the resolving name may be the one that made the last
+            -- arena nameList build incomplete (the member was shown unsorted
+            -- via INDEX instead of being filtered out) — nudge the re-sort.
+            -- Gated on the incomplete flag so a fully-sorted header doesn't
+            -- churn on routine name updates.
+            if arenaNameListIncomplete and unit:match("^raid%d")
+                and DF.GetContentType and DF:GetContentType() == "arena" then
+                ScheduleArenaSortRetry()
+            end
         end
         return
     end

--- a/Frames/Headers.lua
+++ b/Frames/Headers.lua
@@ -92,10 +92,28 @@ local function ScheduleArenaSortRetry()
         if InCombatLockdown() then
             -- Replays via the existing combat-end queue.
             DF.pendingSortingUpdate = true
+        elseif DF.IsFrameSortActive and DF:IsFrameSortActive() then
+            -- FrameSort owns sorting: re-request its order. Calling
+            -- ApplyArenaHeaderSorting here would just yield and clear the
+            -- header to INDEX, never resolving the incomplete state.
+            if DF.FrameSort and DF.FrameSort.RequestSort then
+                DF.FrameSort:RequestSort()
+            end
         elseif DF.ApplyArenaHeaderSorting then
             DF:ApplyArenaHeaderSorting()
         end
     end)
+end
+
+-- FrameSort integration (Features/FrameSort.lua) writes the arena header's
+-- nameList through its own path; this exposes the incomplete-state machinery
+-- so that path gets the same INDEX-fallback + retry + UNIT_NAME_UPDATE-nudge
+-- coverage as the native ApplyArenaHeaderSorting path.
+function DF:SetArenaSortIncomplete(incomplete)
+    SetArenaNameListIncomplete(incomplete)
+    if incomplete then
+        ScheduleArenaSortRetry()
+    end
 end
 
 -- Same pattern for role updates
@@ -6309,12 +6327,18 @@ end
 
 -- Build a sorted nameList for arena frames
 -- Same approach as BuildPartyNameList but iterates raid1-5 (arena uses raid units)
+-- Names come from GetRaidRosterInfo, NOT UnitName: for raid-kind units,
+-- SecureGroupHeaderTemplate matches nameList tokens against GetRaidRosterInfo
+-- names (already realm-qualified for cross-realm), and the roster usually
+-- knows a late-joiner's name BEFORE their player object loads (UnitName
+-- returns UNKNOWNOBJECT while they're still loading in — typical for
+-- non-rated arenas where players trickle into the prep room). Sourcing from
+-- the roster therefore yields a complete, matchable list immediately in the
+-- common late-join case, where UnitName would have forced the INDEX fallback.
 -- Returns nameList, complete. `complete` is false when a member EXISTS but
--- their name hasn't resolved yet (UnitName = nil / UNKNOWNOBJECT while they're
--- still loading in — typical for non-rated arenas where players trickle into
--- the prep room). An unresolved member is OMITTED rather than added as
--- "Unknown": a literal "Unknown" entry never matches their real name, so the
--- header would hide them for the whole round.
+-- the roster hasn't served their name yet. An unresolved member is OMITTED
+-- rather than added as "Unknown": a literal "Unknown" entry never matches
+-- their real name, so the header would hide them for the whole round.
 function DF:BuildArenaNameList(selfPosition)
     local members = {}
     local complete = true
@@ -6322,17 +6346,16 @@ function DF:BuildArenaNameList(selfPosition)
     for i = 1, 5 do
         local unit = "raid" .. i
         if UnitExists(unit) then
-            local name, realm = UnitName(unit)
-            if not name or name == UNKNOWNOBJECT then
+            -- In arena, raid roster index i corresponds to unit "raid"..i
+            -- (same mapping SecureGroupHeaders.lua uses for RAID-kind units).
+            local name = GetRaidRosterInfo(i)
+            -- issecretvalue first: comparing/testing a secret value crashes.
+            if issecretvalue(name) or not name or name == UNKNOWNOBJECT then
                 complete = false
             else
-                local fullName = name
-                if realm and realm ~= "" then
-                    fullName = name .. "-" .. realm
-                end
                 table.insert(members, {
                     unit = unit,
-                    name = fullName,
+                    name = name,
                     isPlayer = UnitIsUnit(unit, "player")
                 })
             end
@@ -8876,6 +8899,10 @@ headerChildEventFrame:SetScript("OnEvent", function(self, event, arg1)
             -- churn on routine name updates.
             if arenaNameListIncomplete and unit:match("^raid%d")
                 and DF.GetContentType and DF:GetContentType() == "arena" then
+                -- A real name-resolution signal: re-arm the safety cap so a
+                -- player who loads in slower than the retry window (~12s)
+                -- still gets re-sorted instead of staying in INDEX order.
+                arenaSortRetryCount = 0
                 ScheduleArenaSortRetry()
             end
         end


### PR DESCRIPTION
**Live + alpha reports:** in non-rated arenas, zoning in early and having the last teammate join a bit later leaves their frame missing for the whole round (joining last yourself is always fine); often described as "first round of every arena, 1-2 players missing", and a mid-match `/reload` can leave the sort wrong afterwards.

**Root cause:** with sorting on and Self Position First/Last (the default), the arena header runs in **NAMELIST** mode. A teammate can *exist* before their name *resolves* (`UnitName` returns nil/`UNKNOWNOBJECT` while they load in — exactly the trickle-in pattern of non-rated queues). A nameList built in that window omits or mis-names them, so the secure header filters their frame out — and nothing repairs it: name resolution fires no `GROUP_ROSTER_UPDATE`, and once the gates open, combat blocks header attribute writes for the rest of the round. Joining last is fine because everyone else's names resolved long ago; solo shuffle is unaffected because FrameSort owns arena sorting when active.

**Fix:**
- `BuildArenaNameList` now reports completeness; an unresolved member is omitted rather than added as a literal "Unknown" (which could never match their real name).
- On an incomplete build, `ApplyArenaHeaderSorting` shows **everyone in INDEX order** instead of applying a filtering nameList — unsorted beats missing — and a capped 0.5s retry loop re-sorts once names resolve. `UNIT_NAME_UPDATE` nudges the retry too (gated on the incomplete flag), with the timer as primary since that event is unreliable.
- `ApplyArenaHeaderSorting`'s combat early-return now queues `pendingSortingUpdate` instead of silently dropping — an arena round's combat lasts minutes, so e.g. a post-`/reload` apply mid-round previously vanished, leaving the header unsorted (the "sort is screwed after reloading" half of the report).

Worst case under the fix is a few seconds of unsorted-but-complete frames during prep, then correct sorting.