### PR TITLE
Arena: stop early GetContentType calls from destroying the reload hint

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2900,7 +2900,18 @@ function DF:GetContentType()
         DF.cachedContentType = "arena"
         return "arena"
     end
-    
+
+    -- ARENA RELOAD FIX: snapshot the saved content-type hint ONCE, before any
+    -- detection branch below can overwrite it. Early calls (e.g.
+    -- FinalizeHeaderInit → UpdateHeaderVisibility at ADDON_LOADED on a reload)
+    -- run while IsInInstance()/IsInRaid() may still be unreliable; without the
+    -- snapshot, those calls wiped DandersFramesCharDB.lastContentType (or
+    -- overwrote it with "openWorld") before the reload fallback could use it.
+    if not DF._contentTypeHintCaptured and DandersFramesCharDB then
+        DF._contentTypeHintCaptured = true
+        DF._contentTypeHintAtLoad = DandersFramesCharDB.lastContentType
+    end
+
     local inInstance, instanceType = IsInInstance()
     
     -- Cache instance type for other uses
@@ -2929,7 +2940,7 @@ function DF:GetContentType()
         -- before the reload. Only trust "arena" — other types recover fine on their own.
         if DF.useContentTypeFallback and not inInstance
            and (instanceType == "none" or instanceType == nil)
-           and DandersFramesCharDB and DandersFramesCharDB.lastContentType == "arena" then
+           and DF._contentTypeHintAtLoad == "arena" then
             DF.cachedContentType = "arena"
             return "arena"
         end
@@ -2957,6 +2968,18 @@ function DF:GetContentType()
     
     -- In a raid group but not in an instance = open world (world boss, etc.)
     if IsInRaid() then
+        -- ARENA RELOAD FIX (part 2): IsInRaid() can recover before
+        -- IsInInstance() after a reload in arena (arena groups ARE raid
+        -- groups). Without this, the not-yet-recovered instanceType made us
+        -- conclude "openWorld" — showing raid frames over the arena header
+        -- and overwriting the saved arena hint.
+        if DF.useContentTypeFallback and not inInstance
+           and (instanceType == "none" or instanceType == nil)
+           and DF._contentTypeHintAtLoad == "arena" then
+            DF.cachedContentType = "arena"
+            return "arena"
+        end
+
         DF.cachedContentType = "openWorld"
         DF.useContentTypeFallback = nil
         if DandersFramesCharDB then DandersFramesCharDB.lastContentType = "openWorld" end
@@ -3334,6 +3357,26 @@ DF._MainEventDispatcher = function(self, event, arg1)
         
         -- Ensure structure exists in per-character DB
         if DandersFramesCharDB.specProfiles == nil then DandersFramesCharDB.specProfiles = {} end
+
+        -- ARENA RELOAD FIX: snapshot the saved content-type hint before any
+        -- GetContentType call can overwrite it (GetContentType also
+        -- self-captures; this pins the earliest possible point), and arm the
+        -- fallback NOW on a /reload — the player only already exists at
+        -- ADDON_LOADED on a reload (same detection Headers.lua uses for the
+        -- combat-safe finalize). PLAYER_ENTERING_WORLD also arms it
+        -- (isReloadingUi), but that's too late for the FinalizeHeaderInit →
+        -- UpdateHeaderVisibility call that runs inside the ADDON_LOADED
+        -- combat-safe window on a combat reload in arena.
+        -- Fresh logins must NOT arm it: a stale "arena" hint from a previous
+        -- session would misclassify the login zone (the fallback only clears
+        -- once real detection returns a definite answer).
+        if not DF._contentTypeHintCaptured then
+            DF._contentTypeHintCaptured = true
+            DF._contentTypeHintAtLoad = DandersFramesCharDB.lastContentType
+        end
+        if UnitExists("player") then
+            DF.useContentTypeFallback = true
+        end
 
         -- Language override lives per-character because the locale files
         -- need to read it at file-load time, before any profile resolution


### PR DESCRIPTION
## Problem

The existing ARENA RELOAD FIX (trust the saved `lastContentType` hint while `IsInInstance()` recovers after a reload) was being defeated by its own neighbours, leaving the arena header hidden after a reload in arena — worst case on a **combat reload mid-round**, where the frames could stay hidden until the round ended.

Sequence:

1. On a reload, `FinalizeHeaderInit` → `UpdateHeaderVisibility` calls `GetContentType()` at **ADDON_LOADED** — before PLAYER_ENTERING_WORLD arms `useContentTypeFallback`.
2. If WoW's APIs aren't ready yet, that early call either **nils `DandersFramesCharDB.lastContentType`** (not-in-raid branch) or **overwrites it with "openWorld"** (in-raid + instanceType "none" — arena groups are raid groups, and `IsInRaid()` can recover before `IsInInstance()`).
3. By the time PEW arms the fallback, the hint it relies on is gone.

Out of combat, the ArenaDetectionRetry / ARENA_PREP backups recover. Mid-combat they can't (secure Show is blocked), so the one window that *can* fix it — the combat-safe ADDON_LOADED window the addon already uses for combat reloads — ran with a wrong content type.

## Fix

- **Snapshot the hint once at load** (`DF._contentTypeHintAtLoad`, captured in Core's ADDON_LOADED handler plus a self-capture in `GetContentType` for ordering safety) and read the fallback from the snapshot, so later live-field writes can't destroy it.
- **Arm the fallback at ADDON_LOADED on a /reload** (player already exists at ADDON_LOADED only on a reload — same detection the header init uses), so the combat-safe `FinalizeHeaderInit` window already resolves "arena" and can show the arena header. Fresh logins still never arm it: a stale "arena" hint from a previous session would misclassify the login zone, and the fallback only clears once real detection returns a definite answer.
- **Extend the fallback to the `IsInRaid()==true` + instanceType "none" case**, which previously classified an arena reload as "openWorld" and showed raid frames over the arena header.

No behaviour change outside the reload-recovery window: the first confident `IsInInstance()`/roster read clears the fallback and resumes normal detection, exactly as before.

## Testing

- Structural syntax check passes; fallback/branch logic traced against all four entry orderings (ADDON_LOADED vs PEW, in/out of combat).
- /reload in arena prep and mid-round: header visibility + sorting recover via the armed fallback instead of waiting for ArenaDetectionRetry.
