### PR TITLE
Flat raid: roster-sourced nameLists (missing frames for loading players)

### DIFF
--- a/Features/FlatRaidFrames.lua
+++ b/Features/FlatRaidFrames.lua
@@ -270,30 +270,35 @@ function FlatRaidFrames:BuildSortedNameList()
     
     -- Gather all raid members with their info
     local members = {}
-    local playerName = UnitName("player")
-    local playerRealm = GetRealmName()
     local playerEntry = nil
-    
+
+    -- Secret-safe predicate (issecretvalue may not exist on older clients).
+    -- Hoisted above the member loop: roster names are checked here too.
+    local issecretvalue = issecretvalue or function() return false end
+
     for i = 1, numMembers do
         local unit = "raid" .. i
-        local name, realm = UnitName(unit)
-        
-        if name then
+        -- Name comes from GetRaidRosterInfo, NOT UnitName: for raid-kind
+        -- units, SecureGroupHeaderTemplate matches nameList tokens against
+        -- GetRaidRosterInfo names (already realm-qualified for cross-realm),
+        -- and the roster usually knows a member's name BEFORE their player
+        -- object loads (UnitName returns UNKNOWNOBJECT while they're loading
+        -- in — e.g. a BG backfill joining mid-match). Building from UnitName
+        -- inserted a literal "Unknown" token that never matches anything,
+        -- hiding that frame until the next out-of-combat rebuild. A member
+        -- the roster can't name yet is skipped instead: the secure header
+        -- hides a nil-roster-name unit in EVERY mode anyway, and the roster
+        -- filling in fires GROUP_ROSTER_UPDATE, which rebuilds this list.
+        -- (issecretvalue first: comparing/testing a secret value crashes.)
+        local fullName, _, subgroup = GetRaidRosterInfo(i)
+
+        if not issecretvalue(fullName) and fullName and fullName ~= UNKNOWNOBJECT then
             -- Filter by group visibility
-            local _, _, subgroup = GetRaidRosterInfo(i)
             if subgroup and db.raidGroupVisible and db.raidGroupVisible[subgroup] == false then
                 -- Skip members in hidden groups
             else
-            -- Build full name with realm for nameList
-            -- Only append realm for cross-realm players (when realm is returned)
-            -- Same-server players should use just the name (matches SecureGroupHeaderTemplate behavior)
-            local fullName
-            if realm and realm ~= "" then
-                fullName = name .. "-" .. realm
-            else
-                fullName = name
-            end
-            
+            local name = fullName:match("([^%-]+)") or fullName
+
             local role = UnitGroupRolesAssigned(unit)
             if role == "NONE" then role = "DAMAGER" end
             
@@ -314,7 +319,6 @@ function FlatRaidFrames:BuildSortedNameList()
             local entry = {
                 name = name,
                 fullName = fullName,
-                realm = realm or playerRealm,
                 role = role,
                 sortRole = sortRole,
                 class = class,
@@ -337,7 +341,6 @@ function FlatRaidFrames:BuildSortedNameList()
     -- combat (Midnight), and even ~= on a secret string throws. A secret (or
     -- missing) name falls back to the unit token — plain and unique. Pure
     -- per-element substitution keeps the comparator a consistent total order.
-    local issecretvalue = issecretvalue or function() return false end
     local function NameKey(m)
         local n = m.name
         if n == nil or issecretvalue(n) then return tostring(m.unit) end

--- a/Features/FrameSort.lua
+++ b/Features/FrameSort.lua
@@ -56,11 +56,29 @@ end
 local function UnitsToNameList(units)
     wipe(namesBuf)
     for i = 1, #units do
-        local name = GetUnitName(units[i], true)
+        local unit = units[i]
+        local name
+        local raidIndex = unit:match("^raid(%d+)$")
+        if raidIndex then
+            -- Raid-kind headers match nameList tokens against GetRaidRosterInfo
+            -- names (realm-qualified), and the roster usually knows a member's
+            -- name BEFORE their player object loads (GetUnitName returns
+            -- "Unknown" while they're loading — e.g. a BG backfill). A literal
+            -- "Unknown" token never matches, hiding that frame; a member the
+            -- roster can't name yet is dropped instead — the secure header
+            -- hides a nil-roster-name unit in every mode anyway, and the
+            -- roster filling in fires a roster event that re-sorts.
+            name = GetRaidRosterInfo(tonumber(raidIndex))
+            if not issecretvalue(name) and name == UNKNOWNOBJECT then
+                name = nil
+            end
+        else
+            name = GetUnitName(unit, true)
+        end
         -- Skip nil and secret values (Midnight 12.0 returns opaque secret strings
         -- for some unit names in instanced content; type() == "string" is not
         -- sufficient — secret values pass that check but crash table.concat).
-        if name and not issecretvalue(name) then
+        if not issecretvalue(name) and name then
             namesBuf[#namesBuf + 1] = name
         end
     end


### PR DESCRIPTION
## Problem

The flat raid layout (raids + battlegrounds) builds its secure-header `nameList` from `UnitName`, with no UNKNOWNOBJECT guard. A still-loading player — e.g. a battleground backfill joining mid-match — returns "Unknown" from `UnitName`, which gets inserted as a literal token that never matches the secure header's roster lookup, so that player's frame stays hidden until the next out-of-combat rebuild (which mid-BG can be minutes away).

This is the same bug class as the arena late-join fix (#155), at 40-player BG scale.

## Fix

`FlatRaidFrames:BuildSortedNameList` now sources names from `GetRaidRosterInfo` — the exact strings `SecureGroupHeaderTemplate` matches raid-kind `nameList` tokens against (realm-qualified, and usually resolved before the player object loads). It was already calling `GetRaidRosterInfo(i)` on the adjacent line for the subgroup filter, so the name is taken from that same call.

A member the roster genuinely can't name yet is skipped rather than inserted as "Unknown": the secure header hides a nil-roster-name unit in every mode anyway, and the roster filling in fires `GROUP_ROSTER_UPDATE`, which rebuilds the list.

The FrameSort integration's flat-raid sorter had the same pattern via `GetUnitName`; `UnitsToNameList` now resolves raid unit tokens through `GetRaidRosterInfo` too. Party tokens keep `GetUnitName` — party-kind headers match `UnitName`-derived names, so that source is correct there.

## Testing

- Structural syntax check passes.
- Verified against Blizzard's `SecureGroupHeaders.lua` (raid-kind headers match `GetRaidRosterInfo` names).
