### PR TITLE
Aura Designer: text-only icons never draw a border (static or expiring)

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -2334,6 +2334,12 @@ function Indicators:ConfigureIcon(frame, config, defaults, auraName, priority)
     -- (spec.size = thickness + inset, spec.inset = -inset).
     -- Also store the base BorderColor so applyState can fall back to it when
     -- thickness/alpha overrides are configured without a colour override.
+    -- Base border ENABLED state for the expiring callback (ADApplyExpiringBorderState
+    -- reads dfAD_baseBorderEnabled ~= false). Without this it was nil → treated as
+    -- enabled, so an expiring border drew even with Show Border off OR in hide-icon
+    -- (text-only) mode. Mirror the square path: gate on both ShowBorder and hideIcon
+    -- so text-only icons never draw a static OR expiring border.
+    icon.dfAD_baseBorderEnabled    = borderEnabled and not hideIcon
     icon.dfAD_baseBorderSize       = borderThickness
     icon.dfAD_baseBorderInset      = borderInset
     icon.dfAD_baseBorderColor      = spec.color

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3163,7 +3163,9 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     colorOverride = true,
                     dualColor     = opts.dualColor,
                     alpha         = true,
-                    thickness     = true, thicknessMin = 0, thicknessMax = opts.thicknessMax or 5,
+                    -- Text-only icons draw no border, so hide the expiring-border
+                    -- thickness control there (other types: proxy.hideIcon is false).
+                    thickness     = not proxy.hideIcon, thicknessMin = 0, thicknessMax = opts.thicknessMax or 5,
                     animation     = true,
                     iconEffects   = opts.iconEffects,
                     tint          = true,  -- secret-safe; works on all auras
@@ -3195,7 +3197,14 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
             g:AddWidget(GUI:CreateSlider(parent, L["Frame Level"], -10, 30, 1, proxy, "frameLevel"), 54)
             g:AddWidget(GUI:CreateDropdown(parent, L["Frame Strata"], FRAME_STRATA_OPTIONS, proxy, "frameStrata"), 54)
             g:AddWidget(GUI:CreateCheckbox(parent, L["Hide Cooldown Swipe"], proxy, "hideSwipe"), 28)
-            g:AddWidget(GUI:CreateCheckbox(parent, L["Hide Icon (Text Only)"], proxy, "hideIcon"), 28)
+            -- Text-only mode: the icon TEXTURE is hidden, so a border (static OR
+            -- expiring) would frame nothing. Rebuild the page on toggle so the
+            -- Border group + the expiring-border thickness control hide/show
+            -- (gated on proxy.hideIcon below) — matching the runtime, which
+            -- force-disables both borders in this mode.
+            g:AddWidget(GUI:CreateCheckbox(parent, L["Hide Icon (Text Only)"], proxy, "hideIcon", function()
+                DF:AuraDesigner_RefreshPage()
+            end), 28)
         end)
         -- Show When Missing
         AddGroup(L["Show When Missing"], function(g)
@@ -3221,6 +3230,9 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
         -- indicators (the indicator's job is to show aura state, not unit
         -- identity), and AD's Expiring section already covers "colour by
         -- time remaining" implicitly through its own colour curve.
+        -- Text-only mode hides the icon texture, so the whole Border group is
+        -- hidden (the runtime force-disables the border there too).
+        if not proxy.hideIcon then
         AddGroup(L["Border"], function(g)
             GUI:CreateBorderControls(g, proxy, "", {
                 parent  = parent,
@@ -3265,6 +3277,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 sizeMin = 1, sizeMax = 5, sizeStep = 1,
             })
         end)
+        end  -- if not proxy.hideIcon (text-only hides the Border group)
         -- Expiring (moved up next to Border — the border's expiring colour and
         -- the per-icon effects all key off the same threshold, so grouping
         -- them adjacent reads more naturally than burying Expiring at the

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3169,7 +3169,9 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     dualColor     = opts.dualColor,
                     alpha         = not proxy.hideIcon,
                     thickness     = not proxy.hideIcon, thicknessMin = 0, thicknessMax = opts.thicknessMax or 5,
-                    animation     = true,
+                    -- Animation rides the border, which text-only icons don't draw,
+                    -- so hide it there too (no border = nowhere for the glow to attach).
+                    animation     = not proxy.hideIcon,
                     iconEffects   = opts.iconEffects,
                     tint          = true,  -- secret-safe; works on all auras
                 },

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3160,11 +3160,14 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 },
                 include = {
                     threshold     = true,
-                    colorOverride = true,
+                    -- Border-specific expiring overrides (colour override + its
+                    -- border colour/alpha, and thickness) are hidden for text-only
+                    -- icons, which draw no border. Threshold, animation, tint and
+                    -- the whole-frame icon effects still apply. (Other types:
+                    -- proxy.hideIcon is false, so these stay on.)
+                    colorOverride = not proxy.hideIcon,
                     dualColor     = opts.dualColor,
-                    alpha         = true,
-                    -- Text-only icons draw no border, so hide the expiring-border
-                    -- thickness control there (other types: proxy.hideIcon is false).
+                    alpha         = not proxy.hideIcon,
                     thickness     = not proxy.hideIcon, thicknessMin = 0, thicknessMax = opts.thicknessMax or 5,
                     animation     = true,
                     iconEffects   = opts.iconEffects,


### PR DESCRIPTION
## Problem

For an Aura Designer **icon** in **Hide Icon (Text Only)** mode, borders didn't behave as expected after the unified-border rework:

- "Show Border, thickness 1" → no border (the static border is intentionally disabled in text-only mode).
- "Border off, expiring border thickness 2" → a border drew **even when not expiring**, and got thicker during expiration.

## Root cause

The static border is correctly gated off in text-only mode (`spec.enabled = borderEnabled and not hideIcon`), but the **icon path never recorded `dfAD_baseBorderEnabled`**. The expiring-border applier reads:

```lua
enabled = el.dfAD_baseBorderEnabled ~= false
```

With `nil`, `nil ~= false` is **true**, so the expiring tick re-enabled the border — ignoring both *Show Border = off* and *hide-icon*. The **square** path sets this field; the icon path didn't. (Thickness 1 looked fine only because an expiring thickness equal to the base never registers an expiring override, so nothing ran.)

Bars use a colour-curve path plus a static border apply, so they were never affected.

## Fix

- **Runtime:** the icon path now sets `dfAD_baseBorderEnabled = borderEnabled and not hideIcon`, mirroring the square — so the expiring border respects both *Show Border* and *hide-icon*. Text-only icons now draw no border, static or expiring.
- **Options:** in text-only mode the **Border** group is hidden, and the border-only **Expiring** controls — Colour Override, Border Colour, Border Alpha, thickness, and the Animation dropdown — are hidden too (the page rebuilds on the Hide Icon toggle). The genuinely-applicable expiring controls (threshold, tint, whole-frame icon effects) stay. This matches the runtime, which can't draw a border there.

## Notes

- The expiring **animation** (a LibCustomGlow effect) attaches to the border, which text-only icons don't draw, so it's hidden rather than wired to run borderless — a borderless-glow option can come later if wanted.
- Structural syntax checks pass; squares/bars unaffected.
