### PR TITLE
Border insets: preserve the pre-rework look (AD icon/square + buff/debuff)

### DIFF
--- a/Changelog.lua
+++ b/Changelog.lua
@@ -59,6 +59,8 @@ DF.CHANGELOG_TEXT = [===[
 * (Defensive Icon) The defensive cooldown icon and its border now render **above auras**. (by Krathe)
 * (Role Icons) **Show Tank / Healer / DPS** toggles now apply live without a `/reload`. (by Krathe)
 * (Aura Designer) Indicators are torn down when the Aura Designer is disabled, and re-applied on **profile swap**. (by Krathe)
+* (Aura Designer) Aura icon/square borders from older profiles **keep their original look** after the unified-border update, instead of appearing thinner or floating in a gap. (by Krathe)
+* (Buff/Debuff) Icon borders from older profiles no longer **float in a gap** around the icon after the unified-border update — they hug the icon as before. (by Krathe)
 * (Targeted Spells) The targeted list no longer appears in **test mode** when the feature is disabled. (by Krathe)
 * (Aura Designer) Replace-mode health-bar highlight fixes — no more **flicker** on phased or out-of-range units, no **bleeding over the frame border**, and the expiring **Pulsate** option now works. (by Krathe)
 * (Test Mode) Replaced several test-mode buff/debuff preview icons that pointed at art removed in Midnight, so they no longer render blank. (by Krathe)

--- a/Core.lua
+++ b/Core.lua
@@ -3292,6 +3292,151 @@ function DF:MigrateAuraBorderKeys(modeDb)
     end
 end
 
+-- ============================================================
+-- BORDER INSET FOLD / ZERO  (appearance-preserving migration)
+--
+-- The unified-border rework changed two border families' inset semantics, so
+-- older profiles render oddly under the new (correct) offset model. One-time,
+-- per-profile guarded; rewrites the stored values to keep the pre-rework look.
+--
+-- 1) AURA DESIGNER icon/square (_borderInsetFoldV1): old visible band was
+--    BorderSize + BorderInset (inset EXTENDED the band, straddling the edge);
+--    new = BorderSize alone, inset a pure outward offset (spec.inset =
+--    -BorderInset), so a stored inset now floats the band in a gap. Fold the
+--    inset back into size (BorderSize += BorderInset, likewise
+--    ExpiringBorderSize; BorderInset = 0), clamped to the slider cap. No-op at 0.
+--
+-- 2) BUFF/DEBUFF icons (_buffDebuffInsetZeroV1): changed the OPPOSITE way — old
+--    band = 2*thickness - inset (inset REDUCED width, hugging the edge); new =
+--    the same icon-mode model, so the stored inset floats it in a gap. Fix is to
+--    ZERO the inset, written EXPLICITLY (the render falls back to the legacy
+--    `or 1` when the key is absent, which would keep the gap), and stripped from
+--    raid auto-layout overrides so each layout inherits the zeroed base.
+--
+-- Iterates the raw SavedVariables profiles directly (never the WrapDB proxy).
+-- The preset-library walk is nil-guarded, so this is correct with or without
+-- the Designer Presets feature present.
+-- ============================================================
+local AD_BORDER_SIZE_MAX = 5   -- AD border-size slider cap (AuraDesigner/Options.lua)
+
+local function FoldIndicatorBorderInset(ind, seen)
+    if type(ind) ~= "table" then return end
+    if seen[ind] then return end       -- a materialised inline config and its
+    seen[ind] = true                   -- library copy may share this table ref
+    local t = ind.type
+    if t ~= "icon" and t ~= "square" then return end
+    local inset = ind.BorderInset or ind.borderInset
+    if not inset or inset == 0 then
+        -- Nothing to fold; drop any lingering legacy inset key so a render
+        -- fallback can't later resurrect a stale value.
+        ind.borderInset = nil
+        return
+    end
+    local function foldSize(v)
+        local folded = (v or 1) + inset
+        if folded < 0 then folded = 0 end
+        if folded > AD_BORDER_SIZE_MAX then folded = AD_BORDER_SIZE_MAX end
+        return folded
+    end
+    ind.BorderSize = foldSize(ind.BorderSize or ind.borderThickness)
+    if ind.ExpiringBorderSize then
+        ind.ExpiringBorderSize = foldSize(ind.ExpiringBorderSize)
+    end
+    ind.BorderInset = 0
+    -- Clear legacy duplicates so the render fallback can't reintroduce pre-fold
+    -- geometry.
+    ind.borderThickness = nil
+    ind.borderInset = nil
+end
+
+local function FoldAuraDesignerConfig(cfg, seen)
+    if type(cfg) ~= "table" or type(cfg.auras) ~= "table" then return end
+    for _, entry in pairs(cfg.auras) do
+        if type(entry) == "table" then
+            if entry.indicators then
+                -- Flat (V1) shape: auras[auraName] = auraCfg
+                for _, ind in ipairs(entry.indicators) do
+                    FoldIndicatorBorderInset(ind, seen)
+                end
+            else
+                -- Per-spec shape: auras[spec][auraName] = auraCfg
+                for _, auraCfg in pairs(entry) do
+                    if type(auraCfg) == "table" and type(auraCfg.indicators) == "table" then
+                        for _, ind in ipairs(auraCfg.indicators) do
+                            FoldIndicatorBorderInset(ind, seen)
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- Write 0 EXPLICITLY (don't just leave absent): the render falls back to the
+-- legacy `or 1` when the key is missing (Update.lua), which would keep the gap.
+local function ZeroBuffDebuffBorderInset(profile)
+    for _, modeKey in ipairs({ "party", "raid" }) do
+        local mode = profile[modeKey]
+        if type(mode) == "table" then
+            mode.buffBorderInset = 0
+            mode.debuffBorderInset = 0
+        end
+    end
+    -- Raid auto-layout overrides: strip the inset keys so each layout inherits
+    -- the now-zeroed base (mirrors CleanupLegacyTextLayoutOverrides' traversal).
+    -- Pinned sets don't override buff/debuff keys, so they inherit the base.
+    local autoDb = profile.raidAutoProfiles
+    if type(autoDb) == "table" then
+        local function stripLayout(layout)
+            local ov = layout and layout.overrides
+            if type(ov) ~= "table" then return end
+            ov.buffBorderInset = nil
+            ov.debuffBorderInset = nil
+        end
+        for _, ctKey in ipairs({ "instanced", "openWorld" }) do
+            local ct = autoDb[ctKey]
+            if type(ct) == "table" and type(ct.profiles) == "table" then
+                for _, layout in pairs(ct.profiles) do stripLayout(layout) end
+            end
+        end
+        if type(autoDb.mythic) == "table" then stripLayout(autoDb.mythic.profile) end
+    end
+end
+
+-- One-shot per-profile, two independently-guarded steps so a profile already
+-- through step 1 still receives step 2. Both steps are value-idempotent.
+function DF:MigrateBorderInsetFold()
+    if not DandersFramesDB_v2 or not DandersFramesDB_v2.profiles then return end
+    for _, profile in pairs(DandersFramesDB_v2.profiles) do
+        if type(profile) == "table" then
+            -- Step 1: AD icon/square fold (preset libraries + inline configs).
+            if not profile._borderInsetFoldV1 then
+                local seen = {}
+                -- Canonical store when Designer Presets exist (nil-guarded so this
+                -- stays correct where they don't).
+                local lib = profile.auraDesignerPresets
+                if type(lib) == "table" then
+                    for _, presetCfg in pairs(lib) do
+                        FoldAuraDesignerConfig(presetCfg, seen)
+                    end
+                end
+                if type(profile.party) == "table" then
+                    FoldAuraDesignerConfig(profile.party.auraDesigner, seen)
+                end
+                if type(profile.raid) == "table" then
+                    FoldAuraDesignerConfig(profile.raid.auraDesigner, seen)
+                end
+                profile._borderInsetFoldV1 = true
+            end
+            -- Step 2: zero buff/debuff border inset (mode-level + raid overrides).
+            if not profile._buffDebuffInsetZeroV1 then
+                ZeroBuffDebuffBorderInset(profile)
+                profile._buffDebuffInsetZeroV1 = true
+            end
+        end
+    end
+end
+
 -- The handler body is stored on DF as _MainEventDispatcher so the profiler
 -- can swap it for an instrumented version at runtime. The frame's actual
 -- script is a thin trampoline that calls through DF — re-binding takes
@@ -5004,6 +5149,14 @@ DF._MainEventDispatcher = function(self, event, arg1)
             -- TD owns the built-in text (gated on migratedFromLegacy inside).
             if DF.CleanupLegacyTextLayoutOverrides then
                 DF:CleanupLegacyTextLayoutOverrides()
+            end
+
+            -- Appearance-preserving border migration: fold AD icon/square inset
+            -- into BorderSize and zero buff/debuff inset so the unified-border
+            -- rework keeps the pre-rework look. Per-profile guarded (no-op once
+            -- run); independent of Designer Presets (preset walk is nil-guarded).
+            if DF.MigrateBorderInsetFold then
+                DF:MigrateBorderInsetFold()
             end
 
             -- CRITICAL: Update power bars now that unit data is available

--- a/Profile.lua
+++ b/Profile.lua
@@ -292,6 +292,11 @@ function DF:SetProfile(name)
         DF:CleanupLegacyTextLayoutOverrides()
     end
 
+    -- Appearance-preserving border migration (per-profile guarded, no-op once run).
+    if DF.MigrateBorderInsetFold then
+        DF:MigrateBorderInsetFold()
+    end
+
     -- Apply the profile — runtime state is already clear so the proxy reads
     -- the new profile directly with no stale overlay
     DF:FullProfileRefresh()
@@ -820,6 +825,17 @@ function DF:ApplyImportedProfile(importData, selectedCategories, selectedFrameTy
         end
     end
 
+    -- Fold/zero border insets on the just-imported configs (pre-rework look).
+    -- Clear the active profile's guards so the imported data is re-scanned; the
+    -- steps are value-idempotent, so already-migrated entries are untouched.
+    if DF.MigrateBorderInsetFold then
+        if DF.db then
+            DF.db._borderInsetFoldV1 = nil
+            DF.db._buffDebuffInsetZeroV1 = nil
+        end
+        DF:MigrateBorderInsetFold()
+    end
+
     -- Force DIRECT aura source mode — imported profiles may have BLIZZARD
     -- which is no longer supported.
     if DF.db.party then DF.db.party.auraSourceMode = "DIRECT" end
@@ -860,6 +876,16 @@ function DF:ImportProfile(str)
         if ResetTDForLegacyImport({ party = newProfile.party, raid = newProfile.raid }) then
             DF:MigrateTextDesignerFromLegacy()
         end
+    end
+
+    -- Fold/zero border insets on the just-imported configs (pre-rework look);
+    -- value-idempotent, so clearing the guards only re-scans the imported data.
+    if DF.MigrateBorderInsetFold then
+        if DF.db then
+            DF.db._borderInsetFoldV1 = nil
+            DF.db._buffDebuffInsetZeroV1 = nil
+        end
+        DF:MigrateBorderInsetFold()
     end
 
     -- Force DIRECT aura source mode — imported profiles may have BLIZZARD


### PR DESCRIPTION
## Problem

Since the unified-border rework, users on older profiles report borders that "look odd" — thinner than before, or floating in a small gap around the icon. This is a one-time data issue: the rework changed what a stored **Border Inset** *means*, but existing saved values were written under the old meaning.

Two border families changed in **opposite** directions:

- **Aura Designer icon/square** — pre-rework the visible band was `BorderSize + BorderInset` (the inset *extended* the band, straddling the icon edge). Post-rework `BorderSize` is the band thickness on its own and `BorderInset` is a pure outward offset, so a stored inset now renders a thinner band floating in a gap.
- **Buff/Debuff icons** — pre-rework the band was `2*thickness − inset` (the inset *reduced* width, hugging the edge). Post-rework they use the same icon-mode model, so the stored inset now floats the band in a gap.

## Fix

A one-time, per-profile-guarded migration in a new self-contained `BorderInsetMigration.lua`:

- **AD icon/square** (`_borderInsetFoldV1`): fold the inset back into size — `BorderSize += BorderInset` (and `ExpiringBorderSize` likewise), `BorderInset = 0`, clamped to the size slider cap (5). No-op when the inset is already 0.
- **Buff/Debuff** (`_buffDebuffInsetZeroV1`): zero the inset (the opposite of folding, since here the inset *reduced* width) — written explicitly on the base party/raid keys (the render falls back to the legacy `or 1` when the key is absent, which would otherwise keep the gap), and stripped from raid auto-layout overrides so each layout inherits the zeroed base.

Two independent guards so a profile that's been through one step still gets the other; both steps are value-idempotent. Hooked after the existing Text Designer legacy migration at login, on profile switch, and on import.

## Scope / safety

- Only AD icon/square and buff/debuff borders are touched — every other border type either never changed or gained a brand-new inset key with nothing stored to migrate.
- Pure SavedVariables data migration (no API calls); iterates the raw profile tables directly.
- Self-contained: the preset-library walk is nil-guarded, so it runs correctly with or without the named-preset feature present.

## Notes

- Preserves the original band **weight** and removes the gap. For AD the restored band sits just inside the edge rather than straddling it (the new engine draws edge-bars, not a backing) — same visual weight; buff/debuff is pixel-identical at the default.
- Verified in-game on older profiles (AD + buff/debuff at default, and a raid auto-layout that overrode the buff/debuff inset).