### PR TITLE
Pinned frames: re-apply on zone-in so they show on BG/arena entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)
 * (Buff/Debuff) Icon borders from older profiles no longer float in a gap after the border rework — they hug the icon as before. (by Krathe)
+* (Pinned Frames) Pinned frames now reappear when you zone into a battleground or arena, instead of staying hidden until a `/reload`. (by Krathe)
 
 ## [4.4.1]
 

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -2446,6 +2446,7 @@ eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 eventFrame:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 eventFrame:RegisterEvent("UNIT_TARGETABLE_CHANGED")
 eventFrame:RegisterEvent("UNIT_FACTION")
+eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
 
 eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
     if event == "ADDON_LOADED" then
@@ -2555,6 +2556,37 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
         return
     end
     
+    if event == "PLAYER_ENTERING_WORLD" then
+        -- Re-apply pinned visibility on zone-in. The roster events that normally
+        -- drive the show path (SetEnabled) fire as you're added to the BG / arena
+        -- raid — often BEFORE the instance, its frames and roster names are ready,
+        -- and frequently in combat (where Reinitialize defers). Nothing re-drove
+        -- them once the instance settled, so pinned sets stayed hidden until a
+        -- manual disable/enable. PLAYER_ENTERING_WORLD is the "instance loaded"
+        -- trigger that was missing.
+        if PinnedFrames.initialized then
+            if InCombatLockdown() then
+                -- Drained on PLAYER_REGEN_ENABLED above (Reinitialize + ProcessAllSets).
+                PinnedFrames.pendingReinitialize = true
+            else
+                local actualMode = GetActualMode()
+                if PinnedFrames.currentMode and actualMode ~= PinnedFrames.currentMode then
+                    PinnedFrames:Reinitialize()
+                    PinnedFrames:ProcessAllSets()
+                else
+                    -- Re-assert each set's visibility (the show path) + re-populate
+                    -- now that the instance has settled. Debounced, combat-safe.
+                    for i = 1, PinnedFrames.MAX_SETS do
+                        local set = GetSetDB(i)
+                        if set then PinnedFrames:SetEnabled(i, set.enabled) end
+                    end
+                    PinnedFrames:RequestProcessAllSets()
+                end
+            end
+        end
+        return
+    end
+
     if event == "INSTANCE_ENCOUNTER_ENGAGE_UNIT" then
         if PinnedFrames.initialized then
             PinnedFrames:OnBossFramesChanged()


### PR DESCRIPTION
**Reported:** pinned frames often don't appear when entering a battleground/arena — the user has to open settings and disable+re-enable the set to make them show. (Confirmed not the *Disable in PvP* gate — that was off for the reporter.)

**Cause:** `PinnedFrames` never registered `PLAYER_ENTERING_WORLD`. The show path (`SetEnabled`) is normally driven by roster events, but on a BG/arena entry those fire *as you're added to the instance raid* — before the instance/frames/roster names are ready, and often in combat (where `Reinitialize` defers). With nothing re-driving it once the zone-in settled, the containers stayed hidden. The manual toggle only worked because it calls `SetEnabled` directly.

**Fix:** register `PLAYER_ENTERING_WORLD` and re-apply once the instance has settled — reinitialize on a party↔raid mode change, otherwise re-assert each set's visibility + a debounced `ProcessAllSets`. In combat, defer via the existing `pendingReinitialize` path (drained on `PLAYER_REGEN_ENABLED`).

Self-contained — one file, +32 lines.