### PR TITLE
Fix Show Buffs/Show Debuffs toggles not applying live until /reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)
 * (Buff/Debuff) Icon borders from older profiles no longer float in a gap after the border rework — they hug the icon as before. (by Krathe)
+* (Buff/Debuff) **Show Buffs / Show Debuffs** toggles now apply live without a `/reload` — already-shown auras hide or reappear immediately instead of lingering until the unit's next aura change. (by Krathe)
 
 ## [4.4.1]
 

--- a/Changelog.lua
+++ b/Changelog.lua
@@ -29,6 +29,7 @@ DF.CHANGELOG_TEXT = [===[
 * (Missing Buff) The missing-buff icon no longer flags a **cross-faction group member in the open world** as needing a buff you can't actually cast on them — it only appears where the buff is castable (e.g. inside instances). (by Krathe)
 * (Defensive Icon) The defensive cooldown icon and its border now render **above auras** and stay co-planar with the icon. (by Krathe)
 * (Role Icons) **Show Tank / Healer / DPS** toggles now apply live without a `/reload`, and are properly decoupled from the Hide-in-Combat gate. (by Krathe)
+* (Buff/Debuff) **Show Buffs / Show Debuffs** toggles now apply live without a `/reload` — already-shown auras hide or reappear immediately instead of lingering until the unit's next aura change. (by Krathe)
 * (Raid Frames) Fixed missing frames for players who are still loading in, such as battleground backfills joining mid-match. (by Krathe)
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)

--- a/Changelog.lua
+++ b/Changelog.lua
@@ -29,7 +29,6 @@ DF.CHANGELOG_TEXT = [===[
 * (Missing Buff) The missing-buff icon no longer flags a **cross-faction group member in the open world** as needing a buff you can't actually cast on them — it only appears where the buff is castable (e.g. inside instances). (by Krathe)
 * (Defensive Icon) The defensive cooldown icon and its border now render **above auras** and stay co-planar with the icon. (by Krathe)
 * (Role Icons) **Show Tank / Healer / DPS** toggles now apply live without a `/reload`, and are properly decoupled from the Hide-in-Combat gate. (by Krathe)
-* (Buff/Debuff) **Show Buffs / Show Debuffs** toggles now apply live without a `/reload` — already-shown auras hide or reappear immediately instead of lingering until the unit's next aura change. (by Krathe)
 * (Raid Frames) Fixed missing frames for players who are still loading in, such as battleground backfills joining mid-match. (by Krathe)
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -5831,7 +5831,11 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         settingsGroup:AddWidget(GUI:CreateHeader(self.child, L["Settings"]), 40)
         local showBuffsCb = settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Buffs"], db, "showBuffs", function()
             self:RefreshStates()
-            DF:UpdateAllFrames()
+            -- Re-scan auras on visible frames (not just layout): the show/hide gate
+            -- lives in the UNIT_AURA-driven UpdateAuras path, so UpdateAllFrames alone
+            -- (layout-only) leaves already-shown auras until the next aura event. Use
+            -- the same refresh the Max Buffs slider uses.
+            DF:RefreshAllVisibleFrames()
         end), 30)
         -- Re-sync checked state when value changes externally (e.g. AD banner click)
         showBuffsCb.refreshContent = function(self)
@@ -6040,7 +6044,9 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         settingsGroup:AddWidget(GUI:CreateHeader(self.child, L["Settings"]), 40)
         settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Show Debuffs"], db, "showDebuffs", function()
             self:RefreshStates()
-            DF:UpdateAllFrames()
+            -- See Show Buffs above: re-scan auras on visible frames so a static
+            -- debuff hides/shows immediately instead of waiting for the next aura event.
+            DF:RefreshAllVisibleFrames()
         end), 30)
         local dispelHighlight = settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Highlight Dispellable"], db, "dispellableHighlight", nil), 30)
         dispelHighlight.disableOn = function(d) return not d.showDebuffs end


### PR DESCRIPTION
## Summary
Toggling **Show Buffs** / **Show Debuffs** in settings didn't take effect on live frames immediately. The value saved correctly, but already-shown auras kept their previous shown/hidden state until a `/reload` or the unit's next aura event. (Test mode was unaffected — it redraws on the spot, which is why it was easy to miss.)

## Root cause
Both checkbox callbacks ran `self:RefreshStates()` + `DF:UpdateAllFrames()`. `UpdateAllFrames` only re-applies frame **layout** (`ApplyFrameLayout`) — its own comment notes that unit/aura data updates are left to `UNIT_*` events. The actual show/hide gate lives in `DF:UpdateAuras_Enhanced` (buffs/debuffs), which is **UNIT_AURA-driven** and never invoked by the toggle. So an already-applied aura kept its state until its unit fired the next `UNIT_AURA`. Buffs *looked* instant only because they churn constantly; a static debuff lingered until a `/reload`.

## Fix
Switch both callbacks to `DF:RefreshAllVisibleFrames()`, which re-runs the aura scan per visible frame (`RefreshLiveFrames` → `FullFrameRefresh` → `DF:UpdateAuras` → the gate). This is the **same refresh the adjacent Max Buffs / Max Debuffs sliders already use**, so it's an existing, proven path — not a new mechanism. It also handles test mode, making it a strict superset of the prior behaviour.

## Scope
- `Options/Options.lua` — two callbacks (Show Buffs, Show Debuffs).
- `Changelog.lua` — one Bug Fixes entry.

No data/persistence change; purely a live-refresh fix.