### PR TITLE
Personal Targeted Spells: honor raid vs party settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)
 * (Buff/Debuff) Icon borders from older profiles no longer float in a gap after the border rework — they hug the icon as before. (by Krathe)
+* (Personal Targeted Spells) The personal targeted-spell display now honours your **raid** and **party** settings separately — disabling it on the raid tab no longer leaves it showing in raid (the whole feature was reading the party settings, ignoring raid's enable / size / position / border). (by Krathe)
 
 ## [4.4.1]
 

--- a/Features/TargetedSpells.lua
+++ b/Features/TargetedSpells.lua
@@ -549,6 +549,14 @@ local function ShouldShowPersonalTargetedSpells(db)
     return true  -- Default to showing
 end
 
+-- Personal Targeted Spells is a player-screen overlay with per-mode settings, so
+-- resolve the ACTIVE mode's DB (raid while in a raid, else party). Without this the
+-- whole personal path read DF:GetDB() (party) and ignored the raid toggle/size/pos.
+-- The group-frame and Targeted List paths stay party-resolved by design.
+local function GetPersonalDB()
+    return IsInRaid() and DF:GetRaidDB() or DF:GetDB()
+end
+
 -- Check if a unit is valid for targeted spell tracking
 -- We ONLY track nameplate units - boss/arena/target/focus all have nameplates too
 -- so tracking them separately would cause duplicates
@@ -1754,7 +1762,7 @@ local function ProcessCastInternal(casterUnit, isChannel)
     end
 
     -- Create personal display icon (always, for every cast - use SetAlphaFromBoolean for visibility)
-    if ShouldShowPersonalTargetedSpells(db) then
+    if ShouldShowPersonalTargetedSpells(GetPersonalDB()) then
         -- Always show icon, let SetAlphaFromBoolean control visibility based on targeting
         DF:ShowPersonalTargetedSpellIcon(casterUnit, casterUnit, spellID, texture, durationObject, isChannel, startTime)
     end
@@ -1860,7 +1868,7 @@ local function HandleTargetChange(casterUnit)
     -- Check if this caster has an active cast we're tracking (by unit token)
     if not activeCasters[casterUnit] then return end
     
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
 
     -- Group-frame visibility update removed: see ProcessCastInternal note.
     -- We only update the personal display now (which uses "player" comparisons,
@@ -1935,8 +1943,8 @@ local function HandleCastStop(casterUnit, wasInterrupted)
     end)
     
     -- Also hide personal targeted spell icon for this caster
-    if db.personalTargetedSpellEnabled then
-        if wasInterrupted and db.personalTargetedSpellShowInterrupted then
+    if GetPersonalDB().personalTargetedSpellEnabled then
+        if wasInterrupted and GetPersonalDB().personalTargetedSpellShowInterrupted then
             -- Will show interrupted animation then hide
             DF:HidePersonalTargetedSpellIcon(casterUnit, false)
         else
@@ -2320,7 +2328,7 @@ end
 
 -- Calculate mover size based on settings
 local function GetPersonalMoverSize()
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local iconSize = db.personalTargetedSpellSize or 40
     local scale = db.personalTargetedSpellScale or 1.0
     local maxIcons = db.personalTargetedSpellMaxIcons or 5
@@ -2348,7 +2356,7 @@ end
 -- anchors to the container's CENTER) ends up in the right place, with the full
 -- block symmetrically centred on the saved (x, y).
 local function GetPersonalContainerPoint(x, y)
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local iconSize = db.personalTargetedSpellSize or 40
     local scale = db.personalTargetedSpellScale or 1.0
     local maxIcons = db.personalTargetedSpellMaxIcons or 5
@@ -2377,7 +2385,7 @@ end
 local function CreatePersonalContainer()
     if personalContainer then return personalContainer end
 
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local x = db.personalTargetedSpellX or 0
     local y = db.personalTargetedSpellY or -150
 
@@ -2522,7 +2530,7 @@ local function CreatePersonalIcon(index)
         -- Handle interrupted animation (needs to run every frame for smooth animation)
         if self.isInterrupted then
             self.interruptTimer = (self.interruptTimer or 0) + elapsed
-            local db = DF:GetDB()
+            local db = GetPersonalDB()
             local duration = db.personalTargetedSpellInterruptedDuration or 0.5
             
             if self.interruptTimer >= duration then
@@ -2738,7 +2746,7 @@ end
 
 -- Position personal icons
 local function PositionPersonalIcons()
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     if not personalContainer then return end
     
     local iconSize = db.personalTargetedSpellSize or 40
@@ -2816,7 +2824,7 @@ end
 
 -- Show a personal targeted spell icon
 function DF:ShowPersonalTargetedSpellIcon(casterUnit, casterKey, spellID, texture, durationObject, isChannel, startTime)
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     if not db.personalTargetedSpellEnabled then return end
     
     CreatePersonalContainer()
@@ -2894,7 +2902,7 @@ function DF:HidePersonalTargetedSpellIcon(casterKey, immediate, fromTimer)
     local icon = personalIcons[iconIndex]
     if not icon then return end
     
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     
     -- If already showing interrupt animation, only hide if timer completed (fromTimer=true)
     -- This prevents UNIT_SPELLCAST_STOP from hiding the icon during interrupt animation
@@ -2983,7 +2991,7 @@ end
 
 -- Update personal display position from settings
 function DF:UpdatePersonalTargetedSpellsPosition()
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local x = db.personalTargetedSpellX or 0
     local y = db.personalTargetedSpellY or -150
     local iconAlpha = db.personalTargetedSpellAlpha or 1.0
@@ -3060,7 +3068,7 @@ function DF:CreatePersonalTargetedSpellsMover()
         end
         self:StartMoving()
 
-        local db = DF:GetDB()
+        local db = GetPersonalDB()
         self:SetScript("OnUpdate", function()
             -- Update icons to follow mover during drag
             local screenWidth, screenHeight = GetScreenWidth(), GetScreenHeight()
@@ -3092,7 +3100,7 @@ function DF:CreatePersonalTargetedSpellsMover()
         local x = centerX - screenWidth / 2
         local y = centerY - screenHeight / 2
         
-        local db = DF:GetDB()
+        local db = GetPersonalDB()
         if db.snapToGrid and DF.gridFrame and DF.gridFrame:IsShown() then
             x, y = DF:SnapToGrid(x, y)
         end
@@ -3123,7 +3131,7 @@ function DF:ShowPersonalTargetedSpellsMover()
         DF:CreatePersonalTargetedSpellsMover()
     end
     
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local x = db.personalTargetedSpellX or 0
     local y = db.personalTargetedSpellY or -150
     
@@ -3146,7 +3154,7 @@ end
 
 -- Test mode support for personal targeted spells
 function DF:ShowTestPersonalTargetedSpells()
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     if not db.personalTargetedSpellEnabled then return end
     
     CreatePersonalContainer()
@@ -3256,7 +3264,7 @@ end
 -- Update test personal targeted spells (called when settings change)
 function DF:UpdateTestPersonalTargetedSpells()
     -- Update if mover is shown OR if in test mode with personal enabled
-    local db = DF:GetDB()
+    local db = GetPersonalDB()
     local moverShown = DF.personalTargetedSpellsMover and DF.personalTargetedSpellsMover:IsShown()
     -- Show personal targeted spells in test mode if personal is enabled (don't require testShowTargetedSpell)
     local inTestMode = (DF.testMode or DF.raidTestMode) and db.personalTargetedSpellEnabled
@@ -6263,7 +6271,7 @@ function DF:InitTargetedSpells()
     -- only manages the container/icons; the events that drive cast tracking
     -- are registered separately so personal display can run even when the
     -- group-frame feature is off or API-blocked.
-    if db.personalTargetedSpellEnabled then
+    if GetPersonalDB().personalTargetedSpellEnabled then
         DF:TogglePersonalTargetedSpells(true)
     end
 


### PR DESCRIPTION
**Bug:** with Personal Targeted Spells disabled on the **raid** tab (and enabled on party), the icon still showed in raid.

**Cause:** the entire personal-targeted runtime resolved its settings with `DF:GetDB()` (always the *party* DB) — the enable gate (`ProcessCastInternal`, `HandleTargetChange`, `HandleCastStop`, `InitTargetedSpells`) and every `Personal*` layout/show/border function. So in a raid it read the party enable toggle (and party size / position / border), ignoring the raid tab entirely. The feature stores settings per-mode (the options page is mode-split, and `NeedsCastEvents` already checks both `db.party` and `db.raid`), so the runtime was simply reading the wrong one.

**Fix:** added a small resolver

```lua
local function GetPersonalDB()
    return IsInRaid() and DF:GetRaidDB() or DF:GetDB()
end
```

and routed the personal-targeted path through it. The group-frame and Targeted List paths stay party-resolved by design (group targeted is party-only; the list is party-only).

Net effect: in raid it honors the raid tab (enable + size/position/border); in party, party.

_Note: touches `TargetedSpells.lua`, which #164 also edits — they don't appear to overlap on the same lines, but worth merging this after #164 to be safe. Not luac-verified (none available); validated in-game._