### PR TITLE
Aura Designer: Name/Health Text indicators work with the Text Designer

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1774,72 +1774,74 @@ end
 -- NAME TEXT COLOR
 -- ============================================================
 
+-- Shared driver for the "Name Text" / "Health Text" AD indicators. The legacy
+-- frame.nameText/healthText are retired (DF:IsLegacyTextHidden == true), so the
+-- visible text is the Text Designer's own FontStrings. We recolour those via the
+-- TD override channel (per category "name"/"health"), which survives TD's own
+-- re-renders. keyField is a per-frame slot holding a stable expiring-ticker key.
+local function ApplyDesignerTextColor(frame, config, auraData, category, keyField)
+    local Render = DF.TextDesigner and DF.TextDesigner.Render
+    if not Render then return end
+
+    local color = config.color
+    if not color then return end
+    local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
+
+    local expiringEnabled = config.expiringEnabled
+    if expiringEnabled == nil then expiringEnabled = false end
+
+    if expiringEnabled then
+        local ec = config.expiringColor or { r = 1, g = 0.2, b = 0.2 }
+        local oc = { r = r, g = g, b = b }
+        -- Stable per-(frame,category) proxy registered with the expiring ticker.
+        -- The engine calls element:IsShown() each tick (and drops the entry when
+        -- false) plus Show/Hide/SetAlpha for show-when-missing, so this must be a
+        -- real frame, not a plain table. Kept shown; the colour is driven through
+        -- SetAuraColorOverride in applyResult/applyManual, not on this proxy.
+        local key = frame[keyField]
+        if not key then
+            key = CreateFrame("Frame", nil, UIParent)
+            frame[keyField] = key
+        end
+        RegisterExpiring(key, {
+            unit = frame.unit,
+            auraInstanceID = auraData and auraData.auraInstanceID,
+            threshold = config.expiringThreshold or 30,
+            duration = auraData and auraData.duration,
+            expirationTime = auraData and auraData.expirationTime,
+            colorCurve = BuildExpiringColorCurve(config.expiringThreshold or 30, ec, oc, config.expiringThresholdMode),
+            thresholdMode = config.expiringThresholdMode,
+            color = ec, originalColor = oc,
+            -- Drive the TD override each tick (TD does not re-render per tick).
+            applyResult = function(_, result)
+                Render:SetAuraColorOverride(frame, category, result)
+            end,
+            applyManual = function(_, isExp, entry)
+                Render:SetAuraColorOverride(frame, category, isExp and entry.color or entry.originalColor)
+            end,
+        })
+    else
+        if frame[keyField] then UnregisterExpiring(frame[keyField]) end
+        Render:SetAuraColorOverride(frame, category, { r = r, g = g, b = b, a = 1 })
+    end
+end
+
+local function RevertDesignerTextColor(frame, category, keyField)
+    if not frame then return end
+    if frame[keyField] then UnregisterExpiring(frame[keyField]) end
+    local Render = DF.TextDesigner and DF.TextDesigner.Render
+    if Render then Render:ClearAuraColorOverride(frame, category) end
+end
+
 function Indicators:ApplyNameText(frame, config, auraData)
     local state = EnsureFrameState(frame)
     if state.nametext then return end
     state.nametext = true
-
-    local nameText = frame.nameText
-    if not nameText then return end
-
-    -- Save original color on first use
-    if not state.savedNameColor then
-        local r, g, b, a = nameText:GetTextColor()
-        state.savedNameColor = { r = r, g = g, b = b, a = a }
-    end
-
-    local color = config.color
-    if color then
-        local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
-        nameText:SetTextColor(r, g, b, 1)
-
-        -- ========================================
-        -- EXPIRING: register with shared ticker
-        -- ========================================
-        local expiringEnabled = config.expiringEnabled
-        if expiringEnabled == nil then expiringEnabled = false end
-        if expiringEnabled then
-            local ec = config.expiringColor or {r = 1, g = 0.2, b = 0.2}
-            local oc = {r = r, g = g, b = b}
-            RegisterExpiring(nameText, {
-                unit = frame.unit,
-                auraInstanceID = auraData and auraData.auraInstanceID,
-                threshold = config.expiringThreshold or 30,
-                duration = auraData and auraData.duration,
-                expirationTime = auraData and auraData.expirationTime,
-                colorCurve = BuildExpiringColorCurve(config.expiringThreshold or 30, ec, oc, config.expiringThresholdMode),
-            thresholdMode = config.expiringThresholdMode,
-                color = ec, originalColor = oc,
-                applyResult = function(el, result, entry)
-                    el:SetTextColor(result.r, result.g, result.b, result.a or 1)
-                end,
-                applyManual = function(el, isExp, entry)
-                    if isExp then
-                        local c = entry.color
-                        el:SetTextColor(c.r or 1, c.g or 0.2, c.b or 0.2, 1)
-                    else
-                        local c = entry.originalColor
-                        el:SetTextColor(c.r, c.g, c.b, 1)
-                    end
-                end,
-            })
-        else
-            UnregisterExpiring(nameText)
-        end
-    end
+    ApplyDesignerTextColor(frame, config, auraData, "name", "_tdNameColorKey")
 end
 
 function Indicators:RevertNameText(frame)
-    local state = frame and frame.dfAD
-    if not state or not state.savedNameColor then return end
-
-    local nameText = frame.nameText
-    if not nameText then return end
-
-    UnregisterExpiring(nameText)
-    local c = state.savedNameColor
-    nameText:SetTextColor(c.r, c.g, c.b, c.a)
-    state.savedNameColor = nil  -- Re-capture next time
+    RevertDesignerTextColor(frame, "name", "_tdNameColorKey")
 end
 
 -- ============================================================
@@ -1850,68 +1852,11 @@ function Indicators:ApplyHealthText(frame, config, auraData)
     local state = EnsureFrameState(frame)
     if state.healthtext then return end
     state.healthtext = true
-
-    local healthText = frame.healthText
-    if not healthText then return end
-
-    -- Save original color on first use
-    if not state.savedHealthTextColor then
-        local r, g, b, a = healthText:GetTextColor()
-        state.savedHealthTextColor = { r = r, g = g, b = b, a = a }
-    end
-
-    local color = config.color
-    if color then
-        local r, g, b = color[1] or color.r or 1, color[2] or color.g or 1, color[3] or color.b or 1
-        healthText:SetTextColor(r, g, b, 1)
-
-        -- ========================================
-        -- EXPIRING: register with shared ticker
-        -- ========================================
-        local expiringEnabled = config.expiringEnabled
-        if expiringEnabled == nil then expiringEnabled = false end
-        if expiringEnabled then
-            local ec = config.expiringColor or {r = 1, g = 0.2, b = 0.2}
-            local oc = {r = r, g = g, b = b}
-            RegisterExpiring(healthText, {
-                unit = frame.unit,
-                auraInstanceID = auraData and auraData.auraInstanceID,
-                threshold = config.expiringThreshold or 30,
-                duration = auraData and auraData.duration,
-                expirationTime = auraData and auraData.expirationTime,
-                colorCurve = BuildExpiringColorCurve(config.expiringThreshold or 30, ec, oc, config.expiringThresholdMode),
-            thresholdMode = config.expiringThresholdMode,
-                color = ec, originalColor = oc,
-                applyResult = function(el, result, entry)
-                    el:SetTextColor(result.r, result.g, result.b, result.a or 1)
-                end,
-                applyManual = function(el, isExp, entry)
-                    if isExp then
-                        local c = entry.color
-                        el:SetTextColor(c.r or 1, c.g or 0.2, c.b or 0.2, 1)
-                    else
-                        local c = entry.originalColor
-                        el:SetTextColor(c.r, c.g, c.b, 1)
-                    end
-                end,
-            })
-        else
-            UnregisterExpiring(healthText)
-        end
-    end
+    ApplyDesignerTextColor(frame, config, auraData, "health", "_tdHealthColorKey")
 end
 
 function Indicators:RevertHealthText(frame)
-    local state = frame and frame.dfAD
-    if not state or not state.savedHealthTextColor then return end
-
-    local healthText = frame.healthText
-    if not healthText then return end
-
-    UnregisterExpiring(healthText)
-    local c = state.savedHealthTextColor
-    healthText:SetTextColor(c.r, c.g, c.b, c.a)
-    state.savedHealthTextColor = nil
+    RevertDesignerTextColor(frame, "health", "_tdHealthColorKey")
 end
 
 -- ============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * (Defensive Icon) The defensive cooldown icon and its border now render **above auras** and stay co-planar with the icon. (by Krathe)
 * (Role Icons) **Show Tank / Healer / DPS** toggles now apply live without a `/reload`, and are properly decoupled from the Hide-in-Combat gate. (by Krathe)
 * (Raid Frames) Fixed missing frames for players who are still loading in, such as battleground backfills joining mid-match. (by Krathe)
+* (Aura Designer) The **Name Text** and **Health Text** indicators (recolour the unit's name/health text on aura presence) work again now that the Text Designer owns that text — they recolour the Text Designer's name/health elements, including the expiring colour fade. (by Krathe)
 * (Aura Designer) Text-only icons no longer draw a leftover border (static or expiring). (by Krathe)
 * (Aura Designer) Aura icon and square borders from older profiles keep their original look after the border rework, instead of appearing thinner or floating in a gap. (by Krathe)
 * (Buff/Debuff) Icon borders from older profiles no longer float in a gap after the border rework — they hug the icon as before. (by Krathe)

--- a/TextDesigner/Render.lua
+++ b/TextDesigner/Render.lua
@@ -207,6 +207,16 @@ local function updateOne(frame, elem, source, globalDefaults, enabledById)
             fs:SetTextColor(color.r, color.g, color.b, (app.color and app.color.a) or 1)
         end
     end
+    -- Aura Designer "Name Text"/"Health Text" colour override wins over the
+    -- resolved/class colour while an aura is active. Stamp the category so
+    -- SetAuraColorOverride can find this FontString; honour any standing
+    -- override so it survives this re-render.
+    local cat = CONTENT_HINTS[elem.contentType]
+    fs._tdCategory = cat
+    local ov = cat and frame._tdAuraColor and frame._tdAuraColor[cat]
+    if ov then
+        fs:SetTextColor(ov.r, ov.g, ov.b, ov.a or 1)
+    end
     local text = getResolver():Resolve(elem, source)
     fs:SetText(getMS().SafeText(text))
     fs:Show()
@@ -340,4 +350,35 @@ function DF:UpdateTextDesigner(frame, hint)
 
     local source = DF.TextDesigner.DataSource.Live(frame)
     Render:UpdateFrame(frame, tdDB, source, hint)
+end
+
+-- ============================================================
+-- AURA DESIGNER COLOUR OVERRIDE
+-- AD's "Name Text" / "Health Text" indicators recolour the unit's text on aura
+-- presence. The legacy frame.nameText/healthText are retired (IsLegacyTextHidden
+-- == true), so AD drives the colour of the TD-owned FontStrings instead, per
+-- category ("name" / "health"). The override is stored on the frame and honoured
+-- by updateOne, so it survives TD's own re-renders; SetAuraColorOverride also
+-- recolours the live FontStrings immediately (and on each expiring-ticker tick).
+-- ============================================================
+
+function Render:SetAuraColorOverride(frame, category, color)
+    if not frame or not category or not color then return end
+    frame._tdAuraColor = frame._tdAuraColor or {}
+    frame._tdAuraColor[category] = color
+    if frame._tdFontStrings then
+        for _, fs in pairs(frame._tdFontStrings) do
+            if fs._tdCategory == category then
+                fs:SetTextColor(color.r, color.g, color.b, color.a or 1)
+            end
+        end
+    end
+end
+
+function Render:ClearAuraColorOverride(frame, category)
+    if not frame or not category then return end
+    if not (frame._tdAuraColor and frame._tdAuraColor[category] ~= nil) then return end
+    frame._tdAuraColor[category] = nil
+    -- Re-render this category so TD reapplies its normal / class colour.
+    DF:UpdateTextDesigner(frame, category)
 end


### PR DESCRIPTION
### Problem
The Aura Designer **Name Text** and **Health Text** indicators recolour the unit's name/health text on aura presence. They worked by recolouring the legacy `frame.nameText` / `frame.healthText`, but those FontStrings are now permanently hidden (`DF:IsLegacyTextHidden` returns `true` — the Text Designer owns the visible name/health text). So the indicators were recolouring invisible text and had no effect.

### Fix
A per-frame, per-category colour override that the Text Designer honours:

- **Text Designer (`TextDesigner/Render.lua`)** — `updateOne` stamps each FontString with its category (`name`/`health`/…) and applies any standing override *after* the resolved/class colour, so it survives TD's own re-renders. New `Render:SetAuraColorOverride` / `ClearAuraColorOverride` store the override and recolour the live category FontStrings immediately (clear re-renders the category so TD restores its normal colour).
- **Aura Designer (`AuraDesigner/Indicators.lua`)** — `Apply/Revert` for Name Text and Health Text drive that override (categories `name`/`health`) via two shared helpers instead of touching the retired legacy FontStrings. The expiring colour fade is preserved: the expiring ticker drives `SetAuraColorOverride` each tick (a real proxy frame is registered with the ticker, since it calls `:IsShown()` on every entry per tick).

The override is per-category, so Name Text recolours the name cluster (name/class/level/…) and Health Text the health cluster (hp current/max/percent/deficit). Class-colour interaction: while the aura is active the AD colour wins; on loss it reverts to the element's normal/class colour.

### Testing
- Name Text / Health Text indicator with a colour → aura applied recolours the TD text; removed reverts.
- Expiring variant fades to the expiring colour as it nears expiry.
- Live frames and test mode.