### PR TITLE
Raid: Group Display Order / My Group First reposition the frames live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug Fixes
 
+* (Raid) **Group Display Order** and **My Group First** now reposition the frames live: changing the order (or toggling My Group First) moves the raid frames immediately instead of only moving the group labels and leaving the frames in default order until the next roster change. The **My Group First** setting also now saves when toggled while editing an active auto layout, instead of being lost on reload. (by Krathe)
 * (Arena) Fixed teammates who load in late sometimes staying missing from your frames for the whole round, and the frame order breaking after a reload mid-match. (by Krathe)
 * (Arena) Fixed your frames staying hidden after a reload during a match. (by Krathe)
 * (Range) The frame border (and other element borders) now reliably **fade out of range**, preserved across border re-renders. (by Krathe)

--- a/Frames/Init.lua
+++ b/Frames/Init.lua
@@ -172,6 +172,41 @@ function DF:UpdateRaidLayout()
     return DF:UpdateRaidGroupedLayout()
 end
 
+-- Effective raid group display order: db.raidGroupDisplayOrder, with the
+-- player's group moved first when "My Group First" is on. Mirrors the builder in
+-- Headers.lua's UpdateRaidGroupOrderAttributes (which orders the group headers
+-- via secure attributes) so the unit-frame positioner agrees with the headers.
+function DF:GetEffectiveRaidGroupOrder(db)
+    db = db or DF:GetRaidDB()
+    local displayOrder = db.raidGroupDisplayOrder
+    if type(displayOrder) ~= "table" or #displayOrder ~= 8 then
+        displayOrder = {1, 2, 3, 4, 5, 6, 7, 8}
+    end
+    local effectiveOrder = {}
+    if db.raidPlayerGroupFirst and DF.cachedPlayerGroup then
+        effectiveOrder[1] = DF.cachedPlayerGroup
+        for _, g in ipairs(displayOrder) do
+            if g ~= DF.cachedPlayerGroup then effectiveOrder[#effectiveOrder + 1] = g end
+        end
+    else
+        for _, g in ipairs(displayOrder) do effectiveOrder[#effectiveOrder + 1] = g end
+    end
+    return effectiveOrder
+end
+
+-- Sort a list of active group numbers in place by effective display order, so
+-- the group-slot positioner (which derives a group's slot from its index within
+-- this list) honours Group Display Order / My Group First. Falls back to raw
+-- group number for any group not present in the effective order.
+function DF:SortActiveGroupListByDisplayOrder(activeGroupList, db)
+    local effectiveOrder = DF:GetEffectiveRaidGroupOrder(db)
+    local rank = {}
+    for pos, g in ipairs(effectiveOrder) do rank[g] = pos end
+    table.sort(activeGroupList, function(a, b)
+        return (rank[a] or a) < (rank[b] or b)
+    end)
+end
+
 -- Group-based raid layout positioning
 function DF:UpdateRaidGroupedLayout()
     local db = DF:GetRaidDB()
@@ -245,8 +280,8 @@ function DF:UpdateRaidGroupedLayout()
                 end
             end
         end
-        table.sort(activeGroupList)
-        
+        DF:SortActiveGroupListByDisplayOrder(activeGroupList, db)
+
         -- Set container size
         local totalWidth, totalHeight = SecureSort:CalculateRaidGroupContainerSize(#activeGroupList, lp)
         DF.raidContainer:SetSize(totalWidth, totalHeight)
@@ -344,9 +379,13 @@ function DF:UpdateRaidGroupedLayout()
         end
     end
     
-    -- Sort activeGroupList by group number
-    table.sort(activeGroupList)
-    
+    -- Order activeGroupList by effective display order (Group Display Order /
+    -- My Group First). PositionRaidFrameToGroupSlot derives each group's slot
+    -- from its index within this list, so a raw group-number sort here pinned
+    -- the frames to default order while the headers/labels already moved — the
+    -- Group Display Order / My Group First desync.
+    DF:SortActiveGroupListByDisplayOrder(activeGroupList, db)
+
     -- Recalculate posInGroup now that we know actual counts
     -- PERFORMANCE FIX: Reuse table
     wipe(reusableGroupCurrentPos)

--- a/Options/AutoProfiles.lua
+++ b/Options/AutoProfiles.lua
@@ -3927,6 +3927,12 @@ end
 -- Returns true if the key is overridden (caller should skip frame refresh).
 function AutoProfilesUI:HandleRuntimeWrite(key, value)
     if not key then return false end
+    -- While EDITING a layout, the write must flow to the normal setter +
+    -- SetProfileSetting so it persists into the layout's override (and previews
+    -- live). Runtime protection is only for non-editing runtime changes —
+    -- otherwise it steals the edit and it's lost on reload (e.g. My Group First).
+    -- Mirrors the WrapDB __newindex guard, which also bows out when IsEditing().
+    if self:IsEditing() then return false end
     if not self.activeRuntimeProfile or not DF.raidOverrides then return false end
 
     -- Check if this key (or its parent) is covered by the overlay


### PR DESCRIPTION
## Summary

Fixes two related bugs in the raid grouped layout:

1. **Group Display Order / My Group First didn't move the frames.** Changing the group order (or toggling **My Group First**) repositioned the group **headers and name labels** correctly, but the **unit frames** stayed in default order. They only snapped into place several seconds later, or when a player joined/left/changed group — and groups would visibly jump as a result.

2. **My Group First wasn't saved on `/reload`** when toggled while editing an active auto layout.

## Root cause

The grouped raid positioner (`SecureSort:PositionRaidFrameToGroupSlot`, via `DF:UpdateRaidGroupedLayout` in `Frames/Init.lua`) derives each group's on-screen slot from the group's **index within `activeGroupList`**. That list was built and then `table.sort(activeGroupList)`-ed — i.e. ordered by **raw group number 1..8**, ignoring the configured display order and My Group First. So the headers (positioned from the display-order attributes) and the frames disagreed, and the frames only "caught up" when Blizzard's `configureChildren` re-anchored them to the already-ordered headers on a roster change.

The persistence bug: while editing an active layout, `AutoProfilesUI:HandleRuntimeWrite` captured the toggle as a runtime-only override and returned early, so the normal setter + `SetProfileSetting` (which persists the layout override) never ran.

## Fix

- `Frames/Init.lua`: new `DF:GetEffectiveRaidGroupOrder(db)` and `DF:SortActiveGroupListByDisplayOrder(list, db)`; order `activeGroupList` by the effective display order (display order, with the player's group first when My Group First is on) at both sort sites. No-op when the order is default. `UpdateFrames` drives the positioner synchronously, so toggling now reorders instantly.
- `Options/AutoProfiles.lua`: `HandleRuntimeWrite` bows out when `IsEditing()`, so the write flows through the normal setter + override persist (mirrors the existing WrapDB `__newindex` editing guard).

## Testing

Tested in a live raid: toggling **My Group First** and reordering **Group Display Order** now reposition the frames immediately (no roster event needed), the labels and frames stay in sync (no more group jumping), and the My Group First setting survives `/reload` when set on an active auto layout.