### PR TITLE
Fix animated borders freezing after hide/show or icon-pool reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* (Borders) Animated borders (dashed / marching-ants and the other motion effects) no longer freeze after a frame hides and re-shows, or an aura icon is recycled from the pool — they kept their "already running" marker even though the underlying animation had stopped, so they sat static until a setting was nudged to force a restart. (by Krathe)
 * (Pinned Frames) Text Designer elements now update on pinned frames right away when you add or edit them, instead of only showing up after toggling test mode.
 * (Raid) **Group Display Order** and **My Group First** now reposition the frames live: changing the order (or toggling My Group First) moves the raid frames immediately instead of only moving the group labels and leaving the frames in default order until the next roster change. The **My Group First** setting also now saves when toggled while editing an active auto layout, instead of being lost on reload. (by Krathe)
 * (Arena) Fixed teammates who load in late sometimes staying missing for the whole round, the frame order breaking after a mid-match reload, and frames staying hidden after a reload during a match. (by Krathe)

--- a/Frames/Border.lua
+++ b/Frames/Border.lua
@@ -980,6 +980,11 @@ local function animSpecHash(anim)
     }, "|")
 end
 
+-- OnUpdate-driver effects: those whose motion is driven by border.animDriver's
+-- OnUpdate (as opposed to LCG glows or the static shape modes). The dedupe in
+-- StartAnimation verifies the driver is actually live for these before no-opping.
+local DRIVER_ANIMS = { DF_DASH = true, WIPE = true, RIPPLE = true, SEGMENT_REVEAL = true, DF_PULSATE = true }
+
 function Border:StartAnimation(border, spec)
     if not border or not spec or not spec.animation then
         self:StopAnimation(border); return
@@ -995,7 +1000,20 @@ function Border:StartAnimation(border, spec)
     -- transition (or any genuine spec change) still goes through the full
     -- restart path below.
     local newHash = animSpecHash(anim)
-    if border._animHash == newHash then return end
+    -- No-op when the same spec is already running — BUT only if the effect is
+    -- genuinely still live. For OnUpdate-driver effects the hash can stay stamped
+    -- while the driver has stopped (e.g. an AD border re-applied across a
+    -- hide/show or pooled-icon cycle), and trusting the hash alone then leaves the
+    -- animation frozen until a real spec change forces a restart (the "move the
+    -- frequency slider off 1 and back" symptom). When the driver is dead, fall
+    -- through and restart instead of no-opping.
+    if border._animHash == newHash then
+        local d = border.animDriver
+        if not DRIVER_ANIMS[border.activeAnimation]
+           or (d and d:IsShown() and d:GetScript("OnUpdate")) then
+            return
+        end
+    end
 
     -- DF_PULSATE retune-in-place: the spec changed, but if a DF Pulsate is
     -- already running on this border, NEVER tear it down — just update its


### PR DESCRIPTION
Animated borders driven by an OnUpdate (DF Dash, Wipe, Ripple, Segment Reveal, DF Pulsate) could stop animating and sit static until a setting was nudged.

`StartAnimation`'s dedupe no-ops whenever the spec hash matches the currently-stamped one. But for those OnUpdate-driver effects the hash can stay stamped after the driver has actually stopped — e.g. an Aura Designer border re-applied across a hide/show, or a pooled icon being recycled — so trusting the hash alone left the border frozen until a real spec change forced a restart.

Fix: gate the no-op on the driver genuinely being live (shown + OnUpdate set) for those effects; otherwise fall through to the normal restart path. Other effects (LCG glows, static shape modes) are unaffected.
