### PR TITLE
Fix status-icon & AFK-timer drop shadows on 12.0.7 (font-object path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* (Status Icons) The drop shadow shows again on the **AFK timer** and **all status-icon text**. A 12.0.7 font change stopped the old fontstring-level shadow from rendering, so status-icon and timer text lost their shadow while the rest of your text kept it; they now apply the shadow through the font itself like everything else. The global **Shadow X / Y / Color** sliders also preview live again while dragging — on live, pinned, and test frames — instead of only after a reload. (by Krathe)
 * (Pinned Frames) Text Designer elements now update on pinned frames right away when you add or edit them, instead of only showing up after toggling test mode.
 * (Raid) **Group Display Order** and **My Group First** now reposition the frames live: changing the order (or toggling My Group First) moves the raid frames immediately instead of only moving the group labels and leaving the frames in default order until the next roster change. The **My Group First** setting also now saves when toggled while editing an active auto layout, instead of being lost on reload. (by Krathe)
 * (Arena) Fixed teammates who load in late sometimes staying missing for the whole round, the frame order breaking after a mid-match reload, and frames staying hidden after a reload during a match. (by Krathe)

--- a/Config.lua
+++ b/Config.lua
@@ -421,8 +421,36 @@ local function GetOrCreateFontFamily(fontPath, outline, useShadow)
         fontFamilies[key] = globalName
         return globalName
     end
-    
+
     return nil
+end
+
+-- 12.0.7: a font's drop shadow lives on its font-family per-alphabet font
+-- objects, not the fontstring (fontstring-level SetShadow* is a silent no-op).
+-- Update the already-built families' shadow in place so the Shadow X/Y/Color
+-- sliders preview live, without a full ClearFontCache + frame rebuild.
+function DF:RefreshFontFamilyShadows()
+    if not CreateFontFamily then return end
+    local db = (DF.GetDB and DF:GetDB())
+        or (DF.db and DF.db[(DF.GUI and DF.GUI.SelectedMode) or "party"])
+    local shadowX = (db and db.fontShadowOffsetX) or 1
+    local shadowY = (db and db.fontShadowOffsetY) or -1
+    local sc = (db and db.fontShadowColor) or {r = 0, g = 0, b = 0, a = 1}
+    for key, globalName in pairs(fontFamilies) do
+        -- Only families built with a shadow (cache-key suffix "|shadow") carry one.
+        if key:sub(-7) == "|shadow" then
+            local fam = _G[globalName]
+            if fam and fam.GetFontObjectForAlphabet then
+                for _, alphabet in ipairs(alphabets) do
+                    local fontObj = fam:GetFontObjectForAlphabet(alphabet)
+                    if fontObj then
+                        fontObj:SetShadowOffset(shadowX, shadowY)
+                        fontObj:SetShadowColor(sc.r or 0, sc.g or 0, sc.b or 0, sc.a or 1)
+                    end
+                end
+            end
+        end
+    end
 end
 
 function DF:GetTextureList(includeSolid)
@@ -741,25 +769,13 @@ function DF:SafeSetFont(fontString, fontNameOrPath, fontSize, outline)
                 end
             end)
 
-            -- Apply shadow directly to fontString (font family shadow is on the font object,
-            -- but we need to apply to each fontString for proper settings)
-            if useShadow then
-                local db
-                if DF.GetDB then
-                    db = DF:GetDB()
-                elseif DF.db then
-                    local mode = (DF.GUI and DF.GUI.SelectedMode) or "party"
-                    db = DF.db[mode]
-                end
-                local shadowX = db and db.fontShadowOffsetX or 1
-                local shadowY = db and db.fontShadowOffsetY or -1
-                local shadowColor = db and db.fontShadowColor or {r = 0, g = 0, b = 0, a = 1}
-                fontString:SetShadowOffset(shadowX, shadowY)
-                fontString:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-            else
-                fontString:SetShadowOffset(0, 0)
-            end
-
+            -- IMPORTANT (12.0.7): the drop shadow lives on the font-family's
+            -- per-alphabet font objects (set in GetOrCreateFontFamily). Do NOT also
+            -- set a fontstring-level shadow here: once a fontstring carries its own
+            -- shadow it stops inheriting the font object's, and fontstring-level
+            -- SetShadow* no longer renders on 12.0.7 — so the net result is NO shadow
+            -- (this is what hid the AFK timer / status-icon shadows). Leaving the
+            -- fontstring untouched lets it inherit the font object's shadow.
             return true
         end
     end

--- a/Core.lua
+++ b/Core.lua
@@ -518,85 +518,21 @@ end
 
 -- Update only font shadows on all text elements
 function DF:LightweightUpdateFontShadows()
-    local mode = DF.GUI and DF.GUI.SelectedMode or "party"
-    local db = DF.db[mode]
-    if not db then return end
-    
-    local shadowX = db.fontShadowOffsetX or 1
-    local shadowY = db.fontShadowOffsetY or -1
-    local shadowColor = db.fontShadowColor or {r = 0, g = 0, b = 0, a = 1}
-    
-    -- Check which elements use SHADOW outline
-    local nameShadow = (db.nameTextOutline == "SHADOW")
-    local healthShadow = (db.healthTextOutline == "SHADOW")
-    local statusShadow = (db.statusTextOutline == "SHADOW")
-    
-    local function UpdateShadows(frame)
-        if not frame then return end
-        
-        -- Update name text shadow
-        if frame.nameText then
-            if nameShadow then
-                frame.nameText:SetShadowOffset(shadowX, shadowY)
-                frame.nameText:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-            end
-        end
-        
-        -- Update health text shadow
-        if frame.healthText then
-            if healthShadow then
-                frame.healthText:SetShadowOffset(shadowX, shadowY)
-                frame.healthText:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-            end
-        end
-        
-        -- Update status text shadow
-        if frame.statusText then
-            if statusShadow then
-                frame.statusText:SetShadowOffset(shadowX, shadowY)
-                frame.statusText:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-            end
-        end
-        
-        -- Update buff/debuff duration and stack shadows
-        if frame.buffIcons then
-            local buffShadow = (db.buffDurationOutline == "SHADOW") or (db.buffStackOutline == "SHADOW")
-            if buffShadow then
-                for _, icon in ipairs(frame.buffIcons) do
-                    if icon then
-                        if icon.duration and (db.buffDurationOutline == "SHADOW") then
-                            icon.duration:SetShadowOffset(shadowX, shadowY)
-                            icon.duration:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-                        end
-                        if icon.count and (db.buffStackOutline == "SHADOW") then
-                            icon.count:SetShadowOffset(shadowX, shadowY)
-                            icon.count:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-                        end
-                    end
-                end
-            end
-        end
-        
-        if frame.debuffIcons then
-            local debuffShadow = (db.debuffDurationOutline == "SHADOW") or (db.debuffStackOutline == "SHADOW")
-            if debuffShadow then
-                for _, icon in ipairs(frame.debuffIcons) do
-                    if icon then
-                        if icon.duration and (db.debuffDurationOutline == "SHADOW") then
-                            icon.duration:SetShadowOffset(shadowX, shadowY)
-                            icon.duration:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-                        end
-                        if icon.count and (db.debuffStackOutline == "SHADOW") then
-                            icon.count:SetShadowOffset(shadowX, shadowY)
-                            icon.count:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-                        end
-                    end
-                end
-            end
-        end
+    -- 12.0.7: fontstring-level SetShadowOffset/SetShadowColor no longer render —
+    -- a font's drop shadow now lives on its font-family per-alphabet font objects.
+    -- The old per-frame fontstring poke was a silent no-op, so update the already
+    -- built font families in place instead (live preview, no full font rebuild).
+    if DF.RefreshFontFamilyShadows then DF:RefreshFontFamilyShadows() end
+    -- A font-object shadow change doesn't repaint already-rendered fontstrings —
+    -- only continuously-ticked test frames pick it up on their own. Re-apply fonts
+    -- so live + pinned frames repaint too.
+    -- Legacy name/health/status text (used when the Text Designer is off):
+    if DF.RefreshAllFonts then DF:RefreshAllFonts() end
+    -- The Text Designer renders the visible text on its own overlay, which the
+    -- above doesn't touch; re-render it so its shadow repaints on live + pinned.
+    if DF.TextDesigner and DF.TextDesigner.Preview and DF.TextDesigner.Preview.RefreshLiveFrames then
+        DF.TextDesigner.Preview:RefreshLiveFrames()
     end
-    
-    IterateFramesInMode(mode, UpdateShadows)
 end
 
 -- Update only aura icon sizes

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -2769,6 +2769,50 @@ function PinnedFrames:RefreshTextDesigner()
     end
 end
 
+-- Re-apply name/health/status fonts on every shown pinned frame (live OR test),
+-- so a global font / shadow change repaints them. The main RefreshAllFonts
+-- iterators don't reach the pinned pool — and pinned test frames live in their
+-- own non-secure pool, not the secure headers. Mirrors RefreshTextDesigner's
+-- traversal. Each call is guarded (GetFrameDB may be nil; RefreshFrameFonts
+-- bails on a nil db) so it can't error on a half-built frame during login.
+function PinnedFrames:RefreshFonts()
+    if not DF.RefreshFrameFonts then return end
+    local function refont(f)
+        if f and f:IsShown() then
+            DF.RefreshFrameFonts(f, DF:GetFrameDB(f))
+        end
+    end
+
+    if self.testModeActive then
+        for setIndex = 1, PinnedFrames.MAX_SETS do
+            local pool = self.testFrames[setIndex]
+            if pool then
+                for i = 1, #pool do refont(pool[i]) end
+            end
+        end
+        return
+    end
+
+    for setIndex = 1, PinnedFrames.MAX_SETS do
+        local set = GetSetDB(setIndex)
+        if set then
+            if IsBossSet(set) then
+                local frames = self.bossFrames[setIndex]
+                if frames then
+                    for i = 1, 8 do refont(frames[i]) end
+                end
+            else
+                local header = self.headers[setIndex]
+                if header then
+                    for i = 1, 40 do refont(header:GetAttribute("child" .. i)) end
+                end
+            end
+        end
+    end
+end
+
+DF.RefreshPinnedFonts = function() PinnedFrames:RefreshFonts() end
+
 -- ============================================================
 -- EVENT HANDLING
 -- All initialization must happen synchronously during ADDON_LOADED

--- a/Frames/StatusIcons.lua
+++ b/Frames/StatusIcons.lua
@@ -229,33 +229,28 @@ function DF:ApplyTimerTextSettings(icon, db, prefix)
     -- it stays put across the 9:59 -> 10:00 boundary too. Anchor the left edge
     -- ~half a typical MM:SS left of centre so it reads centred under the icon.
     t:SetJustifyH("LEFT")
-    -- Centre the timer under the icon. SafeSetFont renders via SetTextScale (the
-    -- font family is fixed at BASE_FONT_SIZE), and that scale pivots about the
-    -- fontstring BOX's centre — so a box wider than the text pushes it off to the
-    -- side once scaled. Size the box to the rendered width and anchor its centre
-    -- under the icon, so the text scales about its own centre and stays put.
+    -- Centre the timer under the icon. SafeSetFont's font-family path renders via
+    -- SetTextScale, which pivots about the fontstring BOX's centre — so size the box
+    -- to the rendered text width and anchor its centre under the icon: the text then
+    -- scales about its own centre and stays put, LEFT-justified so the changing
+    -- seconds never re-centre (no wobble).
     --
-    -- Measure a fixed representative sample, NOT the live string: on pinned frames
-    -- this runs before the timer text is set, so measuring the current (empty or
-    -- transitional) text cached a too-narrow box and the timer truncated/jittered.
-    -- Pick the sample by the current string's LENGTH so the box also fits the
-    -- HH:MM:SS format once the timer passes an hour. Re-measure only when the font,
-    -- size, or format (sample) changes — so it never re-measures per tick.
+    -- Measure a fixed sample ("00:00", or "00:00:00" past an hour), NOT the live
+    -- string (which may be empty when this runs). Re-measure EVERY call rather than
+    -- caching: GetStringWidth taken before the font/scale was ready returned the
+    -- unscaled (BASE_FONT_SIZE) width, and caching that stuck a too-narrow box that
+    -- truncated; measured fresh once the font is live it already reflects the
+    -- rendered width, so no scale factor is needed. The sample is constant, so the
+    -- width never changes tick-to-tick.
     local cur = t:GetText() or ""
     local sample = (#cur >= 8) and "00:00:00" or "00:00"
-    if t._dfTimerSize ~= size or t._dfTimerFont ~= font or t._dfTimerSample ~= sample then
-        t:SetText(sample)
-        local w = t:GetStringWidth() or 0
-        t:SetText(cur)
-        if w > 0 then
-            t._dfTimerWidth = w
-            t._dfTimerSize = size
-            t._dfTimerFont = font
-            t._dfTimerSample = sample
-        end
-    end
-    local w = t._dfTimerWidth or (size * 2.4)
-    t:SetWidth(w)
+    t:SetText(sample)
+    local w = t:GetStringWidth() or 0
+    t:SetText(cur)
+    if w <= 0 then w = size * 2.4 end
+    -- Box is 1px wider than the text so the last glyph never clips, but anchor on
+    -- half the TEXT width (not the padded box) so the digits sit dead centre.
+    t:SetWidth(w + 1)
     t:ClearAllPoints()
     t:SetPoint("TOPLEFT", icon, "BOTTOM", (db[prefix .. "TimerX"] or 0) - w / 2, db[prefix .. "TimerY"] or -1)
 end

--- a/Frames/StatusIcons.lua
+++ b/Frames/StatusIcons.lua
@@ -207,23 +207,18 @@ function DF:ApplyTimerTextSettings(icon, db, prefix)
     local font    = db[prefix .. "TimerFont"]     or db.statusIconFont or "Fonts\\FRIZQT__.TTF"
     local size    = db[prefix .. "TimerFontSize"] or ((db.statusIconFontSize or 12) - 2)
     local outline = db[prefix .. "TimerOutline"]  or db.statusIconFontOutline or "OUTLINE"
-    -- outline may be a composed "SHADOW;<flag>" value; OutlineFlag strips the
-    -- shadow and returns the SetFont flag ("NONE" -> "" since SetFont rejects it).
-    local flag = DF:OutlineFlag(outline)
-    local actualOutline = (flag == "NONE") and "" or flag
-    local fontPath = (DF.GetFont and (DF:GetFont(font) or font)) or font
-    t:SetFont(fontPath, size, actualOutline)
-
-    if DF:OutlineHasShadow(outline) then
-        local sc = db.fontShadowColor or { r = 0, g = 0, b = 0, a = 1 }
-        t:SetShadowOffset(db.fontShadowOffsetX or 1, db.fontShadowOffsetY or -1)
-        t:SetShadowColor(sc.r or 0, sc.g or 0, sc.b or 0, sc.a or 1)
-    else
-        t:SetShadowOffset(0, 0)
-    end
+    -- Font + shadow via SafeSetFont (font-family path). Fontstring-level
+    -- SetShadowColor/Offset is a silent no-op on 12.0.7, so the shadow must ride
+    -- the font object. SetFontObject resets vertex colour — capture + restore it.
+    local cr, cg, cb, ca = t:GetTextColor()
+    DF:SafeSetFont(t, font, size, outline)
 
     local c = db[prefix .. "TimerColor"] or db[prefix .. "TextColor"]
-    if c then t:SetTextColor(c.r or 1, c.g or 1, c.b or 1, c.a or 1) end
+    if c then
+        t:SetTextColor(c.r or 1, c.g or 1, c.b or 1, c.a or 1)
+    else
+        t:SetTextColor(cr, cg, cb, ca)
+    end
 
     -- LEFT-justify the timer instead of centring it. CENTRE justify — even inside
     -- a fixed-width box — re-measures the text's INK box each tick, and a narrow
@@ -233,11 +228,36 @@ function DF:ApplyTimerTextSettings(icon, db, prefix)
     -- char count, see FormatAFKTime), so the string width never changes either —
     -- it stays put across the 9:59 -> 10:00 boundary too. Anchor the left edge
     -- ~half a typical MM:SS left of centre so it reads centred under the icon.
-    local nudge = size * 1.2  -- ~half the width of a 5-char MM:SS timer
-    t:SetWidth(size * 6)
     t:SetJustifyH("LEFT")
+    -- Centre the timer under the icon. SafeSetFont renders via SetTextScale (the
+    -- font family is fixed at BASE_FONT_SIZE), and that scale pivots about the
+    -- fontstring BOX's centre — so a box wider than the text pushes it off to the
+    -- side once scaled. Size the box to the rendered width and anchor its centre
+    -- under the icon, so the text scales about its own centre and stays put.
+    --
+    -- Measure a fixed representative sample, NOT the live string: on pinned frames
+    -- this runs before the timer text is set, so measuring the current (empty or
+    -- transitional) text cached a too-narrow box and the timer truncated/jittered.
+    -- Pick the sample by the current string's LENGTH so the box also fits the
+    -- HH:MM:SS format once the timer passes an hour. Re-measure only when the font,
+    -- size, or format (sample) changes — so it never re-measures per tick.
+    local cur = t:GetText() or ""
+    local sample = (#cur >= 8) and "00:00:00" or "00:00"
+    if t._dfTimerSize ~= size or t._dfTimerFont ~= font or t._dfTimerSample ~= sample then
+        t:SetText(sample)
+        local w = t:GetStringWidth() or 0
+        t:SetText(cur)
+        if w > 0 then
+            t._dfTimerWidth = w
+            t._dfTimerSize = size
+            t._dfTimerFont = font
+            t._dfTimerSample = sample
+        end
+    end
+    local w = t._dfTimerWidth or (size * 2.4)
+    t:SetWidth(w)
     t:ClearAllPoints()
-    t:SetPoint("TOPLEFT", icon, "BOTTOM", (db[prefix .. "TimerX"] or 0) - nudge, db[prefix .. "TimerY"] or -1)
+    t:SetPoint("TOPLEFT", icon, "BOTTOM", (db[prefix .. "TimerX"] or 0) - w / 2, db[prefix .. "TimerY"] or -1)
 end
 
 -- ============================================================
@@ -287,40 +307,25 @@ local function ApplyIconSettings(icon, db, prefix)
         icon:SetFrameLevel(icon:GetParent():GetParent():GetFrameLevel() + frameLevel)
     end
     
-    -- Apply status icon font settings to text
+    -- Apply status icon font settings to text. Route through SafeSetFont so the
+    -- shadow lands on the font-family's per-alphabet font objects — 12.0.7 no
+    -- longer renders fontstring-level SetShadowColor/Offset (it's a silent no-op).
     if icon.text then
         local font = db.statusIconFont or "Fonts\\FRIZQT__.TTF"
         local fontSize = db.statusIconFontSize or 12
         local outline = db.statusIconFontOutline or "OUTLINE"
-        
-        -- outline may be a composed "SHADOW;<flag>" value; OutlineFlag strips
-        -- the shadow and returns the SetFont flag ("NONE" -> "" — SetFont rejects "NONE").
-        local flag = DF:OutlineFlag(outline)
-        local actualOutline = (flag == "NONE") and "" or flag
 
-        -- Get font path from SharedMedia if available
-        local fontPath = font
-        if DF.GetFont then
-            fontPath = DF:GetFont(font) or font
-        end
+        -- SafeSetFont swaps the font object, which resets vertex colour to white;
+        -- capture the current colour so non-overridden icons keep their tint.
+        local cr, cg, cb, ca = icon.text:GetTextColor()
+        DF:SafeSetFont(icon.text, font, fontSize, outline)
 
-        icon.text:SetFont(fontPath, fontSize, actualOutline)
-
-        -- Apply shadow if needed
-        if DF:OutlineHasShadow(outline) then
-            local shadowX = db.fontShadowOffsetX or 1
-            local shadowY = db.fontShadowOffsetY or -1
-            local shadowColor = db.fontShadowColor or {r = 0, g = 0, b = 0, a = 1}
-            icon.text:SetShadowOffset(shadowX, shadowY)
-            icon.text:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
-        else
-            icon.text:SetShadowOffset(0, 0)
-        end
-        
-        -- Apply text color from settings
+        -- Apply text color from settings (falls back to the captured colour).
         local textColor = db[prefix .. "TextColor"]
         if textColor then
             icon.text:SetTextColor(textColor.r or 1, textColor.g or 1, textColor.b or 1, 1)
+        else
+            icon.text:SetTextColor(cr, cg, cb, ca)
         end
     end
     

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -1953,8 +1953,8 @@ end
 -- (during combat reload, fonts may not be fully available at ADDON_LOADED)
 
 local function RefreshFrameFonts(frame, db)
-    if not frame then return end
-    
+    if not frame or not db then return end
+
     -- Name text
     if frame.nameText then
         local nameFont = db.nameFont or "Fonts\\FRIZQT__.TTF"
@@ -1982,6 +1982,10 @@ local function RefreshFrameFonts(frame, db)
         DF:SafeSetFont(frame.statusText, statusFont, statusFontSize, statusOutline)
     end
 end
+
+-- Exposed so the pinned-frame pool (Features/PinnedFrames.lua) can re-font itself
+-- on a global font/shadow change — RefreshAllFonts' iterators don't reach it.
+DF.RefreshFrameFonts = RefreshFrameFonts
 
 function DF:RefreshAllFonts()
     local partyDb = DF:GetDB()
@@ -2066,4 +2070,8 @@ function DF:RefreshAllFonts()
             end
         end
     end
+
+    -- Pinned frames keep their own pool (live boss/header + non-secure test pool)
+    -- which none of the iterators above reach.
+    if DF.RefreshPinnedFonts then DF:RefreshPinnedFonts() end
 end

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1998,6 +1998,13 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             DF:UpdateAllFrames()
             if GUI.SelectedMode == "raid" and DF.UpdateRaidLayout then DF:UpdateRaidLayout() end
             if DF.ApplyPetSettings then DF:ApplyPetSettings() end
+            -- UpdateAllFrames doesn't reach the pinned pool — re-font it too.
+            if DF.RefreshPinnedFonts then DF:RefreshPinnedFonts() end
+            -- Re-render the Text Designer overlay (the visible text) so its shadow
+            -- updates on pinned + live frames too.
+            if DF.TextDesigner and DF.TextDesigner.Preview and DF.TextDesigner.Preview.RefreshLiveFrames then
+                DF.TextDesigner.Preview:RefreshLiveFrames()
+            end
         end
         
         local function LightweightShadowUpdate()

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -1438,37 +1438,18 @@ local function ShowTestIconAsText(icon, text, showText, db, prefix)
                 local font = db.statusIconFont or "Fonts\\FRIZQT__.TTF"
                 local fontSize = db.statusIconFontSize or 12
                 local outline = db.statusIconFontOutline or "OUTLINE"
-                
-                -- outline may be a composed "SHADOW;<flag>" value; OutlineFlag strips
-                -- the shadow and returns the SetFont flag ("NONE" -> "" — SetFont rejects "NONE").
-                local flag = DF:OutlineFlag(outline)
-                local actualOutline = (flag == "NONE") and "" or flag
 
-                -- Get font path from SharedMedia if available
-                local fontPath = font
-                if DF.GetFont then
-                    fontPath = DF:GetFont(font) or font
-                end
+                -- Route through SafeSetFont (font-family path) so the shadow renders
+                -- on 12.0.7. SetFontObject resets vertex colour — capture + restore.
+                local cr, cg, cb, ca = icon.text:GetTextColor()
+                DF:SafeSetFont(icon.text, font, fontSize, outline)
 
-                icon.text:SetFont(fontPath, fontSize, actualOutline)
-
-                -- Apply shadow if needed
-                if DF:OutlineHasShadow(outline) then
-                    local shadowX = db.fontShadowOffsetX or 1
-                    local shadowY = db.fontShadowOffsetY or -1
-                    local shadowColor = db.fontShadowColor or {r = 0, g = 0, b = 0, a = 1}
-                    icon.text:SetShadowOffset(shadowX, shadowY)
-                    icon.text:SetShadowColor(shadowColor.r or 0, shadowColor.g or 0, shadowColor.b or 0, shadowColor.a or 1)
+                -- Apply text color if prefix is provided (else keep captured colour)
+                local textColor = prefix and db[prefix .. "TextColor"]
+                if textColor then
+                    icon.text:SetTextColor(textColor.r or 1, textColor.g or 1, textColor.b or 1, 1)
                 else
-                    icon.text:SetShadowOffset(0, 0)
-                end
-                
-                -- Apply text color if prefix is provided
-                if prefix then
-                    local textColor = db[prefix .. "TextColor"]
-                    if textColor then
-                        icon.text:SetTextColor(textColor.r or 1, textColor.g or 1, textColor.b or 1, 1)
-                    end
+                    icon.text:SetTextColor(cr, cg, cb, ca)
                 end
             end
             


### PR DESCRIPTION
12.0.7's multi-alphabet font rework made fontstring-level `SetShadowColor`/`SetShadowOffset` a silent no-op — the shadow now has to live on the font family's per-alphabet font objects. Name/health/aura text already went through `SafeSetFont` (font family) so kept their shadow; status-icon text and the AFK timer set theirs directly on the fontstring, so it vanished.

- `SafeSetFont`'s font-family path no longer *also* sets a fontstring-level shadow, which on 12.0.7 suppressed the font-object shadow it had just applied.
- Status-icon text + the AFK timer now route through `SafeSetFont` (capturing/restoring vertex colour, since `SetFontObject` resets it).
- New `DF:RefreshFontFamilyShadows` updates the cached families' per-alphabet shadow in place; `LightweightUpdateFontShadows` (the Shadow X/Y/Color slider path) calls it and re-renders, so the preview updates live on live, pinned and test frames (the old per-frame fontstring poke did nothing on 12.0.7).
- The AFK timer re-centres on its measured rendered width (SafeSetFont renders via `SetTextScale`, so the old fixed nudge no longer lined up); a representative sample sizes the box so it stays centred and unclipped, including `HH:MM:SS`.
