### PR TITLE
Animate targeted-spell duration timers in Test Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* (Targeted Spells) The on-frame targeted-spell duration timers now count down in Test Mode instead of sitting on a frozen value, so you can preview the look while configuring them. (by Krathe)
 * (Pinned Frames) Text Designer elements now update on pinned frames right away when you add or edit them, instead of only showing up after toggling test mode.
 * (Raid) **Group Display Order** and **My Group First** now reposition the frames live: changing the order (or toggling My Group First) moves the raid frames immediately instead of only moving the group labels and leaving the frames in default order until the next roster change. The **My Group First** setting also now saves when toggled while editing an active auto layout, instead of being lost on reload. (by Krathe)
 * (Arena) Fixed teammates who load in late sometimes staying missing for the whole round, the frame order breaking after a mid-match reload, and frames staying hidden after a reload during a match. (by Krathe)

--- a/Features/TargetedSpells.lua
+++ b/Features/TargetedSpells.lua
@@ -379,6 +379,30 @@ local function CreateSingleIcon(parent, index)
     -- OnUpdate for cleanup checking and duration text
     local durationThrottle = 0
     container:SetScript("OnUpdate", function(self, elapsed)
+        -- Test mode: live timers come from durationObject (a secret aura value)
+        -- which test icons don't have, so drive a looping fake countdown here so
+        -- the preview animates instead of sitting static.
+        if self.dfTestTimer and (DF.testMode or DF.raidTestMode) then
+            local t = self.dfTestTimer
+            local cyc = (GetTime() + (t.offset or 0)) % t.duration
+            -- Re-arm the cooldown swipe whenever the cycle wraps, so it loops.
+            if self.cooldown and (not t.last or cyc < t.last) then
+                self.cooldown:SetCooldown(GetTime() - cyc, t.duration)
+            end
+            t.last = cyc
+            durationThrottle = durationThrottle + elapsed
+            if durationThrottle >= 0.1 then
+                durationThrottle = 0
+                if self.durationText and self.durationText:IsShown() then
+                    self.durationText:SetFormattedText("%.1f", t.duration - cyc)
+                    if self.durationColor then
+                        self.durationText:SetTextColor(self.durationColor.r, self.durationColor.g, self.durationColor.b, 1)
+                    end
+                end
+            end
+            return
+        end
+
         -- Skip if not active (alpha is controlled by SetAlphaFromBoolean, can't read it)
         if not self.isActive then return end
         

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -5508,13 +5508,19 @@ function DF:UpdateTestTargetedSpell(frame, testData)
                 if icon.durationText then
                     icon.durationText:Hide()
                 end
+                icon.dfTestTimer = nil  -- interrupted icons don't count down
             else
                 -- Normal spell display
                 icon.icon:SetDesaturated(false)
-                
+
                 if icon.interruptOverlay then
                     icon.interruptOverlay:Hide()
                 end
+
+                -- Animate the preview timer: the container OnUpdate loops this
+                -- fake countdown (live timers use a durationObject test lacks).
+                icon.durationColor = durationColor
+                icon.dfTestTimer = { duration = 3, offset = i * 0.5 }
                 
                 -- Cooldown on icon
                 if icon.cooldown then


### PR DESCRIPTION
Live timers come from a `durationObject` (a secret aura value) which test icons don't have, so the test render set the cooldown swipe and duration text once from `GetTime()` and they sat static.

Drives a looping fake countdown from the icon container's `OnUpdate` when a test marker is present (guarded by test mode so it can never touch live icons), re-arming the swipe each cycle. Interrupted test icons opt out (they show the X, no countdown).
