### PR TITLE
Fix SetGradient secret-value crash on expiring gradient borders in combat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug Fixes
 
+* (Aura Designer) Fixed a Lua error that could spam in combat when an aura indicator used a **Gradient** border together with **Expiring Colour Override** — the expiring colour resolves through the aura's protected duration in combat, and the border's gradient-clear step rejected it. The border now recolours cleanly. (by Krathe)
 * (Pinned Frames) Text Designer elements now update on pinned frames right away when you add or edit them, instead of only showing up after toggling test mode.
 * (Raid) **Group Display Order** and **My Group First** now reposition the frames live: changing the order (or toggling My Group First) moves the raid frames immediately instead of only moving the group labels and leaving the frames in default order until the next roster change. The **My Group First** setting also now saves when toggled while editing an active auto layout, instead of being lost on reload. (by Krathe)
 * (Arena) Fixed teammates who load in late sometimes staying missing for the whole round, the frame order breaking after a mid-match reload, and frames staying hidden after a reload during a match. (by Krathe)

--- a/Frames/Border.lua
+++ b/Frames/Border.lua
@@ -25,6 +25,9 @@ local addonName, DF = ...
 
 local CreateFrame = CreateFrame
 local ipairs = ipairs
+-- Midnight-safe: test a colour channel for secretness before feeding it to
+-- CreateColor()/SetGradient (which reject secret values).
+local issecretvalue = issecretvalue or function() return false end
 
 DF.Border = DF.Border or {}
 local Border = DF.Border
@@ -83,9 +86,17 @@ function Border:New(parent, opts)
             -- both cheaper and safe for secret-tinted colours (CreateColor on a
             -- secret value taints execution).
             if not self._solidOnly and CreateColor then
-                local solid = CreateColor(r, g, b, a)
+                -- Reset any leftover gradient before the solid SetColorTexture.
+                -- Use the real colour when non-secret (so a Blizzard pipeline that
+                -- leaves the gradient in place still shows the right colour), but
+                -- fall back to white when ANY channel is SECRET — CreateColor on a
+                -- secret makes SetGradient throw "bad argument" (the expiring path
+                -- passes secret colours in combat). SetColorTexture below paints
+                -- the real, secret-safe colour either way.
+                local clear = (issecretvalue(r) or issecretvalue(g) or issecretvalue(b) or issecretvalue(a))
+                    and CreateColor(1, 1, 1, 1) or CreateColor(r, g, b, a)
                 for _, e in ipairs(edges) do
-                    if e.SetGradient then e:SetGradient("HORIZONTAL", solid, solid) end
+                    if e.SetGradient then e:SetGradient("HORIZONTAL", clear, clear) end
                 end
             end
             for _, e in ipairs(edges) do
@@ -1431,9 +1442,18 @@ function Border:Apply(border, spec)
             -- nothing to clear — skip it so the edges carry no gradient and a
             -- later bare-SetColorTexture recolour stays clean and secret-safe.
             if not border._solidOnly and CreateColor then
-                local solid = CreateColor(cr, cg, cb, ca)
+                -- Reset any leftover gradient before the solid SetColorTexture.
+                -- Use the real colour when non-secret (so a Blizzard pipeline that
+                -- leaves the gradient in place stays correct), but fall back to
+                -- white when ANY channel is SECRET — on the expiring path in combat
+                -- the colour curve resolves through the aura's secret Duration
+                -- object, and CreateColor on a secret makes SetGradient throw "bad
+                -- argument #2". SetColorTexture below paints the real, secret-safe
+                -- colour either way.
+                local clear = (issecretvalue(cr) or issecretvalue(cg) or issecretvalue(cb) or issecretvalue(ca))
+                    and CreateColor(1, 1, 1, 1) or CreateColor(cr, cg, cb, ca)
                 for _, e in ipairs(edges) do
-                    if e.SetGradient then e:SetGradient("HORIZONTAL", solid, solid) end
+                    if e.SetGradient then e:SetGradient("HORIZONTAL", clear, clear) end
                 end
             end
             for _, e in ipairs(edges) do


### PR DESCRIPTION
An Aura Designer icon/square/bar border with a **Gradient** base style and **Expiring Colour Override** flattens to SOLID below threshold. In combat the expiring colour is resolved through the aura's secret Duration object, so its channels are secret — and the solid branch's "clear leftover gradient" step did `CreateColor(secret)` → `SetGradient`, which throws `bad argument #2` (spammed ~58×). The following `SetColorTexture` is secret-safe, so only `SetGradient` choked.

Both gradient-clear sites (`Apply`'s solid branch and `border:SetColor`) now use the real colour only when non-secret (unchanged behaviour — keeps the edge-case Blizzard pipeline correct) and fall back to a constant white when any channel is secret. `SetColorTexture` paints the real, secret-safe colour either way. The gradient *render* branch was already safe (static stop colours; the expiring path flattens away from it).
