### PR TITLE
Fix GUI settings that didn't take effect (wiring audit follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Resource Bar) The **Smooth Bar Animation** toggle now actually smooths the resource/power bar's fill — it previously had no effect. (by Krathe)
+* (Buffs / Debuffs) Fixed pixel-perfect aura icons being sized as if the border were 1px when you set a different **Border Thickness**, which could slightly over-size the icon and misalign its art. (by Krathe)
+* (Status Icons) The **Frame Level** slider now previews live while dragging for the Resurrection, Phased, AFK, Vehicle, Raid Role and Summon icons (matching Scale and Alpha); the value applied before, but only after the next frame rebuild. (by Krathe)
+* (Profiles) The **Missing Buff** and **Defensive** icon **Border Color Source** (Class/Role) is now preserved when exporting or importing a single category, instead of reverting to a static colour. (by Krathe)
+* (Click Casting) A binding's **combat condition** (In/Out of Combat) now shows in the bindings list immediately after you add it, instead of only appearing after a `/reload`. (by Krathe)
+* (Debuffs) Removed the **Highlight Dispellable** toggle, which no longer did anything — dispellable highlighting is handled by the **Dispel Overlay** feature. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/ClickCasting/Bindings.lua
+++ b/ClickCasting/Bindings.lua
@@ -1221,7 +1221,11 @@ function CC:GetBindingKeyText(binding, includeCombatState)
     
     -- Add combat state indicator if requested
     if includeCombatState then
-        local combatSetting = binding.combat or "always"
+        -- Fall back to legacy loadCombat for freshly-added bindings (pre profile-load migration)
+        local combatSetting = binding.combat
+            or (binding.loadCombat == "combat" and "incombat")
+            or (binding.loadCombat == "nocombat" and "outofcombat")
+            or "always"
         if combatSetting == "incombat" then
             result = result .. " [C]"
         elseif combatSetting == "outofcombat" then

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -733,7 +733,12 @@ function CC:CreateBindingRow(parent, binding, index)
     local isMacro = (actionType == "macro") or (binding.macroId ~= nil)
     local fallback = binding.fallback or {}
     local fallbackText = isMacro and nil or GetFallbackDisplayText(fallback)
-    local combatSetting = binding.combat or "always"
+    -- Fall back to the legacy loadCombat field for freshly-added bindings (the
+    -- loadCombat -> combat migration only runs at profile load); map its vocabulary.
+    local combatSetting = binding.combat
+        or (binding.loadCombat == "combat" and "incombat")
+        or (binding.loadCombat == "nocombat" and "outofcombat")
+        or "always"
     
     local targetingInfo = row:CreateFontString(nil, "OVERLAY", "DFFontHighlightSmall")
     targetingInfo:SetPoint("TOPLEFT", name, "BOTTOMLEFT", 0, -2)

--- a/Config.lua
+++ b/Config.lua
@@ -1399,7 +1399,6 @@ DF.PartyDefaults = {
     dispelShowMagic = true,
     dispelShowPoison = true,
     dispelNameText = false,
-    dispellableHighlight = true,
 
     -- Dispel overlay source selector (Phase 1 UI uses bridge to old toggles)
     -- Values: "off" | "dandersframes" | "blizzard" | "both"
@@ -2169,7 +2168,6 @@ DF.PartyDefaults = {
     targetedSpellImportantBorderTexture = "SOLID",
     targetedSpellDisableMouse = false,
     targetedSpellDurationColor = {r = 1, g = 1, b = 1},
-    targetedSpellDurationColorByTime = false,
     targetedSpellDurationFont = "DF Roboto SemiBold",
     targetedSpellDurationOutline = "SHADOW",
     targetedSpellDurationScale = 1,
@@ -3076,7 +3074,6 @@ DF.RaidDefaults = {
     dispelShowMagic = true,
     dispelShowPoison = true,
     dispelNameText = false,
-    dispellableHighlight = true,
 
     -- Dispel overlay source selector (Phase 1 UI uses bridge to old toggles)
     -- Values: "off" | "dandersframes" | "blizzard" | "both"
@@ -3846,7 +3843,6 @@ DF.RaidDefaults = {
     targetedSpellImportantBorderTexture = "SOLID",
     targetedSpellDisableMouse = false,
     targetedSpellDurationColor = {r = 1, g = 1, b = 1},
-    targetedSpellDurationColorByTime = false,
     targetedSpellDurationFont = "DF Roboto SemiBold",
     targetedSpellDurationOutline = "SHADOW",
     targetedSpellDurationScale = 1,

--- a/Core.lua
+++ b/Core.lua
@@ -1537,7 +1537,19 @@ function DF:LightweightUpdateFrameLevel(elementType)
     local mode = DF.GUI and DF.GUI.SelectedMode or "party"
     local db = DF.db[mode]
     if not db then return end
-    
+
+    -- Status icons whose full-render frame level (ApplyIconSettings) is
+    -- (parent-of-parent level + value); mirror that here so the Frame Level
+    -- slider previews live, matching Scale/Alpha. Keyed elementType -> frame field.
+    local SIMPLE_LEVEL_ICONS = {
+        resurrection = "resurrectionIcon",
+        phased       = "phasedIcon",
+        afk          = "afkIcon",
+        vehicle      = "vehicleIcon",
+        raidRole     = "raidRoleIcon",
+        summon       = "summonIcon",
+    }
+
     local function UpdateLevel(frame)
         if not frame then return end
         
@@ -1599,6 +1611,16 @@ function DF:LightweightUpdateFrameLevel(elementType)
                 frame.centerStatusIcon:SetFrameLevel(frameBaseLevel + level)
             else
                 frame.centerStatusIcon:SetFrameLevel(baseLevel + 5)
+            end
+        else
+            -- resurrection / phased / afk / vehicle / raidRole / summon icons
+            local field = SIMPLE_LEVEL_ICONS[elementType]
+            local icon = field and frame[field]
+            if icon then
+                local level = db[field .. "FrameLevel"] or 0
+                if level > 0 then
+                    icon:SetFrameLevel(icon:GetParent():GetParent():GetFrameLevel() + level)
+                end
             end
         end
     end

--- a/ExportCategories.lua
+++ b/ExportCategories.lua
@@ -759,6 +759,7 @@ DF.ExportCategories = {
         "defensiveIconBorderAnimationType",
         "defensiveIconBorderBlendMode",
         "defensiveIconBorderColor",
+        "defensiveIconBorderColorSource",
         "defensiveIconBorderGradientDirection",
         "defensiveIconBorderGradientEnabled",
         "defensiveIconBorderGradientEndColor",
@@ -823,7 +824,6 @@ DF.ExportCategories = {
         "targetedSpellDurationX",
         "targetedSpellDurationY",
         "targetedSpellDurationColor",
-        "targetedSpellDurationColorByTime",
         "targetedSpellGrowth",
         "targetedSpellSpacing",
         "targetedSpellFrameLevel",
@@ -1034,7 +1034,6 @@ DF.ExportCategories = {
         "dispelOnlyPlayerTypes",
         "dispelAnimate",
         "dispelAnimateSpeed",
-        "dispellableHighlight",
         
         -- Missing Buff Icon
         "missingBuffIconEnabled",
@@ -1060,6 +1059,7 @@ DF.ExportCategories = {
         "missingBuffIconBorderAnimationType",
         "missingBuffIconBorderBlendMode",
         "missingBuffIconBorderColor",
+        "missingBuffIconBorderColorSource",
         "missingBuffIconBorderGradientDirection",
         "missingBuffIconBorderGradientEndColor",
         "missingBuffIconBorderGradientStartColor",

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -3101,8 +3101,9 @@ function DF:RepositionCenterGrowthIcons(frame, icons, auraType, visibleCount)
     local offsetY = db[prefix .. "OffsetY"] or 0
     local paddingX = db[prefix .. "PaddingX"] or 2
     local paddingY = db[prefix .. "PaddingY"] or 2
-    local borderThickness = db[prefix .. "BorderThickness"] or 1
-    
+    -- Canonical key is <prefix>BorderSize; <prefix>BorderThickness is a legacy fallback only.
+    local borderThickness = db[prefix .. "BorderSize"] or db[prefix .. "BorderThickness"] or 1
+
     -- Apply pixel-perfect sizing
     if db.pixelPerfect then
         size, scale, borderThickness = DF:PixelPerfectSizeAndScaleForBorder(size, scale, borderThickness)

--- a/Frames/Bars.lua
+++ b/Frames/Bars.lua
@@ -191,7 +191,7 @@ function DF:ApplyResourceBarLayout(frame)
         local power = UnitPower(unit)
         local maxPower = UnitPowerMax(unit)
         bar:SetMinMaxValues(0, maxPower)
-        bar:SetValue(power)
+        DF.SetBarValue(bar, power, frame, db.resourceBarSmooth)
         local cr, cg, cb = DF:GetResourceBarColor(unit, db)
         bar:SetStatusBarColor(cr, cg, cb, 1)
     end
@@ -226,8 +226,8 @@ function DF:UpdateResourceBar(frame)
     
     if maxPower then
         bar:SetMinMaxValues(0, maxPower)
-        DF.SetBarValue(bar, power, frame)
-        
+        DF.SetBarValue(bar, power, frame, db.resourceBarSmooth)
+
         -- Resolve fill colour per the configured colour mode (power / class / custom).
         local cr, cg, cb = DF:GetResourceBarColor(unit, db)
         bar:SetStatusBarColor(cr, cg, cb, 1)

--- a/Frames/Colors.lua
+++ b/Frames/Colors.lua
@@ -78,9 +78,9 @@ end
 -- ============================================================
 -- Uses the new 12.0.5 StatusBar:SetValue interpolation when smoothBars is enabled
 
-local function SetBarValue(bar, value, frame)
+local function SetBarValue(bar, value, frame, smoothOverride)
     if not bar or not bar.SetValue then return end
-    
+
     -- Get the appropriate db for this frame
     local db
     if frame and frame.isRaidFrame then
@@ -88,7 +88,14 @@ local function SetBarValue(bar, value, frame)
     else
         db = DF.GetDB and DF:GetDB()
     end
-    local smoothEnabled = db and db.smoothBars
+    -- smoothOverride lets a specific bar gate on its own key (e.g. resourceBarSmooth)
+    -- instead of the global health-bar smoothBars toggle.
+    local smoothEnabled
+    if smoothOverride ~= nil then
+        smoothEnabled = smoothOverride
+    else
+        smoothEnabled = db and db.smoothBars
+    end
     
     if smoothEnabled and Enum and Enum.StatusBarInterpolation and Enum.StatusBarInterpolation.ExponentialEaseOut then
         bar:SetValue(value, Enum.StatusBarInterpolation.ExponentialEaseOut)

--- a/Frames/Pets.lua
+++ b/Frames/Pets.lua
@@ -642,7 +642,7 @@ function DF:UpdatePetFrameTestMode(frame)
     -- Update health text if shown
     if frame.healthText then
         local db = DF:GetFrameDB(frame)
-        if db.petShowHealth and not hideLegacyText then
+        if db.petShowHealthText and not hideLegacyText then
             local maxHealth = 50000
             local currentHealth = math.floor(maxHealth * healthPercent)
             frame.healthText:SetText(string.format("%d%%", math.floor(healthPercent * 100)))

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -1604,8 +1604,9 @@ function DF:ApplyAuraLayout(frame, auraType)
     local paddingX = db[prefix .. "PaddingX"] or 2
     local paddingY = db[prefix .. "PaddingY"] or 2
     
-    -- Get border thickness for this aura type (needed for pixel-perfect size calculation)
-    local borderThickness = db[prefix .. "BorderThickness"] or 1
+    -- Get border thickness for this aura type (needed for pixel-perfect size calculation).
+    -- Canonical key is <prefix>BorderSize; <prefix>BorderThickness is a legacy fallback only.
+    local borderThickness = db[prefix .. "BorderSize"] or db[prefix .. "BorderThickness"] or 1
     
     -- Apply pixel-perfect sizing to aura size and scale together, adjusting for border
     if db.pixelPerfect then

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -6042,8 +6042,6 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             -- debuff hides/shows immediately instead of waiting for the next aura event.
             DF:RefreshAllVisibleFrames()
         end), 30)
-        local dispelHighlight = settingsGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Highlight Dispellable"], db, "dispellableHighlight", nil), 30)
-        dispelHighlight.disableOn = function(d) return not d.showDebuffs end
         local debuffMax = settingsGroup:AddWidget(GUI:CreateSlider(self.child, L["Max Debuffs"], 0, 8, 1, db, "debuffMax", nil, function() DF:RefreshAllVisibleFrames() end, true), 55)
         debuffMax.disableOn = function(d) return not d.showDebuffs end
         local debuffSize = settingsGroup:AddWidget(GUI:CreateSlider(self.child, L["Icon Size"], 10, 40, 1, db, "debuffSize", nil, function() DF:LightweightUpdateAuraPosition("debuff") end, true), 55)


### PR DESCRIPTION
## Summary

A batch of low-severity wiring fixes from an audit of GUI setting → render-read consistency. Each is a setting that didn't do what it said, or a value that only applied on the wrong path.

- **Resource Bar — "Smooth Bar Animation"** was written but read nowhere (real smoothing keyed off the separate global health-bar `smoothBars`). The resource-bar value now routes through the smoothing helper gated on `resourceBarSmooth`.
- **Pixel-perfect aura icon sizing** read a stale legacy `<prefix>BorderThickness` (always nil → pinned to 1), so with Pixel Perfect on and a non-default **Border Thickness** the icon footprint/inset were computed as if the border were 1px. Now reads the canonical `<prefix>BorderSize`.
- **Frame Level live preview** — `LightweightUpdateFrameLevel` had no branch for the resurrection / phased / afk / vehicle / raidRole / summon icons, so dragging the slider produced no live preview (the value still applied on the next rebuild). Added a branch mirroring the full render.
- **Click-cast combat condition** on a freshly-added binding now shows in the bindings list immediately — the row display readers fall back to the legacy `loadCombat` field (vocabulary-mapped) before the profile-load migration runs.
- **Export coverage** — added `missingBuffIconBorderColorSource` and `defensiveIconBorderColorSource` to the export allowlist, so a single-category export/import preserves the Class/Role border colour source instead of reverting to static.
- **Removed dead settings** — the **Highlight Dispellable** toggle (read nowhere; superseded by the Dispel Overlay feature) and the unused `targetedSpellDurationColorByTime` default (no GUI control, no reader).
- **Test-mode pet frame** read `petShowHealth` (never set); now uses `petShowHealthText`, matching the live path.

## Testing

Verified each setting now behaves: resource bar smooths and toggles off; pixel-perfect icons stay aligned at thickness > 1; the six frame-level sliders preview live; the combat indicator appears without `/reload`; a single-category export/import keeps the colour source; the removed toggles are gone with dispel highlighting still working via Dispel Overlay.