### PR TITLE
Pinned frames: inherit Horizontal/Vertical Spacing as a Match override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Improvements
+
+* (Pinned Frames) Each pinned set's **Horizontal** and **Vertical Spacing** now inherit from the Based-on mode — the grouped frame spacing, or the flat raid spacing — and can be overridden per set with a star and a reset, the same way Width / Height / Scale already do. A pinned set now stays aligned with the frames it mirrors instead of falling back to a fixed spacing. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/Core.lua
+++ b/Core.lua
@@ -1833,6 +1833,12 @@ function DF:MigratePinnedMatchMode()
                         -- a value still at the old hard default (1.0) is treated as
                         -- "inherit" (cleared); a changed value is kept as override.
                         if set.scale == 1.0 then set.scale = nil end
+                        -- Spacing inherits the Based-on mode's frameSpacing unless
+                        -- overridden: the old hard default was 2, so a value still
+                        -- at 2 is treated as "inherit" (cleared); a non-2 value is
+                        -- kept as a deliberate override.
+                        if set.horizontalSpacing == 2 then set.horizontalSpacing = nil end
+                        if set.verticalSpacing == 2 then set.verticalSpacing = nil end
                         -- growDirection is a plain pinned-only setting; an earlier
                         -- build briefly cleared its HORIZONTAL default to nil, so
                         -- restore a concrete value for the dropdown.

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -236,6 +236,27 @@ local function GetSetScale(set, db)
     return (b and b.frameScale) or 1.0
 end
 
+-- Pinned row/column spacing inherits the Based-on mode's layout spacing when the
+-- per-set value is unset (nil), exactly like GetSetScale inherits frameScale.
+-- Without this a pinned set sat on a hardcoded default of 2 and drifted out of
+-- alignment with a raid whose frameSpacing was e.g. 1.  Grouped party / grouped
+-- raid use a single frameSpacing for both axes; flat raid uses
+-- raidFlatHorizontalSpacing / raidFlatVerticalSpacing.  A non-nil per-set
+-- horizontalSpacing / verticalSpacing override wins.  Returns hSpacing, vSpacing.
+local function GetSetSpacing(set, db)
+    local b = GetSetBaselineDB(set, db or GetPinnedModeDB())
+    local bh, bv
+    if b and b.raidUseGroups == false then
+        bh, bv = (b.raidFlatHorizontalSpacing or 2), (b.raidFlatVerticalSpacing or 2)
+    else
+        local s = (b and b.frameSpacing) or 2
+        bh, bv = s, s
+    end
+    local h = set and set.horizontalSpacing
+    local v = set and set.verticalSpacing
+    return (h ~= nil) and h or bh, (v ~= nil) and v or bv
+end
+
 -- Frame-border keys are all "frame…Border…" (frameShowBorder, frameBorderStyle,
 -- frameBorderColor, …); pixelPerfect is the one extra frame-level key BuildSpec
 -- reads. Used to snapshot a set's Border Override from the Based-on mode.
@@ -980,8 +1001,7 @@ function PinnedFrames:UpdateBossHandlerConfig(setIndex)
     if not db then return end
 
     local frameWidth, frameHeight = GetSetFrameSize(set, db)
-    local hSpacing      = set.horizontalSpacing or 2
-    local vSpacing      = set.verticalSpacing or 2
+    local hSpacing, vSpacing = GetSetSpacing(set, db)
     local unitsPerRow   = set.unitsPerRow or 5
     local horizontal    = (GetSetGrowDirection(set) == "HORIZONTAL")
     local frameAnchor   = set.frameAnchor or "START"
@@ -1804,8 +1824,7 @@ function PinnedFrames:ApplyLayoutSettings(setIndex)
     end
     
     local horizontal = GetSetGrowDirection(set) == "HORIZONTAL"
-    local hSpacing = set.horizontalSpacing or 2
-    local vSpacing = set.verticalSpacing or 2
+    local hSpacing, vSpacing = GetSetSpacing(set, db)
     local unitsPerRow = set.unitsPerRow or 5
     local columnAnchor = set.columnAnchor or "START"
     local frameAnchor = set.frameAnchor or "START"
@@ -2016,7 +2035,8 @@ function PinnedFrames:ResizeContainer(setIndex)
         end
 
         local horizontal = GetSetGrowDirection(set) == "HORIZONTAL"
-        local spacing = horizontal and (set.horizontalSpacing or 2) or (set.verticalSpacing or 2)
+        local hSp, vSp = GetSetSpacing(set, db)
+        local spacing = horizontal and hSp or vSp
         local unitsPerRow = set.unitsPerRow or 5
 
         local rows = math.ceil(visibleCount / unitsPerRow)
@@ -2025,9 +2045,9 @@ function PinnedFrames:ResizeContainer(setIndex)
         local width, height
         if horizontal then
             width = cols * frameWidth + (cols - 1) * spacing
-            height = rows * frameHeight + (rows - 1) * (set.verticalSpacing or 2)
+            height = rows * frameHeight + (rows - 1) * vSp
         else
-            width = rows * frameWidth + (rows - 1) * (set.horizontalSpacing or 2)
+            width = rows * frameWidth + (rows - 1) * hSp
             height = cols * frameHeight + (cols - 1) * spacing
         end
 
@@ -2050,7 +2070,8 @@ function PinnedFrames:ResizeContainer(setIndex)
     end
     
     local horizontal = GetSetGrowDirection(set) == "HORIZONTAL"
-    local spacing = horizontal and (set.horizontalSpacing or 2) or (set.verticalSpacing or 2)
+    local hSp, vSp = GetSetSpacing(set, db)
+    local spacing = horizontal and hSp or vSp
     local unitsPerRow = set.unitsPerRow or 5
     
     local rows = math.ceil(visibleCount / unitsPerRow)
@@ -2059,9 +2080,9 @@ function PinnedFrames:ResizeContainer(setIndex)
     local width, height
     if horizontal then
         width = cols * frameWidth + (cols - 1) * spacing
-        height = rows * frameHeight + (rows - 1) * (set.verticalSpacing or 2)
+        height = rows * frameHeight + (rows - 1) * vSp
     else
-        width = rows * frameWidth + (rows - 1) * (set.horizontalSpacing or 2)
+        width = rows * frameWidth + (rows - 1) * hSp
         height = cols * frameHeight + (cols - 1) * spacing
     end
     
@@ -2589,8 +2610,9 @@ local function MakeDefaultSet(index)
         players = {},
         growDirection = "HORIZONTAL",
         unitsPerRow = 5,
-        horizontalSpacing = 2,
-        verticalSpacing = 2,
+        -- horizontalSpacing / verticalSpacing left unset (nil) so a new set
+        -- INHERITS its Based-on mode's frameSpacing via GetSetSpacing; set a
+        -- value only to override (keeps pinned aligned with the frames it mirrors).
         position = { point = "CENTER", x = 0, y = 250 - (index - 1) * 130 },
         showLabel = false,
         columnAnchor = "START",
@@ -3501,8 +3523,7 @@ function PinnedFrames:ApplyPlayerTestLayout(setIndex, set, isRaidMode)
     local borderDB = GetSetBorderDB(set, GetSetBaselineDB(set, db))
     local effDB = BuildPinnedEffDB(db, set.hideAuras, set.hideIcons)
 
-    local hSpacing = set.horizontalSpacing or 2
-    local vSpacing = set.verticalSpacing or 2
+    local hSpacing, vSpacing = GetSetSpacing(set, db)
     local unitsPerRow = set.unitsPerRow or 5
     local frameAnchor = set.frameAnchor or "START"
     local columnAnchor = set.columnAnchor or "START"

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -2959,6 +2959,12 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
                 local set = GetCurrentSet()
                 local mode = (set and set.matchMode) or GUI.SelectedMode
                 local mdb = DF:GetDB(mode)
+                -- baselineKey may be a function (mdb, set) -> value, for settings
+                -- whose inherited source is mode-dependent (e.g. spacing: grouped
+                -- raid uses frameSpacing, flat raid uses raidFlat*Spacing).
+                if type(baselineKey) == "function" then
+                    return baselineKey(mdb, set) or minVal
+                end
                 return (mdb and mdb[baselineKey]) or minVal
             end
             -- Float-tolerant compare (half a step): fractional-step slider drags
@@ -3627,10 +3633,13 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         -- displayed baseline when the matched mode changes (an un-overridden control
         -- then shows the new mode's value; an overridden one keeps its star).
         local pinnedWidthSlider, pinnedHeightSlider, pinnedScaleSlider
+        local pinnedHSpacingSlider, pinnedVSpacingSlider
         local function RefreshMatchOverrides()
             if pinnedWidthSlider then pinnedWidthSlider.Refresh() end
             if pinnedHeightSlider then pinnedHeightSlider.Refresh() end
             if pinnedScaleSlider then pinnedScaleSlider.Refresh() end
+            if pinnedHSpacingSlider then pinnedHSpacingSlider.Refresh() end
+            if pinnedVSpacingSlider then pinnedVSpacingSlider.Refresh() end
         end
 
         local matchOptions = { party = L["Party"], raid = L["Raid"] }
@@ -3737,8 +3746,11 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         Add(layoutGroup, nil, 1)
         layoutGroup.hideOn = function() return activeSubTab ~= "appearance" end  -- Appearance tab
 
-        -- ===== LAYOUT GROUP (Column 2) — pinned-only arrangement (no main-frame
-        -- equivalent, so these are independent settings, not Match overrides) =====
+        -- ===== LAYOUT GROUP (Column 2) — pinned arrangement. Direction / growth /
+        -- units-per-row are pinned-only (no main-frame equivalent). Spacing IS a
+        -- Match override: it inherits the Based-on mode's frameSpacing (grouped) /
+        -- raidFlat*Spacing (flat) so a pinned set stays aligned with the frames it
+        -- mirrors, overridable per set. =====
         local arrangeGroup = GUI:CreateSettingsGroup(self.child, 280)
         arrangeGroup:AddWidget(GUI:CreateHeader(self.child, L["Layout"]), 40)
 
@@ -3757,8 +3769,18 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         arrangeGroup:AddWidget(CreateRefreshableDropdown(self.child, L["Column Growth"], columnAnchorOptions, "columnAnchor", UpdateHighlightLayout), 55)
 
         arrangeGroup:AddWidget(CreateRefreshableSlider(self.child, L["Units Per Row"], 1, 10, 1, "unitsPerRow", UpdateHighlightLayout), 55)
-        arrangeGroup:AddWidget(CreateRefreshableSlider(self.child, L["Horizontal Spacing"], -5, 50, 1, "horizontalSpacing", UpdateHighlightLayout), 55)
-        arrangeGroup:AddWidget(CreateRefreshableSlider(self.child, L["Vertical Spacing"], -5, 50, 1, "verticalSpacing", UpdateHighlightLayout), 55)
+        -- Spacing inherits the Based-on mode's layout spacing (grouped -> frameSpacing,
+        -- flat raid -> raidFlat*Spacing); a per-set value overrides it (gold star + reset).
+        local function SpacingBaseline(flatKey)
+            return function(mdb)
+                if mdb and mdb.raidUseGroups == false then return mdb[flatKey] or 2 end
+                return (mdb and mdb.frameSpacing) or 2
+            end
+        end
+        pinnedHSpacingSlider = CreateMatchOverrideSlider(self.child, L["Horizontal Spacing"], -5, 50, 1, "horizontalSpacing", SpacingBaseline("raidFlatHorizontalSpacing"), UpdateHighlightLayout)
+        arrangeGroup:AddWidget(pinnedHSpacingSlider, 55)
+        pinnedVSpacingSlider = CreateMatchOverrideSlider(self.child, L["Vertical Spacing"], -5, 50, 1, "verticalSpacing", SpacingBaseline("raidFlatVerticalSpacing"), UpdateHighlightLayout)
+        arrangeGroup:AddWidget(pinnedVSpacingSlider, 55)
         Add(arrangeGroup, nil, 2)
         arrangeGroup.hideOn = function() return activeSubTab ~= "appearance" end  -- Appearance tab
 


### PR DESCRIPTION
## Summary

Per-set pinned **Horizontal / Vertical Spacing** was a fixed fallback (2) with no inheritance, so a pinned set could drift from the frames it mirrors. Spacing now behaves like the existing Width / Height / Scale Match overrides:

- A `GetSetSpacing` resolver resolves spacing through the **Based-on** mode's baseline — the grouped `frameSpacing`, or the flat raid horizontal/vertical spacing — when the per-set value is unset.
- The H/V Spacing sliders use `CreateMatchOverrideSlider`, so each shows the inherited value with a **star** and a **reset**, and `RefreshMatchOverrides` updates them when the matched mode changes. (`CreateMatchOverrideSlider` gains support for a function-valued baseline so the grouped/flat baseline can be computed.)
- A small migration normalises any stored spacing `== 2` back to `nil` (inherit), so existing sets pick up inheritance.

## Testing

Per-set spacing shows the inherited value with the star/reset; overriding and resetting behave like the other Match overrides; pinned spacing matches the mirrored frames.