### PR TITLE
Aura Designer: health-bar Tint indicator fills the whole bar

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1388,22 +1388,15 @@ function Indicators:ApplyHealthBar(frame, config, auraData)
         -- ============================================================
         local overlay = GetOrCreateTintOverlay(frame)
         if overlay then
-            -- Keep the AD overlay off the frame border. With framePadding 0 the health
-            -- bar fills the whole frame and the border is drawn inward over its edge, so
-            -- a full-bar overlay sits *under* the border. Out of range the border fades
-            -- to its OOR alpha and the AD tint beneath shows through it, tinting the
-            -- border. Inset the overlay by the border thickness so it never reaches
-            -- under the border. (Replace mode doesn't need this — the real bar already
-            -- sits under the inward border exactly like a normal class-coloured bar.)
-            local _fdb = DF:GetFrameDB(frame)
-            local _bInset = (frame.border and frame.border:IsShown() and _fdb and _fdb.frameBorderSize) or 0
+            -- Full-size. The frame border (frame level +10) draws inward over the health
+            -- bar's edge and sits ABOVE the overlay, so it covers the overlay's outer ring
+            -- and the tint fills the whole visible bar — no missing edge pixels, matching
+            -- replace mode. (Out of range the faded border can let a faint tint show
+            -- through it; gating an inset on the OOR flag proved unreliable — UnitInRange
+            -- returns secret/stale values in instances, sticking the flag and insetting in
+            -- range — so we keep it simple and full-size.)
             overlay:ClearAllPoints()
-            if _bInset > 0 then
-                overlay:SetPoint("TOPLEFT", healthBar, "TOPLEFT", _bInset, -_bInset)
-                overlay:SetPoint("BOTTOMRIGHT", healthBar, "BOTTOMRIGHT", -_bInset, _bInset)
-            else
-                overlay:SetAllPoints(healthBar)
-            end
+            overlay:SetAllPoints(healthBar)
 
             -- Re-sync texture in case the health bar's texture changed since the overlay
             -- was first created (frame recycled to a different unit can swap textures).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Aura Designer) Fixed a **health-bar Tint** indicator leaving the last 1–2 pixels unfilled at each edge of the bar when a frame border was shown — the tint was inset by the border thickness. The tint now fills the whole bar (the border draws on top and frames it cleanly), matching the Replace mode. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/Features/ElementAppearance.lua
+++ b/Features/ElementAppearance.lua
@@ -1157,21 +1157,14 @@ function DF:UpdateAuraDesignerAppearance(frame)
 
     local inRange = GetInRange(frame)
 
-    -- Keep the AD tint/replace overlay inset off the frame border. This is also
-    -- done in ApplyHealthBar, but that only runs on an aura (re)apply — a range
-    -- transition doesn't re-run it, so without re-anchoring here the overlay kept
-    -- its full-frame extent and showed over the border until the next aura tick.
-    -- This pass runs on the range change, so the inset lands immediately.
+    -- Keep the AD tint overlay full-size (matching ApplyHealthBar). The opaque frame
+    -- border (frame level +10) sits above the overlay and covers its outer ring, so a
+    -- full-size overlay fills the whole visible bar with no missing edge pixels. (This
+    -- pass re-anchors on range changes because ApplyHealthBar only runs on aura apply.)
     local _ov = frame.dfAD and frame.dfAD.tintOverlay
     if _ov and frame.healthBar then
-        local _bi = (frame.border and frame.border:IsShown() and db.frameBorderSize) or 0
         _ov:ClearAllPoints()
-        if _bi > 0 then
-            _ov:SetPoint("TOPLEFT", frame.healthBar, "TOPLEFT", _bi, -_bi)
-            _ov:SetPoint("BOTTOMRIGHT", frame.healthBar, "BOTTOMRIGHT", -_bi, _bi)
-        else
-            _ov:SetAllPoints(frame.healthBar)
-        end
+        _ov:SetAllPoints(frame.healthBar)
     end
 
     if db.oorEnabled then


### PR DESCRIPTION
## Summary

A health-bar **Tint** Aura Designer indicator (e.g. recolouring the bar on Atonement) left the last 1–2 px unfilled at each edge of the bar whenever a frame border was shown, and the gap wandered by a pixel as frame size/scale changed. **Replace** mode was unaffected.

Cause: the tint overlay was inset by `frameBorderSize` on all sides (in two places — the apply path and the range-update re-anchor pass). But the overlay already sits **under** the frame border (border at frame level +10, the overlay at health-bar +1), so the opaque border covers the overlay's outer ring on its own. The inset was redundant and was the sole cause of the un-tinted edge; pixel rounding between the raw inset and the border's actual snapped edge produced the wandering pixel.

Fix: anchor the overlay **full-size** (`SetAllPoints`) at both sites. The tint now fills the whole visible bar, matching Replace mode.

The inset originally existed to stop the tint bleeding through the border when it fades out of range. In practice, with the overlay's own OOR alpha fade, the residual is at most a faint tint on the faded border and reads fine — so full-size-always is the simpler, robust choice. (An OOR-gated inset was tried and rejected: `UnitInRange` returns secret/stale values inside instances, which stuck the flag and re-applied the inset *in* range.)

## Testing

In range: the tint fills the entire bar at multiple frame sizes/scales (verified the overlay rect now matches the health bar exactly). Replace mode unchanged. Out of range: no objectionable border bleed.