### PR TITLE
Defensive icons: click-through for stacked defensives that appear mid-combat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Defensive Icons) Fixed click-through not applying to stacked defensive icons that first appear mid-combat, so external click-casting now passes through them immediately instead of only after combat ends. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/Frames/Icons.lua
+++ b/Frames/Icons.lua
@@ -212,8 +212,10 @@ local function GetOrCreateDefensiveBarIcon(frame, index)
         GameTooltip:Hide()
     end)
 
-    -- Mouse setup: enable hover for tooltips, propagate clicks to parent for bindings
-    -- Same approach as buff/debuff icons — guarded for combat lockdown
+    -- Mouse setup: enable hover for tooltips, propagate clicks to parent for bindings.
+    -- SetPropagateMouseMotion/Clicks ARE protected in combat (ADDON_ACTION_BLOCKED), so
+    -- this must stay combat-guarded; mid-combat creations defer to PLAYER_REGEN_ENABLED.
+    -- (Real fix for bug 961 is pre-creating these icons out of combat — see UpdateDefensiveBar.)
     if not InCombatLockdown() then
         icon:EnableMouse(true)
         if icon.SetPropagateMouseMotion then
@@ -1031,6 +1033,15 @@ function DF:UpdateDefensiveBar(frame)
     local cache = DF.BlizzardAuraCache and DF.BlizzardAuraCache[unit]
     do
         local maxDefs = db.defensiveBarMax or 4
+        -- Bug 961: the click-passthrough setup in GetOrCreateDefensiveBarIcon
+        -- (SetPropagateMouseMotion/Clicks) is combat-protected, so an extra defensive
+        -- icon first created mid-combat can't be made click-through until combat ends.
+        -- This function runs on every aura update, so pre-create the whole extra-icon
+        -- pool here while out of combat — the icons are created hidden and stay
+        -- click-through, so they're ready (and pass clicks) the moment combat starts.
+        if not InCombatLockdown() then
+            for i = 2, maxDefs do GetOrCreateDefensiveBarIcon(frame, i) end
+        end
         local iconSize = db.defensiveIconSize or 24
         local borderSize = db.defensiveIconBorderSize or 2
         local borderColor = db.defensiveIconBorderColor or DEFAULT_DEFENSIVE_BORDER_COLOR
@@ -1328,7 +1339,16 @@ function DF:UpdateAuraClickThrough()
     -- Use SetMouseClickEnabled(false) to allow tooltips while passing clicks through
     -- This is Cell's approach for click-casting compatibility with tooltips
     -- If DisableMouse is enabled, use EnableMouse(false) for complete click-through (no tooltips)
-    
+
+    -- The SetPropagateMouse* / EnableMouse setters below are protected in combat
+    -- (ADDON_ACTION_BLOCKED). If this runs mid-combat — e.g. the user toggles the
+    -- click-through option — defer it: flag for the PLAYER_REGEN_ENABLED handler, which
+    -- re-runs this out of combat.
+    if InCombatLockdown() then
+        DF.auraIconsNeedMouseFix = true
+        return
+    end
+
     local function updateFrameClickThrough(frame)
         if not frame then return end
         local db = DF:GetFrameDB(frame)


### PR DESCRIPTION
Fixes the defensive-icon click-through reported as not working (Lab #961).

**Problem:** the 2nd+ defensive icons (the stacked defensive bar) are created lazily, and their mouse-passthrough setup (`SetPropagateMouseMotion` / `SetPropagateMouseClicks`) is protected in combat. So a defensive that first appears mid-combat — e.g. an external on top of a personal cooldown — didn't become click-through until combat ended, which is exactly when you're trying to click past it.

**Fix:**
- Pre-create the extra defensive-icon pool out of combat in `UpdateDefensiveBar` (which runs on every aura update), so the icons already exist and are click-through before combat starts. They're created hidden, so there's no visual change.
- Combat-guard `UpdateAuraClickThrough` so toggling the click-through option mid-combat defers to the `PLAYER_REGEN_ENABLED` handler instead of throwing `ADDON_ACTION_BLOCKED`.

Only affects external click-casting (the option's stated scope); the built-in click-casting is unaffected, since it binds on the unit frame and doesn't rely on the icons being mouse-transparent.