### PR TITLE
UI: fix unsupported-glyph note + standardise inline "Note:" labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Options / Click Casting) Note labels no longer show a stray "?" in place of an unsupported symbol, and inline "Note:" labels now use one consistent style across the options. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -176,7 +176,7 @@ function CC:ShowAddBindingDialog(onComplete, existingBinding, existingIndex)
         macWarning:SetPoint("TOPLEFT", keyCaptureBtn, "BOTTOMLEFT", 0, -2)
         macWarning:SetWidth(390)
         macWarning:SetJustifyH("LEFT")
-        macWarning:SetText("|cffff9900" .. L["Note: Cmd + Left Click unavailable on Mac"])
+        macWarning:SetText(L["Note: Cmd + Left Click unavailable on Mac"])
         macWarning:SetTextColor(0.9, 0.6, 0.2)
         yOffset = yOffset - 12  -- Extra space for the warning
     end
@@ -1042,7 +1042,7 @@ function CC:CreateEditBindingPanel()
     macWarning:SetPoint("RIGHT", clearBindBtn, "RIGHT", 0, 0)
     macWarning:SetJustifyH("LEFT")
     macWarning:SetWordWrap(false)
-    macWarning:SetText("|cffff9900" .. L["Note: Cmd + Left Click unavailable on Mac"])
+    macWarning:SetText(L["Note: Cmd + Left Click unavailable on Mac"])
     macWarning:SetTextColor(0.9, 0.6, 0.2)
     if IsMacClient and IsMacClient() then
         macWarning:Show()
@@ -4197,7 +4197,7 @@ function CC:CreateMacroListRow(parent, macroData, index)
     if (macroData.source == "global_import" or macroData.source == "char_import") and CC:IsMacroOutOfSync(macroData.id) then
         local syncIcon = row:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
         syncIcon:SetPoint("RIGHT", -8, 0)
-        syncIcon:SetText("⚠")
+        syncIcon:SetText("!")
         syncIcon:SetTextColor(1, 0.8, 0)
     end
     

--- a/ClickCasting/UI/Main.lua
+++ b/ClickCasting/UI/Main.lua
@@ -1888,7 +1888,7 @@ function CC:CreateKeybindPopup()
     local isMac = IsMacClient and IsMacClient()
     local macWarning = popup:CreateFontString(nil, "OVERLAY", "DFFontHighlightSmall")
     macWarning:SetPoint("TOP", instructions, "BOTTOM", 0, -4)
-    macWarning:SetText("|cffff9900" .. L["Note: Cmd + Left Click unavailable on Mac"] .. "|r")
+    macWarning:SetText(L["Note: Cmd + Left Click unavailable on Mac"])
     macWarning:SetTextColor(0.9, 0.6, 0.2)
     if isMac then
         macWarning:Show()

--- a/Debug/Performance.lua
+++ b/Debug/Performance.lua
@@ -174,7 +174,7 @@ function DF:StartPerformanceTracking(interval)
         Perf.cpuEnabled = false
         Perf.useNewAPI = false
         print("|cff00ff00DandersFrames:|r Performance tracking started (Memory only)")
-        print("|cffff9900Note:|r CPU profiling requires WoW 10.0+ or /console scriptProfile 1")
+        print("|cFFFF4444Note:|r CPU profiling requires WoW 10.0+ or /console scriptProfile 1")
     end
     
     -- Initial sample

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -1087,8 +1087,8 @@ L["Normal Dispels"] = true
 L["Not Available on Raid Frames"] = true
 L["Not Cancelable"] = true
 L["Not in a raid group"] = true
-L["Note: Cmd + Left Click unavailable on Mac"] = true
-L["Note: Font sizes are not changed. Adjust sizes in each element's page."] = true
+L["Note: Cmd + Left Click unavailable on Mac"] = "|cFFFF4444Note:|r Cmd + Left Click unavailable on Mac"
+L["Note: Font sizes are not changed. Adjust sizes in each element's page."] = "|cFFFF4444Note:|r Font sizes are not changed. Adjust sizes in each element's page."
 L["Notifications"] = true
 L["Notify me when a newer version is available"] = true
 L["OOR"] = true
@@ -1600,7 +1600,7 @@ L["Zoom Icon"] = true
 L["%sGlobal: 80%s %s— Setting matches global, no override stored%s"] = true
 L["%sModified%s %s— Setting differs from global. Click%s %sreset%s %sto revert.%s"] = true
 L["• Name Text\n• Health Text\n• Status Text (Dead/Offline)\n• Buff Stack & Duration\n• Debuff Stack & Duration\n• Pet Frame Text\n• Targeted Spell Duration\n• Defensive Icon Duration\n• Status Icon Text (Res, Summon, etc.)\n• Group Labels (Raid)\n• Targeted List\n• Personal Targeted Spell\n• Aura Designer Indicators\n• Pinned Frames"] = true
-L["⚠ Note: Click-through icons will not show tooltips."] = true
+L["|cFFFF4444Note:|r Click-through icons will not show tooltips."] = true
 
 -- Popup.lua and WizardBuilder.lua strings
 L["Back to List"] = true

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -4183,7 +4183,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         end), 30)
         tsDisableMouse.disableOn = function(d) return not d.targetedSpellEnabled end
         
-        clickThroughGroup:AddWidget(GUI:CreateLabel(self.child, L["⚠ Note: Click-through icons will not show tooltips."], 250), 25)
+        clickThroughGroup:AddWidget(GUI:CreateLabel(self.child, L["|cFFFF4444Note:|r Click-through icons will not show tooltips."], 250), 25)
         
         Add(clickThroughGroup, nil, 1)
         


### PR DESCRIPTION
Small consistency pass on inline note labels.

**Fixes:**
- The **Click-Through Icons** note and the macro out-of-sync indicator used a warning glyph the game font can't render, so it showed as a `?`. Replaced with a red `Note:` prefix / a plain `!`.
- Standardised the other inline `Note:` labels (the Mac click-cast note, the Performance note) to the same red `Note:` style used elsewhere in the options, instead of the ad-hoc orange/plain variants they had.

No behaviour change — text/colour only. The locale keys stay plain English; the colour lives in the value/usage.

Note: touches `Options.lua` and `BindingEditor.lua`, which also appear in #177 — if #177 merges first these may need a trivial rebase.