### PR TITLE
Raid: hide group labels when flat mode takes over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Raid) Group labels no longer occasionally appear over the flat raid grid. When an auto layout switched from a grouped layout to a flat one, the group labels from the grouped layout could be left behind floating over the flat frames; they are now hidden when flat mode takes over, the same as the grouped headers already were. (by Krathe)
+
 ## [4.5.0]
 
 ### New Features

--- a/Features/FlatRaidFrames.lua
+++ b/Features/FlatRaidFrames.lua
@@ -1174,6 +1174,19 @@ function FlatRaidFrames:SetEnabled(enabled)
             end
         end
 
+        -- Group labels belong to grouped mode only. The same auto-layout grouped→flat
+        -- switch that can leave separated headers visible can also leave a stale group
+        -- label floating over the flat grid, so hide them here too.
+        if DF.raidGroupLabels then
+            for i = 1, 8 do
+                local label = DF.raidGroupLabels[i]
+                if label then
+                    label:Hide()
+                    if label.shadow then label.shadow:Hide() end
+                end
+            end
+        end
+
         -- When already visible, only refresh child sizes and isRaidFrame flag
         -- (skip the heavy Hide/Show + UpdateNameList cycle to avoid double-work
         -- since ApplyRaidFlatSorting will follow from ProcessRosterUpdate).


### PR DESCRIPTION
Fixes the group labels (G1, G2, …) occasionally appearing over the **flat** raid grid even with grouping off (lab bug #966, part 1).

**Cause:** group labels are only ever shown in grouped mode (the label updater gates on `groupLabelEnabled and raidUseGroups`), so in flat mode they can only be *stale* leftovers. When an auto layout switches from a grouped layout to a flat one, `FlatRaidFrames:SetEnabled` already hides the grouped *separated headers* to avoid both layouts rendering at once — but it didn't hide the group *labels*, so a label from the prior grouped layout could be left floating over the flat frames. That's the intermittent "sometimes" appearance.

**Fix:** hide the group labels on flat-mode entry, right next to the existing separated-header hide (same lifecycle, same artifact class).

One file, no behaviour change in grouped mode.