### PR TITLE
Highlights: add "Hide on Tanks" option for the aggro highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* (Highlights) New **Hide on Tanks** option for the Aggro Highlight — a tank holding aggro is expected, so the highlight there is just noise. Enable it and the aggro highlight is suppressed on tank-role players, so it stands out only when a **DPS or healer** pulls aggro. Off by default; works in role-assigned content (dungeons, Mythic+, raids). (by Krathe)
 * (Pet Frames) Added an optional **power bar**. Enable **Show Power Bar** to display the pet's power (mana / energy / focus / etc.) as a bar along the bottom of the frame, with an adjustable height and either power-type or a custom colour. Off by default. (by Krathe)
 
 ### Improvements

--- a/Config.lua
+++ b/Config.lua
@@ -921,6 +921,7 @@ DF.PartyDefaults = {
     aggroHighlightMode = "GLOW",
     aggroHighlightThickness = 1,
     aggroOnlyTanking = false,
+    aggroHideOnTanks = false,
     aggroUseCustomColors = false,
 
     -- Anchor/Position
@@ -2600,6 +2601,7 @@ DF.RaidDefaults = {
     aggroHighlightMode = "GLOW",
     aggroHighlightThickness = 1,
     aggroOnlyTanking = false,
+    aggroHideOnTanks = false,
     aggroUseCustomColors = false,
 
     -- Anchor/Position

--- a/ExportCategories.lua
+++ b/ExportCategories.lua
@@ -1147,6 +1147,7 @@ DF.ExportCategories = {
         "aggroHighlightThickness",
         "aggroHighlightInset",
         "aggroOnlyTanking",
+        "aggroHideOnTanks",
         "aggroUseCustomColors",
         "aggroColorHighThreat",
         "aggroColorHighestThreat",

--- a/Features/Highlights.lua
+++ b/Features/Highlights.lua
@@ -672,6 +672,14 @@ function DF:UpdateHighlights(frame, forceSelection, forceAggro)
         else
             isAggro = status and status > 0
         end
+        -- "Hide on Tanks": a tank holding aggro is expected, so the highlight is just
+        -- noise — suppress it for TANK-role units so healers only see when a DPS or
+        -- healer pulls aggro. Role-based, so it applies in role-assigned content
+        -- (dungeons/M+/raids) and no-ops where roles aren't set (UnitGroupRolesAssigned
+        -- returns "NONE").
+        if isAggro and db.aggroHideOnTanks and unit and UnitGroupRolesAssigned(unit) == "TANK" then
+            isAggro = false
+        end
     end
 
     -- TD: stash the threat status (already fetched above for the aggro border)

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -880,6 +880,7 @@ L["Hide buffs from the buff bar when they are already displayed by the Defensive
 L["Hide Auras"] = true
 L["Hide Cooldown Swipe"] = true
 L["Hide from Main Frames"] = true
+L["Hide on Tanks"] = true
 L["Hide from Main Frames Tooltip"] = "Removes this set's pinned members from your main party/raid frames so they appear only in the pinned set. Applies out of combat. Your frame sorting setting is preserved."
 L["Hide duplicate buffs"] = true
 L["Hide in Combat"] = true

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -8459,6 +8459,10 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             if DF.UpdateAllHighlights then DF:UpdateAllHighlights() end
         end), 28)
         aggroOnlyTanking.hideOn = HideAggroModeNone
+        local aggroHideOnTanks = aggroGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Hide on Tanks"], db, "aggroHideOnTanks", function()
+            if DF.UpdateAllHighlights then DF:UpdateAllHighlights() end
+        end), 28)
+        aggroHideOnTanks.hideOn = HideAggroModeNone
         local aggroThick = aggroGroup:AddWidget(GUI:CreateSlider(self.child, L["Thickness"], 1, 10, 1, db, "aggroHighlightThickness", nil, function() DF:LightweightUpdateHighlight("aggro") end, true), 55)
         aggroThick.hideOn = HideAggroOptions
         local aggroInset = aggroGroup:AddWidget(GUI:CreateSlider(self.child, L["Inset"], -10, 10, 1, db, "aggroHighlightInset", nil, function() DF:LightweightUpdateHighlight("aggro") end, true), 55)


### PR DESCRIPTION
Implements feature request #26 (8 upvotes).

## What

A tank holding aggro is expected, so the aggro highlight on tanks is just noise for a healer. The new **Hide on Tanks** toggle (Highlights → Aggro) suppresses the aggro highlight on **tank-role** players, so it stands out only when a **DPS or healer** pulls aggro. Off by default (no behaviour change for existing setups).

## How

In `DF:UpdateHighlights`, right after threat status resolves:

```lua
if isAggro and db.aggroHideOnTanks and unit and UnitGroupRolesAssigned(unit) == "TANK" then
    isAggro = false
end
```

Role-based, so it applies in role-assigned content (dungeons, Mythic+, raids — where it matters) and harmlessly no-ops where roles aren't assigned (`UnitGroupRolesAssigned` returns `"NONE"`). The test-mode preview path (`forceAggro`) is untouched.

## Scope

- `aggroHideOnTanks` setting added to party + raid defaults (default `false`).
- Checkbox under Highlights → Aggro (hidden when aggro mode is None, like the sibling options).
- Added to the aggro export category.

Note: this is distinct from the existing **Only Show When Tanking** (`aggroOnlyTanking`), which filters by threat *status* (only status 3), not by *role* — so it doesn't cover this request.