### PR TITLE
Borders: honour Border Inset for texture-style borders (and update live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+* (Borders) Fixed **Border Inset** being ignored when the border uses a **texture** style — texture borders sat flush against the frame regardless of the inset, and a changed inset didn't update live. Texture borders now honour Border Inset and update immediately, matching solid/gradient borders. Affects every texture border in the addon (frame borders, buff/debuff squares, Aura Designer, etc.). (by Krathe)
 * (Nicknames) Fixed an error when matching nicknames against boss or NPC names on pinned frames during encounters.
 * (Localization) Test Mode, frame position, and grid layout labels now translate properly instead of always showing English.
 * (Localization) Text Designer, Aura Designer, and auto-profile labels now follow your chosen language.

--- a/Frames/Border.lua
+++ b/Frames/Border.lua
@@ -1493,9 +1493,15 @@ function Border:Apply(border, spec)
         for _, e in ipairs(edges) do if e then e:Hide() end end
         if not border.bd then
             border.bd = CreateFrame("Frame", nil, border, "BackdropTemplate")
-            border.bd:SetAllPoints(border)
         end
         local bd = border.bd
+        -- Re-anchor with the inset offsets on every Apply so texture borders honour
+        -- BorderInset and update live, matching the solid/gradient edges above.
+        -- (Previously SetAllPoints(border) once at creation: inset was ignored and
+        -- never updated.) inset == 0 reproduces the old flush layout exactly.
+        bd:ClearAllPoints()
+        bd:SetPoint("TOPLEFT", border, "TOPLEFT", inset, -inset)
+        bd:SetPoint("BOTTOMRIGHT", border, "BOTTOMRIGHT", -inset, inset)
         -- Thickness 0 = no border: hide the backdrop instead of clamping the
         -- edge to 1px (parity with the solid/gradient path above). The
         -- animation overlay is a separate frame and keeps running.


### PR DESCRIPTION
## Bug

In `DF.Border`'s texture branch, the BackdropTemplate child (`border.bd`) was anchored with `SetAllPoints(border)` **inside the creation guard** — so it ignored **Border Inset** entirely, and because it was anchored only once at creation, a changed inset never updated live. Solid/gradient borders already re-anchor on every `Apply` with the inset offsets ([Frames/Border.lua:1382-1399](DandersFrames/Frames/Border.lua#L1382)).

Result: texture-style borders sat flush against the frame regardless of the Border Inset setting. Affects every texture border in the addon (frame borders, buff/debuff squares, Aura Designer, etc.).

## Fix

Move the anchoring out of the creation guard and re-anchor `border.bd` on every `Apply` with the same inset offsets the solid/gradient edges use:

```lua
bd:ClearAllPoints()
bd:SetPoint("TOPLEFT", border, "TOPLEFT", inset, -inset)
bd:SetPoint("BOTTOMRIGHT", border, "BOTTOMRIGHT", -inset, inset)
```

`inset` is already in scope (`local inset = spec.inset or 0`, pixel-perfect-adjusted).

## Risk

Low — with `inset == 0` this reproduces the old `SetAllPoints` layout exactly, so existing setups are unchanged. Only non-zero **Border Inset** with a texture style starts working (and now live-updates). luacheck clean.

(Originally spotted and fixed on the 12.1 PTR copy; this ports the same fix to live/retail per the normal flow.)