### PR TITLE
Raid frames: keep test mode & settings changes from disturbing live frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ A top-to-bottom rework of the configuration UI so every panel shares one consist
 
 ### Bug Fixes
 
+* (Raid) Test mode and settings changes can no longer disturb your **live** raid frames — group order and positions are always driven by the secure layout, fixing the grouped-raid inversion that previously needed a `/reload`. (by Krathe)
+* (Raid) Retired an obsolete internal reverse-group-order setting that could invert raid groups; group order is controlled entirely by **Group Display Order** / **My Group First**. (by Krathe)
 * (Borders) **Border Inset** is now honoured by texture-style borders, and updates live. (by Krathe)
 * (Text) Fixed a stray health value (often a "%") appearing for users who never turned health text on. (by Krathe)
 * (Nicknames) Fixed an error matching nicknames against boss/NPC names on pinned frames in encounters.

--- a/Core.lua
+++ b/Core.lua
@@ -3552,6 +3552,28 @@ function DF:MigrateBorderInsetFold()
     end
 end
 
+-- One-time cleanup: the legacy raidGroupOrder ("NORMAL"/"REVERSE") toggle is
+-- deprecated -- group order now comes solely from the Group Display Order /
+-- My Group First feature (raidGroupDisplayOrder), which every positioner honours.
+-- The live header path never applied raidGroupOrder, but the test/legacy Lua
+-- positioner did, so a stale "REVERSE" made test/legacy disagree with live. The
+-- reverse code is gone; NORMAL-ize any lingering value so it can't mislead
+-- exports/debug. Per-profile guarded; idempotent. (Re-reverse via Group Display Order.)
+function DF:MigrateDeprecateRaidGroupOrder()
+    if not DandersFramesDB_v2 or not DandersFramesDB_v2.profiles then return end
+    for _, profile in pairs(DandersFramesDB_v2.profiles) do
+        if type(profile) == "table" and not profile._raidGroupOrderRetiredV1 then
+            if type(profile.party) == "table" and profile.party.raidGroupOrder == "REVERSE" then
+                profile.party.raidGroupOrder = "NORMAL"
+            end
+            if type(profile.raid) == "table" and profile.raid.raidGroupOrder == "REVERSE" then
+                profile.raid.raidGroupOrder = "NORMAL"
+            end
+            profile._raidGroupOrderRetiredV1 = true
+        end
+    end
+end
+
 -- One-time: carry the old bespoke important-spell highlight settings
 -- (targetedSpellHighlightStyle/Color/Size/Inset) into the new Important Spell
 -- Border key set (targetedSpellImportantBorder*), which is a second DF.Border
@@ -5385,6 +5407,12 @@ DF._MainEventDispatcher = function(self, event, arg1)
             -- (Text Designer now renders all text). Per-profile guarded.
             if DF.MigrateOORTextAlpha then
                 DF:MigrateOORTextAlpha()
+            end
+
+            -- Retire the deprecated raidGroupOrder reverse toggle (NORMAL-ize any
+            -- stale "REVERSE"); group order now comes from Group Display Order.
+            if DF.MigrateDeprecateRaidGroupOrder then
+                DF:MigrateDeprecateRaidGroupOrder()
             end
 
             -- CRITICAL: Update power bars now that unit data is available

--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -3317,7 +3317,15 @@ function SecureSort:PositionRaidFrameToSlot(frame, slotIndex, frameCount, layout
     if not frame or not container then
         return false
     end
-    
+
+    -- DOOR-SHUT backstop (flat): mirror the grouped positioner. The live flat raid
+    -- frames are children of the FlatRaidFrames secure header; this Lua per-frame
+    -- positioner is for TEST frames (DF.testRaidContainer) only. Refuse any call
+    -- that targets the live container so test mode can never drive live frames.
+    if container == DF.raidContainer then
+        return false
+    end
+
     local x, y = self:CalculateRaidSlotPosition(slotIndex, frameCount, layoutParams)
     local anchor, relativeAnchor = self:GetRaidSlotAnchors(layoutParams)
     
@@ -3642,8 +3650,7 @@ function SecureSort:CalculateRaidGroupPosition(groupNum, posInGroup, playersInGr
     local horizontal = lp.horizontal
     local groupAnchor = lp.groupAnchor
     local playerAnchor = lp.playerAnchor
-    local reverseGroupOrder = lp.reverseGroupOrder
-    
+
     -- ============================================================
     -- Mirror the LIVE grouped positioner exactly so test == live:
     --   * the secure snippet (Headers.lua position snippet) anchors each group
@@ -3708,15 +3715,13 @@ function SecureSort:CalculateRaidGroupPosition(groupNum, posInGroup, playersInGr
     end
     local gInRC = isPartialRow and popRem or groupsPerRowCol
 
-    -- Reverse group order within the row/column when raidGroupOrder == "REVERSE".
-    -- gInRC is the live snippet's groupsInThisRC (full row -> groupsPerRowCol,
-    -- partial last row -> popRem), so this mirrors the secure snippet's
-    -- `posInRC = groupsInThisRC - 1 - posInRC`. Applied unconditionally (NOT gated
-    -- on testMode): this function also drives the live sorting-disabled grouped
-    -- path (Frames/Init.lua), so both live and test must reverse identically.
-    if reverseGroupOrder then
-        posInRC = gInRC - 1 - posInRC
-    end
+    -- Group order is driven SOLELY by activeGroupList (Group Display Order /
+    -- My Group First, via DF:GetEffectiveRaidGroupOrder). The legacy
+    -- raidGroupOrder == "REVERSE" toggle is deprecated (no GUI; superseded by the
+    -- display-order feature) and is intentionally NOT applied here -- the live
+    -- header positioner (Headers.lua:UpdateRaidPositionAttributes) never honoured
+    -- it, so honouring it here made test/legacy disagree with live. gInRC is still
+    -- the row/column population used by the groupAnchor END/CENTER offsets below.
 
     local x, yDown
     if horizontal then
@@ -3861,7 +3866,17 @@ function SecureSort:PositionRaidFrameToGroupSlot(frame, groupNum, posInGroup, pl
     if not frame or not container then
         return false
     end
-    
+
+    -- DOOR-SHUT backstop: this legacy Lua per-frame positioner must NEVER drive
+    -- LIVE raid frames. In header mode the live frames are children of the secure
+    -- group headers (positioned by the secure header path); only TEST frames
+    -- (passed with DF.testRaidContainer) or genuinely headerless legacy frames may
+    -- use this. The live container + active headers => a live header frame slipped
+    -- through; refuse it so test mode can never corrupt live.
+    if container == DF.raidContainer and DF.raidSeparatedHeaders then
+        return false
+    end
+
     local x, y = self:CalculateRaidGroupPosition(groupNum, posInGroup, playersInGroup, activeGroupList, layoutParams)
 
     -- Anchor TOPLEFT, identical to the in-combat secure snippet. (An older
@@ -4346,8 +4361,7 @@ function SecureSort:RegisterPhase25Snippets()
         local horizontal = lc.horizontal
         local groupAnchor = lc.groupAnchor or "CENTER"
         local playerAnchor = lc.playerAnchor or "START"
-        local reverseGroupOrder = lc.reverseGroupOrder
-        
+
         -- Get frame count
         local frameCount = self:GetAttribute("raidFrameCount") or 0
         self:CallMethod("DebugPrint", "RAID POS GROUPED: frameCount=" .. frameCount)
@@ -4473,12 +4487,12 @@ function SecureSort:RegisterPhase25Snippets()
                         local rcIndex = math.floor((groupIndex - 1) / groupsPerRowCol) + 1
                         local posInRC = (groupIndex - 1) % groupsPerRowCol
 
-                        -- Apply reverse group order if enabled
+                        -- Group order comes solely from activeGroupList (display
+                        -- order / my-group-first). Legacy raidGroupOrder=="REVERSE"
+                        -- is deprecated and not applied (the header positioner never
+                        -- honoured it). groupsInThisRC is still needed for rc sizing.
                         local groupsInThisRC = math.min(groupsPerRowCol, activeGroupCount - (rcIndex - 1) * groupsPerRowCol)
-                        if reverseGroupOrder then
-                            posInRC = groupsInThisRC - 1 - posInRC
-                        end
-                        
+
                         -- Calculate row/column container dimensions
                         local rcWidth, rcHeight
                         if horizontal then

--- a/Features/SecureSort.lua
+++ b/Features/SecureSort.lua
@@ -2717,7 +2717,6 @@ function SecureSort:PushRaidGroupLayoutConfig()
         raidGroupLayoutConfig.horizontal = %s
         raidGroupLayoutConfig.groupAnchor = "%s"
         raidGroupLayoutConfig.playerAnchor = "%s"
-        raidGroupLayoutConfig.reverseGroupOrder = %s
         raidUseGroups = %s
     ]],
         lp.frameWidth,
@@ -2729,7 +2728,6 @@ function SecureSort:PushRaidGroupLayoutConfig()
         tostring(lp.horizontal),
         lp.groupAnchor or "CENTER",
         lp.playerAnchor or "START",
-        tostring(lp.reverseGroupOrder or false),
         tostring(useGroups)
     )
     
@@ -3344,41 +3342,6 @@ function SecureSort:PositionRaidFrameToSlot(frame, slotIndex, frameCount, layout
     return true
 end
 
--- Position all visible raid frames to grid slots (insecure - for test mode)
--- @param frameCount: number of visible frames to position
--- @param layoutParams: raid layout configuration
--- @param container: the container frame
--- @return number of frames actually moved
-function SecureSort:PositionAllRaidFramesToSlots(frameCount, layoutParams, container)
-    if not container then
-        DebugPrint("ERROR: PositionAllRaidFramesToSlots - container is nil")
-        return 0
-    end
-    
-    if not DF.IterateRaidFrames then
-        return 0
-    end
-    
-    local moved = 0
-    local frameIndex = 0
-    DF:IterateRaidFrames(function(frame, idx)
-        frameIndex = frameIndex + 1
-        if frameIndex > frameCount then return true end  -- Stop iteration
-        
-        if frame and frame:IsShown() then
-            local slotIndex = frameIndex - 1  -- Convert to 0-based
-            if self:PositionRaidFrameToSlot(frame, slotIndex, frameCount, layoutParams, container) then
-                moved = moved + 1
-            end
-        end
-    end)
-    
-    if moved > 0 then
-        DebugPrint("Positioned " .. moved .. "/" .. frameCount .. " raid frames")
-    end
-    return moved
-end
-
 -- ============================================================
 -- LAYOUT PARAMETERS
 -- ============================================================
@@ -3573,7 +3536,6 @@ SecureSort.raidGroupLayoutParams = {
     horizontal = true,           -- Direction players fill within group (HORIZONTAL = left-to-right)
     groupAnchor = "CENTER",      -- How groups are anchored (START/CENTER/END)
     playerAnchor = "START",      -- How players are anchored within group slot (START/CENTER/END)
-    reverseGroupOrder = false,   -- Whether to reverse group order
 }
 
 -- Update raid GROUP layout parameters from DF settings
@@ -3610,7 +3572,6 @@ function SecureSort:UpdateRaidGroupLayoutParams()
         horizontal = db.growDirection == "HORIZONTAL",
         groupAnchor = db.raidGroupAnchor or "START",
         playerAnchor = db.raidPlayerAnchor or "START",
-        reverseGroupOrder = db.raidGroupOrder == "REVERSE",
         groupRowGrowth = db.raidGroupRowGrowth or "START",
     }
     

--- a/Frames/Init.lua
+++ b/Frames/Init.lua
@@ -303,6 +303,23 @@ function DF:UpdateRaidGroupedLayout()
         return
     end
     
+    -- DOOR-SHUT (live frames are never Lua-driven): in header mode the live unit
+    -- frames are children of the secure group headers and are positioned ONLY by
+    -- the secure header path. DF.raidFrames is a PROXY that resolves to those live
+    -- children (Frames/Core.lua), so the legacy Lua per-frame fallback below would
+    -- SetPoint them onto the container and fight the secure layout -- that is how
+    -- entering test mode or a GUI change could shove the LIVE frames around (e.g.
+    -- the group-order inversion). Route header mode to the secure path here; the Lua
+    -- fallback now only runs for genuinely headerless legacy frames (none in current
+    -- builds). TEST frames are positioned separately in TestMode.lua
+    -- (DF.testRaidFrames / DF.testRaidContainer) and never reach this live path.
+    if hasHeaders then
+        DF:UpdateRaidHeaderVisibility()
+        DF:PositionRaidHeaders()
+        DF:UpdateRaidGroupLabels()
+        return
+    end
+
     -- Sorting disabled OR test mode - use Lua-based positioning logic
     -- (Test mode has no real raid roster, so secure code can't query group membership)
     -- Update group layout params from current settings


### PR DESCRIPTION
## Raid frames: keep test mode & settings changes from disturbing live frames

Two related raid-positioning fixes.

### 1. Live frames are no longer driven by the legacy Lua positioner
Live grouped raid frames are children of the secure group headers and should only ever be positioned by the secure header path. But `UpdateRaidGroupedLayout`'s "header mode → secure, return" early-out was effectively dead: it gated on `not hasLegacy`, and `DF.raidFrames` is a proxy that resolves to live header children, so `hasLegacy` is always true in a populated raid. As a result, with sorting off (or in test mode) the legacy Lua per-frame positioner would `SetPoint` the live header children directly — so **entering test mode or changing a setting could shift/invert the live raid frames until a `/reload`.**

Fix: header mode now routes to the secure path unconditionally, and the per-frame positioners (`PositionRaidFrameToGroupSlot` / `PositionRaidFrameToSlot`) refuse any call targeting the live container while headers exist. The legacy Lua path is now reserved for test frames and genuinely headerless legacy frames; `raidTestMode` can no longer reroute live positioning.

### 2. Retired the deprecated `raidGroupOrder` reverse toggle
`raidGroupOrder` ("NORMAL"/"REVERSE") has no GUI any more — it was superseded by Group Display Order / My Group First (`raidGroupDisplayOrder`). The live header path never applied it, but the test/legacy Lua positioner still did, so a stale `REVERSE` made test/legacy disagree with live (inverted groups). Removed it from the positioners (group order comes solely from the display-order feature) and added a one-time migration that NORMAL-izes any lingering value.

### Verification
Test-vs-live positioning was confirmed identical across both grouped and flat layouts over the full cross-product of settings (orientation, anchors, grow-from, groups/players-per-row, partial rosters, display order, my-group-first). Verified in-game: entering/exiting test mode and changing settings no longer move live frames; group display order and my-group-first still apply correctly.
