### PR TITLE
Priority sliders: higher number wins (match every other slider)

### DIFF
--- a/AuraDesigner/Engine.lua
+++ b/AuraDesigner/Engine.lua
@@ -136,7 +136,7 @@ local groupLookup = {}       -- Reused: "auraName#indicatorID" → { group, memb
 local groupActiveMembers = {} -- Reused: groupID → { ordered active members }
 
 local function prioritySort(a, b)
-    return a.priority < b.priority  -- Lower number = higher priority (1 wins over 10)
+    return a.priority > b.priority  -- Higher number = higher priority (10 wins over 1)
 end
 
 -- Hoisted from an inline closure inside ResolveLayoutGroups' sort call.

--- a/AuraDesigner/Engine.lua
+++ b/AuraDesigner/Engine.lua
@@ -398,6 +398,7 @@ function Engine:UpdateFrame(frame)
     -- resolved table render actually reads, so a half-migrated block can't render
     -- via the stale legacy path.
     if DF.MigrateAuraDesignerBorderKeysLazy then DF.MigrateAuraDesignerBorderKeysLazy(adDB) end
+    if DF.MigrateAuraDesignerPrioritiesLazy then DF.MigrateAuraDesignerPrioritiesLazy(adDB) end
 
     -- Debug: throttled diagnostic dump
     local now = GetTime()
@@ -889,6 +890,7 @@ function Engine:UpdateTestFrame(frame)
     end
     if DF.MigrateAuraDesignerInstancesLazy then DF.MigrateAuraDesignerInstancesLazy(adDB) end
     if DF.MigrateAuraDesignerBorderKeysLazy then DF.MigrateAuraDesignerBorderKeysLazy(adDB) end
+    if DF.MigrateAuraDesignerPrioritiesLazy then DF.MigrateAuraDesignerPrioritiesLazy(adDB) end
 
     local specAuras = adDB.auras and adDB.auras[spec]
     if not specAuras then
@@ -1102,6 +1104,7 @@ function Engine:PreWarmIndicators(frame)
     if not adDB then return end
     if DF.MigrateAuraDesignerInstancesLazy then DF.MigrateAuraDesignerInstancesLazy(adDB) end
     if DF.MigrateAuraDesignerBorderKeysLazy then DF.MigrateAuraDesignerBorderKeysLazy(adDB) end
+    if DF.MigrateAuraDesignerPrioritiesLazy then DF.MigrateAuraDesignerPrioritiesLazy(adDB) end
 
     -- Resolve spec
     local spec = self:ResolveSpec(adDB)

--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -2027,7 +2027,7 @@ function Indicators:ConfigureIcon(frame, config, defaults, auraName, priority)
     -- Frame level: base from frame (not contentOverlay) + per-indicator level + small priority tiebreaker
     local level = config.frameLevel or (defaults and defaults.indicatorFrameLevel) or 2
     local baseLevel = frame:GetFrameLevel()
-    local priorityBoost = math.floor((20 - (priority or 5)) / 4)  -- 0-5 range for tiebreaking
+    local priorityBoost = math.floor((9 + (priority or 5)) / 4)  -- higher priority = higher frame level
     icon:SetFrameLevel(math.max(0, baseLevel + level + priorityBoost))
 
     -- Frame strata: per-indicator override, falls back to global default.
@@ -2894,7 +2894,7 @@ function Indicators:ConfigureSquare(frame, config, defaults, auraName, priority)
     -- Frame level: base from frame (not contentOverlay) + per-indicator level + small priority tiebreaker
     local level = config.frameLevel or (defaults and defaults.indicatorFrameLevel) or 2
     local baseLevel = frame:GetFrameLevel()
-    local priorityBoost = math.floor((20 - (priority or 5)) / 4)  -- 0-5 range for tiebreaking
+    local priorityBoost = math.floor((9 + (priority or 5)) / 4)  -- higher priority = higher frame level
     sq:SetFrameLevel(math.max(0, baseLevel + level + priorityBoost))
 
     -- Frame strata: per-indicator override, falls back to global default.
@@ -3972,7 +3972,7 @@ function Indicators:ConfigureBar(frame, config, defaults, auraName, priority)
     -- Frame level: base from frame (not contentOverlay) + per-indicator level + small priority tiebreaker
     local level = config.frameLevel or (defaults and defaults.indicatorFrameLevel) or 2
     local baseLevel = frame:GetFrameLevel()
-    local priorityBoost = math.floor((20 - (priority or 5)) / 4)  -- 0-5 range for tiebreaking
+    local priorityBoost = math.floor((9 + (priority or 5)) / 4)  -- higher priority = higher frame level
     bar:SetFrameLevel(math.max(0, baseLevel + level + priorityBoost))
 
     -- Frame strata: per-indicator override, falls back to global default.

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -2568,7 +2568,7 @@ local function RefreshPreviewEffects()
     -- Frame-level effects all draw onto the SAME single preview elements (one
     -- healthFill / healthBg / nameText / etc.), so when more than one aura
     -- configures the same type they conflict. The runtime resolves this by
-    -- priority (lower number wins; first claim per type — see prioritySort and
+    -- priority (higher number wins; first claim per type — see prioritySort and
     -- Indicators:Apply's `if state.X then return end`). Mirror that here so the
     -- preview is deterministic instead of pairs()-order-dependent: iterate auras
     -- in ascending-priority order (tiebreak by name) and apply first-wins per type.

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -2579,7 +2579,7 @@ local function RefreshPreviewEffects()
         end
     end
     sort(sortedAuras, function(a, b)
-        if a.priority ~= b.priority then return a.priority < b.priority end
+        if a.priority ~= b.priority then return a.priority > b.priority end  -- higher number = higher priority
         return a.name < b.name
     end)
 
@@ -5708,10 +5708,15 @@ CreateEffectCard = function(parent, yPos, effect)
             local priSlider = GUI:CreateSlider(body, L["Priority"], 1, 10, 1, auraProxy, "priority")
             -- Extra gap above (was +4) so the slider isn't squished against the
             -- triggers / Add Trigger row, plus a little breathing room below before
-            -- the effect's Appearance group (increment 54 → 68).
+            -- the effect's Appearance group (increment 54 → 68 → 84 with the note).
             priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 5, -(triggersH + 14))
             priSlider:SetWidth(bodyWidth - 10)
-            triggersH = triggersH + 68
+            -- Direction note: HIGHER number = higher priority (matches every slider).
+            local priNote = body:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
+            priNote:SetPoint("TOPLEFT", priSlider, "BOTTOMLEFT", 0, -2)
+            priNote:SetText(L["Higher priority wins"])
+            priNote:SetTextColor(0.6, 0.6, 0.6)
+            triggersH = triggersH + 84
         end
 
         local _, bodyH = BuildTypeContent(body, effect.typeKey, effect.auraName, bodyWidth, proxy, triggersH, indicatorGroup, effect.indicatorID)

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -5709,11 +5709,13 @@ CreateEffectCard = function(parent, yPos, effect)
             -- Extra gap above (was +4) so the slider isn't squished against the
             -- triggers / Add Trigger row, plus a little breathing room below before
             -- the effect's Appearance group (increment 54 → 68 → 84 with the note).
-            priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 5, -(triggersH + 14))
-            priSlider:SetWidth(bodyWidth - 10)
+            -- x=8 matches the "TRIGGERED BY" section above (Options.lua trigContainer)
+            -- so the Priority slider + note line up with the card's other elements.
+            priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 8, -(triggersH + 14))
+            priSlider:SetWidth(bodyWidth - 16)
             -- Direction note in the standard GUI label style (dim, wrapped) so it
             -- matches every other settings note: HIGHER number = higher priority.
-            local priNote = GUI:CreateLabel(body, L["Higher priority wins"], bodyWidth - 10)
+            local priNote = GUI:CreateLabel(body, L["Higher priority wins"], bodyWidth - 16)
             priNote:SetPoint("TOPLEFT", priSlider, "BOTTOMLEFT", 0, -2)
             triggersH = triggersH + 84
         end

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -5711,11 +5711,10 @@ CreateEffectCard = function(parent, yPos, effect)
             -- the effect's Appearance group (increment 54 → 68 → 84 with the note).
             priSlider:SetPoint("TOPLEFT", body, "TOPLEFT", 5, -(triggersH + 14))
             priSlider:SetWidth(bodyWidth - 10)
-            -- Direction note: HIGHER number = higher priority (matches every slider).
-            local priNote = body:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
+            -- Direction note in the standard GUI label style (dim, wrapped) so it
+            -- matches every other settings note: HIGHER number = higher priority.
+            local priNote = GUI:CreateLabel(body, L["Higher priority wins"], bodyWidth - 10)
             priNote:SetPoint("TOPLEFT", priSlider, "BOTTOMLEFT", 0, -2)
-            priNote:SetText(L["Higher priority wins"])
-            priNote:SetTextColor(0.6, 0.6, 0.6)
             triggersH = triggersH + 84
         end
 

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -475,6 +475,46 @@ local function MigrateInstancesLazy(adDB)
 end
 DF.MigrateAuraDesignerInstancesLazy = MigrateInstancesLazy
 
+-- Lazy, flag-gated Priority-scale flip (old lower-wins → new higher-wins). Same
+-- resolve-time, once-per-table pattern as the border-key fold above: it runs on
+-- the EXACT adDB about to be rendered/edited, so auto-layout overlays, presets,
+-- and the legacy inline config are all covered AT POINT OF USE, gated by
+-- `_priorityHigherWinsV1`. Fresh configs are born flagged (NewAuraDesignerConfig)
+-- and exports/imports carry the flag on the copied table, so only genuine pre-4.6
+-- data is ever flipped — and exactly once. Replaces the old one-shot ADDON_LOADED
+-- walker, which misclassified flat auras with no indicators and double-flipped
+-- newly-created / imported profiles into corruption.
+local function FlipAuraPriority(auraCfg)
+    if type(auraCfg) == "table" and type(auraCfg.priority) == "number" then
+        local p = math.floor(auraCfg.priority + 0.5)
+        if p < 1 then p = 1 elseif p > 10 then p = 10 end
+        auraCfg.priority = 11 - p
+    end
+end
+local function MigratePrioritiesLazy(adDB)
+    if type(adDB) ~= "table" or adDB._priorityHigherWinsV1 then return end
+    local auras = adDB.auras
+    if type(auras) == "table" then
+        -- Shape detection off the first entry only, matching MigrateBorderKeysOnAurasTable.
+        for _, val in pairs(auras) do
+            if type(val) == "table" then
+                if val.priority ~= nil or val.indicators ~= nil or val.icon ~= nil then
+                    for _, auraCfg in pairs(auras) do FlipAuraPriority(auraCfg) end            -- flat: auras[name]
+                else
+                    for _, specAuras in pairs(auras) do                                         -- spec: auras[spec][name]
+                        if type(specAuras) == "table" then
+                            for _, auraCfg in pairs(specAuras) do FlipAuraPriority(auraCfg) end
+                        end
+                    end
+                end
+            end
+            break
+        end
+    end
+    adDB._priorityHigherWinsV1 = true
+end
+DF.MigrateAuraDesignerPrioritiesLazy = MigratePrioritiesLazy
+
 local function GetAuraDesignerDB()
     -- The editor is mode-tabbed: it edits the preset the active mode uses
     -- (party → its assigned preset, etc.). Because edited == used, live
@@ -493,6 +533,7 @@ local function GetAuraDesignerDB()
     end
     MigrateInstancesLazy(adDB)
     MigrateBorderKeysLazy(adDB)
+    MigratePrioritiesLazy(adDB)
     return adDB
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ A top-to-bottom rework of the configuration UI so every panel shares one consist
 * (Auto Layouts) Moving raid frames while an auto layout is active now edits **that layout**, via its own Unlock button. (by Krathe)
 * (Pinned Frames) Each set's **Horizontal/Vertical Spacing** now inherits from the based-on mode, overridable per set. (by Krathe)
 * (Options / Click Casting) Inline "Note:" labels are now consistent and no longer show a stray "?". (by Krathe)
-* (Click Casting) The binding **Priority** slider now reads left-to-right as High → Low and shows the priority number directly. The stored priority is unchanged — only the slider's display orientation changed. (by Krathe)
+* (Click Casting / Aura Designer) The **Priority** sliders now read left-to-right as Low → High — **higher number wins**, matching every other slider (right = more). Your existing priorities are migrated automatically, so only the displayed number changes, not which binding or aura takes precedence. (by Krathe)
 
 ### Bug Fixes
 

--- a/ClickCasting/Bindings.lua
+++ b/ClickCasting/Bindings.lua
@@ -2262,7 +2262,7 @@ function CC:BuildCombinedMacroForBindings(bindings, forGlobalBinding)
     
     -- Sort each category by priority
     local function sortByPriority(a, b)
-        return (a.priority or 5) < (b.priority or 5)
+        return (a.priority or 5) > (b.priority or 5)  -- higher number = higher priority
     end
     table.sort(friendly, sortByPriority)
     table.sort(hostile, sortByPriority)
@@ -3063,7 +3063,7 @@ end
 function CC:FindBestKnownSpellBinding(bindings)
     -- Sort by priority first
     table.sort(bindings, function(a, b)
-        return (a.binding.priority or 5) < (b.binding.priority or 5)
+        return (a.binding.priority or 5) > (b.binding.priority or 5)  -- higher number = higher priority
     end)
     
     for _, item in ipairs(bindings) do

--- a/ClickCasting/Constants.lua
+++ b/ClickCasting/Constants.lua
@@ -351,6 +351,9 @@ CC.IsDefaultProfile = IsDefaultProfile
 
 -- Default profile template (what goes inside each profile)
 local PROFILE_TEMPLATE = {
+    -- Born in the new higher-wins priority scale, so the lazy priority migration
+    -- (CC:MigratePrioritiesLazy) never flips a freshly-created / copied profile.
+    _priorityHigherWinsV1 = true,
     bindings = {},
     customMacros = {},
     consumables = {},  -- Saved consumable item IDs

--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -196,7 +196,10 @@ function CC:InitializeSavedVariables()
     
     -- Get active profile
     self.profile = classData.profiles[classData.activeProfile]
-    
+    -- Flip legacy (pre-4.6) priorities to higher-wins on the active profile at
+    -- login, before the legacy references below feed the flipped comparators.
+    if self.MigratePrioritiesLazy then self:MigratePrioritiesLazy(self.profile) end
+
     -- Set up legacy references for compatibility (point to profile data)
     self.db.bindings = self.profile.bindings
     self.db.customMacros = self.profile.customMacros

--- a/ClickCasting/Profiles.lua
+++ b/ClickCasting/Profiles.lua
@@ -259,17 +259,41 @@ function CC:GetProfileList()
     return names
 end
 
+-- Lazy, flag-gated Priority-scale flip for a Click Casting profile (old
+-- lower-wins → new higher-wins, 11-p over 1..10). Mirrors the Aura Designer
+-- lazy migration: it runs on the EXACT profile table at point-of-use (when the
+-- profile is made active / read), gated by `profile._priorityHigherWinsV1`, so
+-- it flips each stored setup exactly once. New profiles are born flagged
+-- (PROFILE_TEMPLATE) and imports carry the flag on the copied table, so only
+-- genuine pre-4.6 bindings are ever flipped. Replaces the old one-shot
+-- ADDON_LOADED walk (whose store-level flag meant a later-imported old profile
+-- was never flipped, and new/imported profiles were double-flipped).
+function CC:MigratePrioritiesLazy(profile)
+    if type(profile) ~= "table" or profile._priorityHigherWinsV1 then return end
+    if type(profile.bindings) == "table" then
+        for _, binding in ipairs(profile.bindings) do
+            if type(binding) == "table" and type(binding.priority) == "number" then
+                local p = math.floor(binding.priority + 0.5)
+                if p < 1 then p = 1 elseif p > 10 then p = 10 end
+                binding.priority = 11 - p
+            end
+        end
+    end
+    profile._priorityHigherWinsV1 = true
+end
+
 -- Get the currently active profile data
 function CC:GetActiveProfile()
     local classData = self:GetClassData()
     local defaultName = GetDefaultProfileName()
     local profileName = classData.activeProfile or defaultName
-    
+
     -- Ensure the profile exists
     if not classData.profiles[profileName] then
         classData.profiles[profileName] = self:CreateEmptyProfile()
     end
-    
+
+    self:MigratePrioritiesLazy(classData.profiles[profileName])
     return classData.profiles[profileName], profileName
 end
 
@@ -298,9 +322,12 @@ function CC:SetActiveProfile(profileName)
     
     local oldProfile = classData.activeProfile
     classData.activeProfile = profileName
-    
+
     -- Update self.profile reference
     self.profile = classData.profiles[profileName]
+    -- Flip legacy (pre-4.6) priorities to higher-wins on first activation of this
+    -- profile, before its bindings feed the flipped comparators / macro build.
+    self:MigratePrioritiesLazy(self.profile)
     
     -- Also update legacy self.db references for compatibility
     self.db.bindings = self.profile.bindings

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -1244,13 +1244,13 @@ function CC:CreateEditBindingPanel()
     priorityLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
     panel.priorityLabel = priorityLabel
 
-    -- Shared slider builder. The stored field (panel.pendingBinding.priority,
-    -- 1 = High .. 10 = Low) is written 1:1 via customGet/customSet, so the saved
-    -- value is identical to the old hand-rolled slider (which also stored the raw
-    -- priority; its 11-value was only a display-geometry inversion). The slider's
-    -- internal value now equals the priority directly, so the builder's input box
-    -- shows the actual priority number. Thumb runs left = 1 (High) .. right = 10
-    -- (Low); the hint labels below are oriented to match.
+    -- Shared slider builder. The stored field (panel.pendingBinding.priority) is
+    -- written 1:1 via customGet/customSet and shown directly in the input box.
+    -- Direction: HIGHER number = higher priority (10 wins over 1), matching every
+    -- other slider (right = more). Thumb runs left = 1 (Low) .. right = 10 (High);
+    -- the hint labels + centre note below match. A one-time migration
+    -- (DF:MigratePriorityHigherWins) remapped older saved values, and the
+    -- resolution comparators were flipped, so existing bindings resolve the same.
     local prioritySlider = DF.GUI:CreateSlider(
         advancedContent,            -- parent
         "",                         -- label (priorityLabel handles the caption)
@@ -1274,16 +1274,22 @@ function CC:CreateEditBindingPanel()
     )
     prioritySlider:SetPoint("TOPLEFT", 68, -155)
 
-    -- Priority hint labels (1 = High on left, 10 = Low on right)
+    -- Priority hint labels (1 = Low on left, 10 = High on right — higher wins).
+    local lowLabel = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
+    lowLabel:SetPoint("TOPLEFT", prioritySlider, "BOTTOMLEFT", 0, -2)
+    lowLabel:SetText(L["1 = Low"])
+    lowLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+
     local highLabel = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
-    highLabel:SetPoint("TOPLEFT", prioritySlider, "BOTTOMLEFT", 0, -2)
-    highLabel:SetText(L["1 = High"])
+    highLabel:SetPoint("TOPRIGHT", prioritySlider, "BOTTOMRIGHT", 0, -2)
+    highLabel:SetText(L["10 = High"])
     highLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
 
-    local lowLabel = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
-    lowLabel:SetPoint("TOPRIGHT", prioritySlider, "BOTTOMRIGHT", 0, -2)
-    lowLabel:SetText(L["10 = Low"])
-    lowLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+    -- Centre note clarifying direction (sits between the corner Low/High labels).
+    local priNote = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
+    priNote:SetPoint("TOP", prioritySlider, "BOTTOM", 0, -2)
+    priNote:SetText(L["Higher priority wins"])
+    priNote:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
 
     panel.prioritySlider = prioritySlider
     
@@ -1860,8 +1866,8 @@ function CC:ShowEditBindingPanel(spellData, existingBinding, existingIndex)
     end
     
     -- Update priority slider. The slider's internal value equals the stored
-    -- priority directly (1 = High .. 10 = Low); the builder's input box and fill
-    -- update off this value.
+    -- priority directly (1 = Low .. 10 = High; higher wins); the builder's input
+    -- box and fill update off this value.
     panel.prioritySlider.slider:SetValue(currentPriority)
     
     -- Update fallback checkboxes (only if not a macro)

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -1274,22 +1274,10 @@ function CC:CreateEditBindingPanel()
     )
     prioritySlider:SetPoint("TOPLEFT", 68, -155)
 
-    -- Priority hint labels (1 = Low on left, 10 = High on right — higher wins).
-    local lowLabel = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
-    lowLabel:SetPoint("TOPLEFT", prioritySlider, "BOTTOMLEFT", 0, -2)
-    lowLabel:SetText(L["1 = Low"])
-    lowLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
-
-    local highLabel = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
-    highLabel:SetPoint("TOPRIGHT", prioritySlider, "BOTTOMRIGHT", 0, -2)
-    highLabel:SetText(L["10 = High"])
-    highLabel:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
-
-    -- Centre note clarifying direction (sits between the corner Low/High labels).
-    local priNote = advancedContent:CreateFontString(nil, "OVERLAY", "DFFontNormalSmall")
-    priNote:SetPoint("TOP", prioritySlider, "BOTTOM", 0, -2)
-    priNote:SetText(L["Higher priority wins"])
-    priNote:SetTextColor(C_TEXT_DIM.r, C_TEXT_DIM.g, C_TEXT_DIM.b)
+    -- Direction note in the standard GUI label style (dim, wrapped) so it matches
+    -- every other settings note: higher number = higher priority.
+    local priNote = DF.GUI:CreateLabel(advancedContent, L["Higher priority wins"], 248)
+    priNote:SetPoint("TOPLEFT", prioritySlider, "BOTTOMLEFT", 0, -2)
 
     panel.prioritySlider = prioritySlider
     

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -1273,10 +1273,15 @@ function CC:CreateEditBindingPanel()
         CC.ACCENT                   -- accentColor (ClickCasting green)
     )
     prioritySlider:SetPoint("TOPLEFT", 68, -155)
-    -- No direction note here: this binding editor is a compact fixed dialog and a
-    -- note line under the slider collides with the Delete/Cancel/Save row. The
-    -- slider is higher-wins (consistent with the Aura Designer, which shows the
-    -- explanatory "Higher priority wins" note where there's room for it).
+
+    -- Direction note (standard GUI label style). The slider's container is 50px
+    -- tall (its bottom sits near the Delete/Cancel/Save row), so the note is placed
+    -- in the gap BELOW the visible bar — anchored ~28px down from the slider top and
+    -- shifted left to x=0 to sit under the "Priority:" caption. Anchored to the
+    -- slider so it tracks the macro/spell repositioning; the CreateLabel frame has
+    -- no background, so its lower extent over the button row is invisible.
+    local priNote = DF.GUI:CreateLabel(advancedContent, L["Higher priority wins"], 248)
+    priNote:SetPoint("TOPLEFT", prioritySlider, "TOPLEFT", -68, -28)
 
     panel.prioritySlider = prioritySlider
     

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -94,7 +94,7 @@ function CC:ShowAddBindingDialog(onComplete, existingBinding, existingIndex)
         macroText = nil,
         loadSpec = nil,
         loadCombat = nil,
-        priority = 5,  -- Default priority (1=highest, 10=lowest)
+        priority = 5,  -- Default priority (10=highest, 1=lowest)
     }
     
     local yOffset = -45
@@ -1556,7 +1556,7 @@ function CC:ShowEditBindingPanel(spellData, existingBinding, existingIndex)
             actionType = spellData.actionType or self.ACTION_TYPES.SPELL,
             spellId = spellData.spellId,
             spellName = spellData.spellName or spellData.name,
-            priority = 5,  -- Default priority (1=highest, 10=lowest)
+            priority = 5,  -- Default priority (10=highest, 1=lowest)
         }
         
         if spellData.isMacro then
@@ -2063,7 +2063,7 @@ function CC:ProcessKeybind(bindType, key)
         modifiers = mods,
         scope = defaultScope,
         combat = defaultCombat,
-        priority = 5,  -- Default priority (1=highest, 10=lowest)
+        priority = 5,  -- Default priority (10=highest, 1=lowest)
         -- Default to all frames
         frames = {
             dandersFrames = true,

--- a/ClickCasting/UI/BindingEditor.lua
+++ b/ClickCasting/UI/BindingEditor.lua
@@ -1247,10 +1247,10 @@ function CC:CreateEditBindingPanel()
     -- Shared slider builder. The stored field (panel.pendingBinding.priority) is
     -- written 1:1 via customGet/customSet and shown directly in the input box.
     -- Direction: HIGHER number = higher priority (10 wins over 1), matching every
-    -- other slider (right = more). Thumb runs left = 1 (Low) .. right = 10 (High);
-    -- the hint labels + centre note below match. A one-time migration
-    -- (DF:MigratePriorityHigherWins) remapped older saved values, and the
-    -- resolution comparators were flipped, so existing bindings resolve the same.
+    -- other slider (right = more). Thumb runs left = 1 (Low) .. right = 10 (High).
+    -- A one-time migration (DF:MigratePriorityHigherWins) remapped older saved
+    -- values, and the resolution comparators were flipped, so existing bindings
+    -- resolve the same.
     local prioritySlider = DF.GUI:CreateSlider(
         advancedContent,            -- parent
         "",                         -- label (priorityLabel handles the caption)
@@ -1273,11 +1273,10 @@ function CC:CreateEditBindingPanel()
         CC.ACCENT                   -- accentColor (ClickCasting green)
     )
     prioritySlider:SetPoint("TOPLEFT", 68, -155)
-
-    -- Direction note in the standard GUI label style (dim, wrapped) so it matches
-    -- every other settings note: higher number = higher priority.
-    local priNote = DF.GUI:CreateLabel(advancedContent, L["Higher priority wins"], 248)
-    priNote:SetPoint("TOPLEFT", prioritySlider, "BOTTOMLEFT", 0, -2)
+    -- No direction note here: this binding editor is a compact fixed dialog and a
+    -- note line under the slider collides with the Delete/Cancel/Save row. The
+    -- slider is higher-wins (consistent with the Aura Designer, which shows the
+    -- explanatory "Higher priority wins" note where there's room for it).
 
     panel.prioritySlider = prioritySlider
     

--- a/Core.lua
+++ b/Core.lua
@@ -3552,6 +3552,75 @@ function DF:MigrateBorderInsetFold()
     end
 end
 
+-- One-time: flip the Priority sliders from "lower number wins" to "higher
+-- number wins" so they match every other slider (right = more). The stored
+-- value is remapped 11-p (an involution over 1..10), and every comparator and
+-- the frame-level priority boost were flipped to match, so EXISTING setups
+-- resolve IDENTICALLY -- only the number the slider shows changes. Covers both
+-- the Aura Designer aura priority (DandersFramesDB_v2) and the Click Casting
+-- binding priority (DandersFramesClickCastingDB). Each store is guarded by its
+-- own flag; idempotent.
+local function FlipStoredPriority(t)
+    if type(t) == "table" and type(t.priority) == "number" then
+        local p = math.floor(t.priority + 0.5)
+        if p < 1 then p = 1 elseif p > 10 then p = 10 end
+        t.priority = 11 - p
+    end
+end
+
+-- Walk an Aura Designer config's auras (mirrors FoldAuraDesignerConfig: handles
+-- both the flat V1 `auras[name]` shape and the per-spec `auras[spec][name]`
+-- shape) and flip each aura's priority.
+local function FlipAuraDesignerPriorities(cfg)
+    if type(cfg) ~= "table" or type(cfg.auras) ~= "table" then return end
+    for _, entry in pairs(cfg.auras) do
+        if type(entry) == "table" then
+            if entry.indicators then
+                FlipStoredPriority(entry)                 -- flat: entry IS the auraCfg
+            else
+                for _, auraCfg in pairs(entry) do         -- per-spec: entry is a spec table
+                    FlipStoredPriority(auraCfg)
+                end
+            end
+        end
+    end
+end
+
+function DF:MigratePriorityHigherWins()
+    -- Aura Designer (party/raid configs + designer presets), per-profile guarded.
+    if DandersFramesDB_v2 and DandersFramesDB_v2.profiles then
+        for _, profile in pairs(DandersFramesDB_v2.profiles) do
+            if type(profile) == "table" and not profile._priorityHigherWinsV1 then
+                if type(profile.party) == "table" then FlipAuraDesignerPriorities(profile.party.auraDesigner) end
+                if type(profile.raid) == "table" then FlipAuraDesignerPriorities(profile.raid.auraDesigner) end
+                if type(profile.auraDesignerPresets) == "table" then
+                    for _, presetCfg in pairs(profile.auraDesignerPresets) do
+                        FlipAuraDesignerPriorities(presetCfg)
+                    end
+                end
+                profile._priorityHigherWinsV1 = true
+            end
+        end
+    end
+
+    -- Click Casting bindings (class -> profile -> bindings), guarded on the CC store.
+    local ccdb = DandersFramesClickCastingDB
+    if ccdb and type(ccdb.classes) == "table" and not ccdb._priorityHigherWinsV1 then
+        for _, classData in pairs(ccdb.classes) do
+            if type(classData) == "table" and type(classData.profiles) == "table" then
+                for _, profile in pairs(classData.profiles) do
+                    if type(profile) == "table" and type(profile.bindings) == "table" then
+                        for _, binding in ipairs(profile.bindings) do
+                            FlipStoredPriority(binding)
+                        end
+                    end
+                end
+            end
+        end
+        ccdb._priorityHigherWinsV1 = true
+    end
+end
+
 -- One-time: carry the old bespoke important-spell highlight settings
 -- (targetedSpellHighlightStyle/Color/Size/Inset) into the new Important Spell
 -- Border key set (targetedSpellImportantBorder*), which is a second DF.Border
@@ -5385,6 +5454,13 @@ DF._MainEventDispatcher = function(self, event, arg1)
             -- (Text Designer now renders all text). Per-profile guarded.
             if DF.MigrateOORTextAlpha then
                 DF:MigrateOORTextAlpha()
+            end
+
+            -- Flip Priority sliders to higher-wins (AD auras + CC bindings).
+            -- Behaviour-preserving (remaps stored values + flipped comparators);
+            -- per-store guarded, idempotent.
+            if DF.MigratePriorityHigherWins then
+                DF:MigratePriorityHigherWins()
             end
 
             -- CRITICAL: Update power bars now that unit data is available

--- a/Core.lua
+++ b/Core.lua
@@ -3552,72 +3552,38 @@ function DF:MigrateBorderInsetFold()
     end
 end
 
--- One-time: flip the Priority sliders from "lower number wins" to "higher
--- number wins" so they match every other slider (right = more). The stored
--- value is remapped 11-p (an involution over 1..10), and every comparator and
--- the frame-level priority boost were flipped to match, so EXISTING setups
--- resolve IDENTICALLY -- only the number the slider shows changes. Covers both
--- the Aura Designer aura priority (DandersFramesDB_v2) and the Click Casting
--- binding priority (DandersFramesClickCastingDB). Each store is guarded by its
--- own flag; idempotent.
-local function FlipStoredPriority(t)
-    if type(t) == "table" and type(t.priority) == "number" then
-        local p = math.floor(t.priority + 0.5)
-        if p < 1 then p = 1 elseif p > 10 then p = 10 end
-        t.priority = 11 - p
-    end
-end
-
--- Walk an Aura Designer config's auras (mirrors FoldAuraDesignerConfig: handles
--- both the flat V1 `auras[name]` shape and the per-spec `auras[spec][name]`
--- shape) and flip each aura's priority.
-local function FlipAuraDesignerPriorities(cfg)
-    if type(cfg) ~= "table" or type(cfg.auras) ~= "table" then return end
-    for _, entry in pairs(cfg.auras) do
-        if type(entry) == "table" then
-            if entry.indicators then
-                FlipStoredPriority(entry)                 -- flat: entry IS the auraCfg
-            else
-                for _, auraCfg in pairs(entry) do         -- per-spec: entry is a spec table
-                    FlipStoredPriority(auraCfg)
-                end
-            end
-        end
-    end
-end
-
-function DF:MigratePriorityHigherWins()
-    -- Aura Designer (party/raid configs + designer presets), per-profile guarded.
+-- Transition shim (unreleased-only): an earlier iteration of the priority flip
+-- converted values to the new higher-wins scale and then stamped a COARSE flag —
+-- profile-level for Aura Designer, store-level for Click Casting. The replacement
+-- lazy migrations (DF.MigrateAuraDesignerPrioritiesLazy / CC:MigratePrioritiesLazy)
+-- key off a FINER flag (per resolved adDB table / per CC profile). Forward the
+-- coarse flags to the fine ones WITHOUT touching any value, so data already
+-- converted by the old pass is never double-flipped. Purely additive + idempotent
+-- (only sets flags); a no-op for anyone who never ran the old pass. Auto-layout
+-- overlays are intentionally left unstamped — the old pass never converted them,
+-- so the lazy migration must still flip those on first resolve.
+function DF:ForwardPriorityMigrationFlags()
+    local function stamp(adDB) if type(adDB) == "table" then adDB._priorityHigherWinsV1 = true end end
     if DandersFramesDB_v2 and DandersFramesDB_v2.profiles then
         for _, profile in pairs(DandersFramesDB_v2.profiles) do
-            if type(profile) == "table" and not profile._priorityHigherWinsV1 then
-                if type(profile.party) == "table" then FlipAuraDesignerPriorities(profile.party.auraDesigner) end
-                if type(profile.raid) == "table" then FlipAuraDesignerPriorities(profile.raid.auraDesigner) end
+            if type(profile) == "table" and profile._priorityHigherWinsV1 then
+                if type(profile.party) == "table" then stamp(profile.party.auraDesigner) end
+                if type(profile.raid) == "table" then stamp(profile.raid.auraDesigner) end
                 if type(profile.auraDesignerPresets) == "table" then
-                    for _, presetCfg in pairs(profile.auraDesignerPresets) do
-                        FlipAuraDesignerPriorities(presetCfg)
-                    end
+                    for _, presetCfg in pairs(profile.auraDesignerPresets) do stamp(presetCfg) end
                 end
-                profile._priorityHigherWinsV1 = true
             end
         end
     end
-
-    -- Click Casting bindings (class -> profile -> bindings), guarded on the CC store.
     local ccdb = DandersFramesClickCastingDB
-    if ccdb and type(ccdb.classes) == "table" and not ccdb._priorityHigherWinsV1 then
+    if ccdb and ccdb._priorityHigherWinsV1 and type(ccdb.classes) == "table" then
         for _, classData in pairs(ccdb.classes) do
             if type(classData) == "table" and type(classData.profiles) == "table" then
                 for _, profile in pairs(classData.profiles) do
-                    if type(profile) == "table" and type(profile.bindings) == "table" then
-                        for _, binding in ipairs(profile.bindings) do
-                            FlipStoredPriority(binding)
-                        end
-                    end
+                    if type(profile) == "table" then profile._priorityHigherWinsV1 = true end
                 end
             end
         end
-        ccdb._priorityHigherWinsV1 = true
     end
 end
 
@@ -5456,11 +5422,13 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 DF:MigrateOORTextAlpha()
             end
 
-            -- Flip Priority sliders to higher-wins (AD auras + CC bindings).
-            -- Behaviour-preserving (remaps stored values + flipped comparators);
-            -- per-store guarded, idempotent.
-            if DF.MigratePriorityHigherWins then
-                DF:MigratePriorityHigherWins()
+            -- Priority higher-wins flip is now lazy/at-point-of-use — see
+            -- DF.MigrateAuraDesignerPrioritiesLazy and CC:MigratePrioritiesLazy.
+            -- Only forward the old coarse migration flags to the new fine-grained
+            -- ones here (never flips a value), so data an earlier pass already
+            -- converted is not double-flipped.
+            if DF.ForwardPriorityMigrationFlags then
+                DF:ForwardPriorityMigrationFlags()
             end
 
             -- CRITICAL: Update power bars now that unit data is available

--- a/DesignerPresets.lua
+++ b/DesignerPresets.lua
@@ -45,6 +45,9 @@ function DF:NewAuraDesignerConfig()
     cfg.auras = {}
     cfg.layoutGroups = {}
     cfg.nextLayoutGroupID = 1
+    -- Born in the new higher-wins priority scale, so the lazy priority migration
+    -- never flips a freshly-created config (see MigrateAuraDesignerPrioritiesLazy).
+    cfg._priorityHigherWinsV1 = true
     return cfg
 end
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -63,8 +63,6 @@ L["Pick an Aura Designer preset below for this layout. 'Inherit (Global)' follow
 L["Pick a Text Designer preset below for this layout. 'Inherit (Global)' follows your global one."] = true
 L["Clears this layout's Aura Designer preset override so it follows your global Aura Designer preset."] = true
 -- ClickCasting UI strings
-L["1 = Low"] = true
-L["10 = High"] = true
 L["Higher priority wins"] = true
 L["A few things to know:\n\n- Party only — raid frames aren't supported.\n\n- If two members share the same class, role, race and sex, they can't be told apart and won't show an icon (you'll be warned by name).\n\n- This relies on Blizzard behaviour that isn't officially supported. Blizzard could change it at any time — if they do, the feature simply stops working and there's no fix. There's no guarantee it stays."] = true
 L["A newer version is available (%s). Get it on CurseForge."] = true

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -63,8 +63,9 @@ L["Pick an Aura Designer preset below for this layout. 'Inherit (Global)' follow
 L["Pick a Text Designer preset below for this layout. 'Inherit (Global)' follows your global one."] = true
 L["Clears this layout's Aura Designer preset override so it follows your global Aura Designer preset."] = true
 -- ClickCasting UI strings
-L["1 = High"] = true
-L["10 = Low"] = true
+L["1 = Low"] = true
+L["10 = High"] = true
+L["Higher priority wins"] = true
 L["A few things to know:\n\n- Party only — raid frames aren't supported.\n\n- If two members share the same class, role, race and sex, they can't be told apart and won't show an icon (you'll be warned by name).\n\n- This relies on Blizzard behaviour that isn't officially supported. Blizzard could change it at any time — if they do, the feature simply stops working and there's no fix. There's no guarantee it stays."] = true
 L["A newer version is available (%s). Get it on CurseForge."] = true
 L["A-Z"] = true


### PR DESCRIPTION
## Priority sliders: higher number wins

The Click Casting **binding Priority** and Aura Designer **aura Priority** sliders used *lower-number-wins* (1 = highest) — the opposite of every other slider in the addon, and the opposite of how priority is presented elsewhere. So dragging the slider right made an item *lose*, which read as backwards.

This flips both to **higher-number-wins** (10 = highest), so the sliders read left-to-right as **Low → High** like everything else.

### Behaviour-preserving
- A one-time migration remaps stored values (`11 - p`, an involution over 1–10).
- The resolution comparators (CC binding sort, AD `prioritySort` + the AD options sort) and the AD frame-level priority boost were all flipped to match.
- Net result: existing bindings/auras resolve **identically** — only the displayed number changes, never which one wins.

### UI
- `Low` / `High` end labels and a "Higher priority wins" note under both sliders.

`raidGroupOrder` and other unrelated changes are intentionally **not** in this PR.
