### PR TITLE
Fix role-icon crash on roleless units (NPC/boss pinned frames)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A top-to-bottom rework of the configuration UI so every panel shares one consist
 
 ### Bug Fixes
 
+* (Pinned Frames / Test Mode) Fixed a Lua error that spammed and froze the UI (forcing a reload) when previewing pinned frames containing NPC/boss units — role icons no longer error on units without a role. (by Krathe)
 * (Borders) **Border Inset** is now honoured by texture-style borders, and updates live. (by Krathe)
 * (Text) Fixed a stray health value (often a "%") appearing for users who never turned health text on. (by Krathe)
 * (Nicknames) Fixed an error matching nicknames against boss/NPC names on pinned frames in encounters.

--- a/Frames/Core.lua
+++ b/Frames/Core.lua
@@ -748,6 +748,11 @@ function DF:GetRoleIconTexture(db, role)
             return atlas  -- atlas name, no texcoords
         end
         local c = BLIZZARD_ROLE_COORDS[role]
+        -- Unknown/missing role (e.g. "NONE" or nil for a roleless unit): no icon.
+        -- Callers pass the result to SetIconTextureOrAtlas, which no-ops on nil.
+        -- Guard prevents indexing a nil coord table (a roleless test/raid unit
+        -- otherwise crashed GetRoleIconTexture).
+        if not c then return nil end
         return "Interface\\LFGFrame\\UI-LFG-ICON-PORTRAITROLES", c[1], c[2], c[3], c[4]
     end
 end

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -1223,12 +1223,15 @@ function DF:UpdateTestIcons(frame, testData)
     -- Role Icon
     if frame.roleIcon then
         local role = testData.role
-        local shouldShow = true
-        
+        -- Only TANK/HEALER/DAMAGER have a role icon; a nil/"NONE" role shows none
+        -- (matches live StatusIcons and avoids GetRoleIconTexture indexing a nil
+        -- coord table for a roleless test unit).
+        local shouldShow = (role == "TANK" or role == "HEALER" or role == "DAMAGER")
+
         -- In test mode (out of combat), if "Only Apply Settings in Combat" is checked, show all icons
         local applySettings = not db.roleIconOnlyInCombat
-        
-        if applySettings then
+
+        if shouldShow and applySettings then
             if role == "TANK" then
                 shouldShow = db.roleIconShowTank ~= false
             elseif role == "HEALER" then


### PR DESCRIPTION
## Fix role-icon crash on roleless units (NPC/boss pinned frames)

A user hit a repeating Lua error that froze the UI and forced a `/reload` every time they set up pinned frames containing NPC/boss units:

```
Frames/Core.lua: attempt to index local 'c' (a nil value) in GetRoleIconTexture
  <- UpdateTestIcons <- UpdateTestFrame <- EnterTestMode <- ShowRaidTestFrames <- ToggleTestPanel
```

### Cause
`GetRoleIconTexture` did `local c = BLIZZARD_ROLE_COORDS[role]` then indexed `c[1]`. That table only has `TANK`/`HEALER`/`DAMAGER` keys, so a **roleless unit** (`role` = `nil` or `"NONE"`, e.g. an NPC/boss in a pinned set's test preview) made `c` nil → crash. The error fired on every frame update, spamming and leaving test mode half-initialized so it couldn't be closed without a reload.

Live unit frames were unaffected because `StatusIcons` already gates the call (`if not shouldShow or role == "NONE" then Hide`); the **test path** (`UpdateTestIcons`) did not gate, and the friendly-boss test data is roleless.

### Fix
1. `GetRoleIconTexture` returns `nil` for an unknown/missing role instead of indexing a nil table — `SetIconTextureOrAtlas` already no-ops on nil, so every caller is crash-proof.
2. `UpdateTestIcons` only shows a role icon for `TANK`/`HEALER`/`DAMAGER`, matching the live `StatusIcons` behaviour (roleless units show no role icon).

Two-file change; no behaviour change for units that have a role.
