### PR TITLE
Sorting: fix combat-status banner showing as a blank white box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A top-to-bottom rework of the configuration UI so every panel shares one consist
 
 ### Bug Fixes
 
+* (Sorting) Fixed the combat-status banner on the Sorting page sometimes appearing as a blank white box instead of its coloured status. (by Krathe)
 * (Borders) **Border Inset** is now honoured by texture-style borders, and updates live. (by Krathe)
 * (Text) Fixed a stray health value (often a "%") appearing for users who never turned health text on. (by Krathe)
 * (Nicknames) Fixed an error matching nicknames against boss/NPC names on pinned frames in encounters.

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -3851,8 +3851,15 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             end
         end
 
-        combatBanner.hideOn = HideSortOptions
-        combatBanner.UpdateBanner = UpdateCombatBanner
+        -- Hide when an external FrameSort addon owns sorting OR our sorting is off
+        -- (the combat banner is only meaningful while our sorting is enabled).
+        -- Without the sortEnabled check, the page's RefreshStates re-showed the
+        -- banner after UpdateCombatBanner had hidden it -- a white, tone-less box.
+        combatBanner.hideOn = function(d) return (d.useFrameSort and FrameSortApi) or not d.sortEnabled end
+        -- Reapply tone + text on every page refresh. RefreshStates calls
+        -- refreshContent (not the old custom UpdateBanner method), so the banner
+        -- never shows without a tone (the backdrop defaults to white until toned).
+        combatBanner.refreshContent = UpdateCombatBanner
         Add(combatBanner, combatBanner.layoutHeight, "both")
 
         -- Initial update

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -3855,7 +3855,7 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
         -- (the combat banner is only meaningful while our sorting is enabled).
         -- Without the sortEnabled check, the page's RefreshStates re-showed the
         -- banner after UpdateCombatBanner had hidden it -- a white, tone-less box.
-        combatBanner.hideOn = function(d) return (d.useFrameSort and FrameSortApi) or not d.sortEnabled end
+        combatBanner.hideOn = function(d) return HideSortOptions(d) or not d.sortEnabled end
         -- Reapply tone + text on every page refresh. RefreshStates calls
         -- refreshContent (not the old custom UpdateBanner method), so the banner
         -- never shows without a tone (the backdrop defaults to white until toned).


### PR DESCRIPTION
## Sorting: fix combat-status banner showing as a blank white box

On the Sorting page the "Combat Safe / Combat Limitation" banner sometimes rendered as a blank **white box** instead of its coloured status.

### Cause
- `CreateInfoBanner`'s backdrop defaults to white — the colour only comes from `SetTone()`.
- The banner's tone/text were applied by a custom `UpdateBanner` method that the page's `RefreshStates` never calls (it calls `refreshContent`).
- Its `hideOn` only hid the banner for an external FrameSort addon, **not** when sorting is disabled — but `UpdateCombatBanner` hides it (without setting a tone) when sorting is off.

So when sorting was off (or on a refresh that ran before the tone was applied), `UpdateCombatBanner` hid the untoned banner and `RefreshStates` re-showed it as a toneless white box. Intermittent because it depended on refresh order / `sortEnabled` state.

### Fix
- The banner gets its own `hideOn` that also hides when sorting is disabled (so it's never shown without a reason).
- The tone/text setter is wired into `refreshContent`, so `RefreshStates` reapplies it on every show — the banner is never shown white.

One-file change. Safe from the banner relayout-loop class because `SetText` is already idempotent.
