### PR TITLE
Fonts: validate SafeSetFont inputs against corrupted profile values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ A top-to-bottom rework of the configuration UI so every panel shares one consist
 
 ### Bug Fixes
 
+* (Fonts) **A corrupted font setting can no longer break the addon on login** — font name, size and outline values are validated before use, so a bad value in an imported or hand-edited profile now degrades to default text styling instead of erroring out the entire frame layout (which showed up as missing debuffs, broken test mode and blank settings values). (by Krathe)
 * (Pinned Frames / Test Mode) Fixed a Lua error that spammed and froze the UI (forcing a reload) when previewing pinned frames containing NPC/boss units — role icons no longer error on units without a role. (by Krathe)
 * (Sorting) Fixed the combat-status banner on the Sorting page sometimes appearing as a blank white box instead of its coloured status. (by Krathe)
 * (Raid) Test mode and settings changes can no longer disturb your **live** raid frames — group order and positions are always driven by the secure layout, fixing the grouped-raid inversion that previously needed a `/reload`. (by Krathe)

--- a/Config.lua
+++ b/Config.lua
@@ -678,8 +678,15 @@ end
 function DF:SafeSetFont(fontString, fontNameOrPath, fontSize, outline)
     if not fontString then return false end
 
-    fontSize = fontSize or 10
-    outline = outline or ""
+    -- Harden against wrong-typed profile values: raw db values reach here from
+    -- every caller, and a corrupted import can store a boolean/number/table in
+    -- a font key. Coerce instead of crashing (a bad outline once broke frame
+    -- layout addon-wide on login): bad font name -> fallback font, bad size ->
+    -- default, bad outline -> no flags.
+    if type(fontNameOrPath) ~= "string" then fontNameOrPath = nil end
+    fontSize = tonumber(fontSize) or 10
+    if fontSize <= 0 then fontSize = 10 end
+    if type(outline) ~= "string" then outline = "" end
 
     -- The stored outline value may carry a "SHADOW;" prefix (Grid2-style: a drop
     -- shadow combined with any flag, e.g. "SHADOW;MONOCHROME, OUTLINE"). The legacy


### PR DESCRIPTION
## What

Hardens `DF:SafeSetFont` against wrong-typed stored values: non-string font name falls through to the fallback font, non-numeric/non-positive size becomes the default 10, non-string outline becomes no flags.

## Why

Live 4.5.0 user report: after a settings change (most likely a profile import), every login threw 7x:

```
[DandersFrames/Config.lua]:689: in function 'SafeSetFont'
[DandersFrames/Frames/Update.lua]:1700: in function 'ApplyAuraLayout'
[DandersFrames/Frames/Update.lua]:493: in function 'ApplyFrameLayout'
...
[DandersFrames/Frames/Init.lua]:1516: in function 'UpdateAllFrames'
```

Root cause: `SafeSetFont` defaults `nil` inputs but calls `outline:match()` on whatever else arrives — and it receives raw db values from every caller. A non-string in one aura outline key (boolean/number/table from a corrupted import) crashed the whole layout pass: debuff icons never laid out, test mode and the settings pages broke with it.

With the guard, one bad key degrades to default text styling for that one text instead of taking down frame layout addon-wide.

## Notes

- Behaviour unchanged for all valid stored values (`nil` handling identical to before; numeric-string sizes now coerced via `tonumber`, previously relied on Lua string arithmetic further down).
- The affected user has a no-code workaround in the meantime (re-selecting the Outline dropdowns rewrites the key), but this makes the failure class impossible.
- Changelog entry included under Unreleased → Bug Fixes.