### PR TITLE
Text Designer: restore health text dropped by the 4.6.0 legacy migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Text Designer) **Restored health text lost when upgrading to 4.6.0** — the legacy-to-Text-Designer conversion keyed "did this profile use health text?" off an internal flag that never actually controlled the old display, so upgrading dropped the health text element for most converting profiles (and its cleanup pass could remove a working health element from profiles converted by earlier versions). The conversion now keys off the real setting — the health text Format, where only NONE means off — and profiles that already lost their health text get it rebuilt from their legacy settings on login. If you had deliberately deleted the auto-created health element, it may reappear once — delete it again and it will stay gone. The stray "%" cleanup now targets only profiles that genuinely had health text disabled. (by Krathe)
+
 ## [4.6.0]
 
 ### Interface Overhaul

--- a/TextDesigner/Migration.lua
+++ b/TextDesigner/Migration.lua
@@ -35,6 +35,94 @@ end
 -- PER-MODE BUILD
 -- ============================================================
 
+-- Build ONE health element from a mode's legacy settings, or nil when the
+-- user had health text off. The live legacy renderer is gated by
+-- healthTextFormat ALONE ("NONE" = off; anything else renders, Config
+-- default CURRENTMAX) — showHealthText was only ever read by test mode,
+-- has no GUI control, and defaults to false, so it must NOT gate this:
+-- keying on it (4.6.0) silently dropped the health element for every
+-- migrating profile. `nextID` is the caller's element-id allocator.
+local function buildHealthElement(db, nextID)
+    -- Default to the real Config default (CURRENTMAX), NOT "PERCENT" — a nil
+    -- format is the unset default, and falling back to PERCENT was what turned
+    -- it into a bare "%". Composite formats render as one group FontString that
+    -- owns the font/size/outline/color/anchor/offset.
+    local healthFormat = db.healthTextFormat or "CURRENTMAX"
+    if healthFormat == "NONE" then
+        -- The one legacy state that genuinely means "no health text".
+        return nil
+    end
+
+    -- Color is re-copied per element so a group + its siblings never share
+    -- the same color ref.
+    local healthCommon = {
+        anchor        = db.healthTextAnchor,
+        offsetX       = db.healthTextX,
+        offsetY       = db.healthTextY,
+        useClassColor = db.healthTextUseClassColor,
+        outline       = db.healthTextOutline,
+        font          = db.healthFont,
+        fontSize      = db.healthFontSize,
+    }
+    local function newHealthElem(extra)
+        local e = {
+            id            = nextID(),
+            enabled       = true,
+            label         = "",
+            anchor        = healthCommon.anchor,
+            offsetX       = healthCommon.offsetX,
+            offsetY       = healthCommon.offsetY,
+            color         = copyColor(db.healthTextColor),
+            useClassColor = healthCommon.useClassColor,
+            outline       = healthCommon.outline,
+            font          = healthCommon.font,
+            fontSize      = healthCommon.fontSize,
+            overrides     = appearanceOverrides(),
+        }
+        for k, v in pairs(extra) do e[k] = v end
+        return e
+    end
+
+    if healthFormat == "PERCENT" then
+        return newHealthElem({
+            contentType = "hp_percent",
+            decimals    = 0,
+            hidePercent = db.healthTextHidePercent,
+        })
+    elseif healthFormat == "CURRENT" then
+        return newHealthElem({
+            contentType  = "hp_current",
+            abbreviate   = db.healthTextAbbreviate,
+            hideWhenZero = true,
+        })
+    elseif healthFormat == "DEFICIT" then
+        return newHealthElem({
+            contentType  = "hp_deficit",
+            abbreviate   = db.healthTextAbbreviate,
+            hideWhenZero = true,
+        })
+    elseif healthFormat == "CURRENT_PERCENT" then
+        return newHealthElem({
+            contentType    = "group",
+            groupSeparator = " ",
+            groupItems     = {
+                { contentType = "hp_current", abbreviate = db.healthTextAbbreviate },
+                { contentType = "hp_percent", decimals = 0 },
+            },
+        })
+    else
+        -- CURRENTMAX / CURRENT_MAX / unknown → the Config default (current / max).
+        return newHealthElem({
+            contentType    = "group",
+            groupSeparator = " / ",
+            groupItems     = {
+                { contentType = "hp_current", abbreviate = db.healthTextAbbreviate, hideWhenZero = false },
+                { contentType = "hp_max",     abbreviate = db.healthTextAbbreviate },
+            },
+        })
+    end
+end
+
 -- Builds the elements array for one mode's legacy settings. `tdDB` is the
 -- mode's db.textDesigner; the nextElementID counter on it is used + bumped
 -- the same way the picker does so future manual adds keep unique ids.
@@ -68,85 +156,12 @@ local function buildElements(db, tdDB)
     }
 
     -- ── HEALTH ───────────────────────────────────────────────
-    -- Only migrate health text if the user actually had it ENABLED. showHealthText
-    -- defaults to false, so without this gate the migration injected a health
-    -- element onto frames for everyone who never turned health text on — showing a
-    -- stray "%" (PERCENT / nil format) or "x / y" on the health bar. Status text
-    -- is gated the same way (statusTextEnabled) below; health was the gap.
-    if db.showHealthText ~= false then
-        -- Default to the real Config default (CURRENTMAX), NOT "PERCENT" — a nil
-        -- format is the unset default, and falling back to PERCENT was what turned
-        -- it into a bare "%". Composite formats render as one group FontString that
-        -- owns the font/size/outline/color/anchor/offset.
-        local healthFormat = db.healthTextFormat or "CURRENTMAX"
-        -- Color is re-copied per element (in newHealthElem) so a group + its
-        -- siblings never share the same color ref.
-        local healthCommon = {
-            anchor        = db.healthTextAnchor,
-            offsetX       = db.healthTextX,
-            offsetY       = db.healthTextY,
-            useClassColor = db.healthTextUseClassColor,
-            outline       = db.healthTextOutline,
-            font          = db.healthFont,
-            fontSize      = db.healthFontSize,
-        }
-        local function newHealthElem(extra)
-            local e = {
-                id            = nextID(),
-                enabled       = true,
-                label         = "",
-                anchor        = healthCommon.anchor,
-                offsetX       = healthCommon.offsetX,
-                offsetY       = healthCommon.offsetY,
-                color         = copyColor(db.healthTextColor),
-                useClassColor = healthCommon.useClassColor,
-                outline       = healthCommon.outline,
-                font          = healthCommon.font,
-                fontSize      = healthCommon.fontSize,
-                overrides     = appearanceOverrides(),
-            }
-            for k, v in pairs(extra) do e[k] = v end
-            return e
-        end
-
-        if healthFormat == "PERCENT" then
-            elements[#elements + 1] = newHealthElem({
-                contentType = "hp_percent",
-                decimals    = 0,
-                hidePercent = db.healthTextHidePercent,
-            })
-        elseif healthFormat == "CURRENT" then
-            elements[#elements + 1] = newHealthElem({
-                contentType  = "hp_current",
-                abbreviate   = db.healthTextAbbreviate,
-                hideWhenZero = true,
-            })
-        elseif healthFormat == "DEFICIT" then
-            elements[#elements + 1] = newHealthElem({
-                contentType  = "hp_deficit",
-                abbreviate   = db.healthTextAbbreviate,
-                hideWhenZero = true,
-            })
-        elseif healthFormat == "CURRENT_PERCENT" then
-            elements[#elements + 1] = newHealthElem({
-                contentType    = "group",
-                groupSeparator = " ",
-                groupItems     = {
-                    { contentType = "hp_current", abbreviate = db.healthTextAbbreviate },
-                    { contentType = "hp_percent", decimals = 0 },
-                },
-            })
-        else
-            -- CURRENTMAX / CURRENT_MAX / unknown → the Config default (current / max).
-            elements[#elements + 1] = newHealthElem({
-                contentType    = "group",
-                groupSeparator = " / ",
-                groupItems     = {
-                    { contentType = "hp_current", abbreviate = db.healthTextAbbreviate, hideWhenZero = false },
-                    { contentType = "hp_max",     abbreviate = db.healthTextAbbreviate },
-                },
-            })
-        end
+    -- Gated inside buildHealthElement on healthTextFormat ~= "NONE" — the
+    -- only off-state the legacy live renderer ever honoured. Status text is
+    -- gated on statusTextEnabled below because the live path reads that key.
+    local healthElem = buildHealthElement(db, nextID)
+    if healthElem then
+        elements[#elements + 1] = healthElem
     end
 
     -- ── STATUS (Dead / Offline / Ghost) ──────────────────────
@@ -232,13 +247,17 @@ end
 -- ============================================================
 -- CORRECTIVE PASS — remove stray auto-migrated health text
 -- ============================================================
--- The pre-fix migration ignored showHealthText, so profiles that had health text
--- OFF still got an auto-built health element (a stray "%" / "x / y" on the bar).
--- The builder is fixed going forward, but already-migrated profiles keep the
--- artifact and the one-shot migratedFromLegacy guard stops a natural re-run. This
--- removes it, but ONLY when safe:
---   1. the profile was auto-migrated AND had health text OFF (showHealthText ==
---      false) — so nobody who actually wanted health text is touched; and
+-- The original (4.4-era) migration turned healthTextFormat == "NONE" — the only
+-- legacy state where the live path showed NO health text — into a percent
+-- element (its else-branch), so those users got a stray "%" / "x / y" on the
+-- bar. The builder is fixed going forward, but already-migrated profiles keep
+-- the artifact and the one-shot migratedFromLegacy guard stops a natural
+-- re-run. This removes it, but ONLY when safe:
+--   1. the profile was auto-migrated AND had health text off in the one way the
+--      live renderer honoured (healthTextFormat == "NONE") — so nobody who
+--      actually saw health text is touched. (4.6.0 keyed this on
+--      showHealthText == false, which is the DEFAULT — that wrongly deleted
+--      wanted health elements; RestoreMigratedHealthText below repairs it.)
 --   2. the health element is still byte-identical to what the (buggy) migration
 --      produced — so a moved / recoloured / reformatted element (user engaged with
 --      it) is left alone.
@@ -307,8 +326,9 @@ function DF:CorrectStrayMigratedHealthText()
         local tdDB = db and ((DF.GetModeTextDesigner and DF:GetModeTextDesigner(mode))
             or (DF.TextDesigner and DF.TextDesigner.EnsureDB and DF.TextDesigner:EnsureDB(db)))
         if db and tdDB and not tdDB.healthMigrationCorrected then
-            -- Eligible only when this profile was auto-migrated AND had health text off.
-            if tdDB.migratedFromLegacy == true and db.showHealthText == false
+            -- Eligible only when this profile was auto-migrated AND had health
+            -- text off in the way the live renderer honoured (format NONE).
+            if tdDB.migratedFromLegacy == true and db.healthTextFormat == "NONE"
                 and type(tdDB.elements) == "table" then
                 local expected = legacyMigratedHealthElement(db)
                 for i = #tdDB.elements, 1, -1 do
@@ -325,6 +345,81 @@ function DF:CorrectStrayMigratedHealthText()
     end
     if total > 0 then
         DF:Debug("TD", "CorrectStrayMigratedHealthText: removed %d stray health element(s)", total)
+        if DF.TextDesigner and DF.TextDesigner.Preview and DF.TextDesigner.Preview.RefreshAll then
+            DF.TextDesigner.Preview:RefreshAll()
+        end
+        if DF.UpdateAllFrames then DF:UpdateAllFrames() end
+    end
+
+    -- Chained here (rather than separately wired in Core/Profile) so it runs
+    -- at both existing call sites — login and profile switch — and always
+    -- AFTER the stray-element removal above.
+    DF:RestoreMigratedHealthText()
+end
+
+-- ============================================================
+-- CORRECTIVE PASS 2 — restore health text the 4.6.0 migration dropped
+-- ============================================================
+-- 4.6.0 gated the migrated health element on showHealthText — a key the live
+-- legacy renderer never read (test-mode only, no GUI control, defaults to
+-- false). Two damage classes shipped:
+--   * fresh 4.6.0 migrations skipped the health element entirely; and
+--   * the stray-"%" corrective pass above deleted 4.4/4.5-era migrated health
+--     elements from any profile whose (unrelated) showHealthText was false.
+-- For auto-migrated stores that ended up with NO health element even though
+-- the legacy format says health text was on, rebuild it from the mode's
+-- legacy settings. One-shot per store (healthRestoredV2). Known trade-off: a
+-- user who deliberately deleted their auto-migrated health element gets it
+-- back once (called out in the changelog); the flag stops any repeat.
+
+-- True if any element (or item of a composite group) renders a health value.
+local function isHealthContent(contentType)
+    return type(contentType) == "string" and contentType:sub(1, 3) == "hp_"
+end
+
+local function hasHealthElement(elements)
+    for _, e in ipairs(elements) do
+        if isHealthContent(e.contentType) then return true end
+        if e.contentType == "group" and type(e.groupItems) == "table" then
+            for _, item in ipairs(e.groupItems) do
+                if isHealthContent(item.contentType) then return true end
+            end
+        end
+    end
+    return false
+end
+
+function DF:RestoreMigratedHealthText()
+    if not DF.db then return end
+    local total = 0
+    for _, mode in ipairs({ "party", "raid" }) do
+        local db = DF:GetDB(mode)
+        local tdDB = db and ((DF.GetModeTextDesigner and DF:GetModeTextDesigner(mode))
+            or (DF.TextDesigner and DF.TextDesigner.EnsureDB and DF.TextDesigner:EnsureDB(db)))
+        if db and tdDB and not tdDB.healthRestoredV2 then
+            if tdDB.migratedFromLegacy == true
+                and type(tdDB.elements) == "table"
+                and (db.healthTextFormat or "CURRENTMAX") ~= "NONE"
+                and not hasHealthElement(tdDB.elements) then
+                tdDB.nextElementID = tdDB.nextElementID or 1
+                local function nextID()
+                    local id = tdDB.nextElementID
+                    tdDB.nextElementID = id + 1
+                    return id
+                end
+                local elem = buildHealthElement(db, nextID)
+                if elem then
+                    tdDB.elements[#tdDB.elements + 1] = elem
+                    total = total + 1
+                end
+            end
+            -- Mark every visited store — including ineligible ones — so the
+            -- scan never re-runs.
+            tdDB.healthRestoredV2 = true
+        end
+    end
+    if total > 0 then
+        DF:Debug("TD", "RestoreMigratedHealthText: rebuilt %d health element(s) from legacy settings", total)
         if DF.TextDesigner and DF.TextDesigner.Preview and DF.TextDesigner.Preview.RefreshAll then
             DF.TextDesigner.Preview:RefreshAll()
         end


### PR DESCRIPTION
Hotfix for a 4.6.0 regression that's generating user reports: **health text disappears when a profile converts from the built-in text to the Text Designer**, plus a smaller group seeing an unwanted "%" element. One file + changelog; suggest shipping as 4.6.1.

## Root cause

The 4.6.0 stray-"%" fix gated the migrated health element on `showHealthText`:

* The legacy **live** renderer has never read `showHealthText` — from 4.3.x through today it is gated by `healthTextFormat` alone (`"NONE"` = off, anything else renders, Config default `CURRENTMAX`). `showHealthText` was only ever read by test mode, has **no GUI control**, and defaults to `false`.
* So on 4.6.0 the gate fails for virtually every converting profile: the migration builds name + status but **no health element**, then enables TD and hides the legacy text → health text gone. This also fires per-profile on profile switch (lazy migration), and the "Import Current Text Settings" button is blocked by the same gate, so users can't self-repair.
* The corrective pass in the same commit removes an auto-migrated health element whenever `showHealthText == false` — i.e. by default — so updating 4.5.0 → 4.6.0 could also **delete a working health element** that had been driving the display since 4.4/4.5.
* The genuine "had health text off" state in the legacy world was `healthTextFormat = "NONE"`; that is also the state the original 4.4 migration mishandled into a percent element (the true source of the stray "%").

## Fix (TextDesigner/Migration.lua)

1. **Builder** — health element gated on `healthTextFormat ~= "NONE"` with an explicit NONE branch; the `showHealthText` gate is removed. Construction is factored into a shared `buildHealthElement`; output shape is unchanged for every non-NONE format.
2. **Corrective pass** — eligibility keyed on `format == "NONE"` instead of `showHealthText == false`, so it can only touch profiles that genuinely had health text disabled. (Because the fixed builder produces no element for NONE profiles, the pass can never remove a freshly built element.)
3. **New one-shot restore pass** (`RestoreMigratedHealthText`, runs after the corrective pass at both login and profile switch) — an auto-migrated store with no health element (plain `hp_*` or inside a composite group) whose legacy format says health text was on gets the element rebuilt from the mode's legacy settings. This repairs both damage classes retroactively on the user's next login. Guarded by a per-store `healthRestoredV2` flag.

Known trade-off, called out in the changelog: a user who deliberately deleted their **auto-migrated** health element gets it back once (deleting it again sticks, the flag prevents any repeat). Users who built their own TD setup from scratch are untouched (no `migratedFromLegacy` flag), as are profiles that still have any health element.

## Notes

* The changelog hunk will trivially conflict with PR #201 (both add a `### Bug Fixes` block under `[Unreleased]`) — resolve by combining the entry lists under one header; the code files don't overlap.
* The element construction was verified against the migration history so the corrective pass's frozen-shape matching still applies unchanged; the state matrix (fresh conversion, 4.6.0-damaged, corrective-deleted, NONE-format, deliberate-delete, custom-built TD) was traced case by case. An in-game pass on the migration/restore paths is running on our side — will confirm on the PR.
