### PR TITLE
Aura Designer: clear expiring state when a tracked aura refreshes

### DIFF
--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1115,6 +1115,16 @@ local function ApplyBorderToOverlay(ch, frame, config, auraData)
     if expiringEnabled == nil then expiringEnabled = false end
     local ec = config.expiringColor
 
+    -- Keep the expiring entry's aura times fresh on EVERY cycle, rebuild or
+    -- not: an aura REFRESH keeps the same auraInstanceID, so it lands in the
+    -- signature skip below with the ticker entry still holding the pre-refresh
+    -- duration/expirationTime. The manual threshold math then decays to zero
+    -- remaining and parks the border permanently "expiring" — a stuck pulse,
+    -- or a stuck-visible Show-When-Missing tracker. (No-op when no expiring
+    -- entry is registered for this overlay.)
+    DF.Expiring:UpdateEntryTimes(ch, auraData and auraData.duration,
+        auraData and auraData.expirationTime, auraID)
+
     -- Change detection — ApplyBorder runs every Apply cycle (frame-level
     -- indicator), so skip the rebuild + expiring re-register when nothing the
     -- border cares about changed.  Comprehensive (covers every render-affecting

--- a/AuraDesigner/Indicators.lua
+++ b/AuraDesigner/Indicators.lua
@@ -1115,23 +1115,24 @@ local function ApplyBorderToOverlay(ch, frame, config, auraData)
     if expiringEnabled == nil then expiringEnabled = false end
     local ec = config.expiringColor
 
-    -- Keep the expiring entry's aura times fresh on EVERY cycle, rebuild or
-    -- not: an aura REFRESH keeps the same auraInstanceID, so it lands in the
-    -- signature skip below with the ticker entry still holding the pre-refresh
-    -- duration/expirationTime. The manual threshold math then decays to zero
-    -- remaining and parks the border permanently "expiring" — a stuck pulse,
-    -- or a stuck-visible Show-When-Missing tracker. (No-op when no expiring
-    -- entry is registered for this overlay.)
-    DF.Expiring:UpdateEntryTimes(ch, auraData and auraData.duration,
-        auraData and auraData.expirationTime, auraID)
-
     -- Change detection — ApplyBorder runs every Apply cycle (frame-level
     -- indicator), so skip the rebuild + expiring re-register when nothing the
     -- border cares about changed.  Comprehensive (covers every render-affecting
     -- spec field) so GUI edits reach live frames without /reload.  The expiring
     -- ticker recolours live via RecolorActive between rebuilds.
     local sig = BorderTypeSpecSig(spec, auraID, config)
-    if ch.dfAD_sig == sig then return end
+    if ch.dfAD_sig == sig then
+        -- Same visual spec — but an aura REFRESH keeps its auraInstanceID, so
+        -- it lands here with the expiring entry still holding the pre-refresh
+        -- duration/expirationTime. The manual threshold math then decays to
+        -- zero remaining and parks the border permanently "expiring" (stuck
+        -- pulse). Refresh the entry's times before skipping; the rebuild path
+        -- below re-registers with fresh times anyway. (No-op when no expiring
+        -- entry is registered for this overlay.)
+        DF.Expiring:UpdateEntryTimes(ch, auraData and auraData.duration,
+            auraData and auraData.expirationTime, auraID)
+        return
+    end
     ch.dfAD_sig = sig
 
     DF.Border:Apply(ch, spec)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* (Aura Designer) **Expiring state now clears when an aura is refreshed** — refreshing a tracked aura (re-casting a HoT in its pandemic window, for example) kept the border's cached expiry times from before the refresh, so once an indicator crossed its Expiring Threshold it stayed "expiring" forever: pulse animations never stopped and Show-When-Missing trackers stayed visible full-time. The expiring engine now refreshes its timing data on every aura update. Present since 4.4.0; borders using the Expiring Color Override were unaffected. (by Krathe)
+* (Aura Designer) Fixed expiring border animations staying stuck on after the tracked aura was refreshed (for example re-casting a HoT in its pandemic window). (by Krathe)
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Aura Designer) **Expiring state now clears when an aura is refreshed** — refreshing a tracked aura (re-casting a HoT in its pandemic window, for example) kept the border's cached expiry times from before the refresh, so once an indicator crossed its Expiring Threshold it stayed "expiring" forever: pulse animations never stopped and Show-When-Missing trackers stayed visible full-time. The expiring engine now refreshes its timing data on every aura update. Present since 4.4.0; borders using the Expiring Color Override were unaffected. (by Krathe)
+
 ## [4.7.0]
 
 ### Bug Fixes

--- a/Frames/Expiring.lua
+++ b/Frames/Expiring.lua
@@ -316,6 +316,30 @@ function Expiring:Unregister(element)
     end
 end
 
+-- Refresh a registered entry's aura-time fields without a full re-register.
+-- Change-detection callers (the AD border path) skip their rebuild — and with
+-- it the RegisterExpiring call — when nothing VISUAL changed. An aura REFRESH
+-- keeps the same auraInstanceID, so it takes that skip and the entry's cached
+-- duration/expirationTime go stale; the manual threshold fallback then
+-- computes remaining time from the stale expiration, which decays to zero and
+-- parks the entry permanently "expiring" (stuck pulse, stuck Show-When-Missing
+-- visibility). Callers pass the CURRENT aura data every apply cycle; this is a
+-- no-op when the element has no registered entry.
+--
+-- The new values are assigned unconditionally (no equality short-circuit:
+-- duration/expirationTime may be secret values, and comparing secrets taints)
+-- and the entry re-evaluates immediately, mirroring Register, so a refresh
+-- that climbs back above the threshold un-expires on this same update instead
+-- of a tick later.
+function Expiring:UpdateEntryTimes(element, duration, expirationTime, auraInstanceID)
+    local entry = element and expiringRegistry[element]
+    if not entry then return end
+    entry.duration = duration
+    entry.expirationTime = expirationTime
+    entry.auraInstanceID = auraInstanceID
+    EvaluateEntry(element, entry)
+end
+
 -- ~3 FPS shared ticker.  One OnUpdate for every registered element across the
 -- whole addon (AD indicators + buff expiring borders).
 local expiringFrame = CreateFrame("Frame")


### PR DESCRIPTION
Fixes a user report: an expiring pulse border "remains when I refresh it". Reported against 4.6.0 but **present since the 4.4.0 DF.Border unification** — the reporter hit it on 4.5.0.

## Root cause

`ApplyBorderToOverlay` uses a change-detection signature to skip rebuilds on every apply cycle. The signature covers every visual field plus the `auraInstanceID` — but **an aura refresh keeps its auraInstanceID** and only extends `expirationTime`. A refresh therefore takes the skip, and with it skips the `RegisterExpiring` call, leaving the expiring ticker's entry holding the **pre-refresh `duration`/`expirationTime`**.

From there:
- The ticker's live duration-curve path self-heals (it queries `C_UnitAuras.GetAuraDuration` fresh each tick) — but it's only wired when the **Expiring Color Override** is enabled (that's what builds the `colorCurve`).
- Pulse-only borders fall to the **manual fallback**, which computes remaining time from the stale expiration. That decays to zero and parks permanently at/below any threshold → the pulse never stops.
- The designer preview rebuilds on every refresh, which masked the gap there.

Hide-until-expiring (Show When Missing) borders are **not** affected: the Apply tail clears `dfAD_sig` for them every cycle, so they always re-registered with fresh times.

## Fix

* New `Expiring:UpdateEntryTimes(element, duration, expirationTime, auraInstanceID)` in `Frames/Expiring.lua`: refreshes a registered entry's aura-time fields and re-evaluates immediately (mirroring `Register`), no-op when the element has no entry. Values are assigned **unconditionally** — no equality short-circuit, since duration/expirationTime can be secret values and comparing secrets taints.
* `ApplyBorderToOverlay` calls it **inside the signature-match branch** — the only path that skips re-registration; the rebuild path re-registers with fresh times anyway (relocated there per review, avoiding a redundant evaluation against the outgoing entry on rebuilds).
* Audited the sibling `RegisterExpiring` sites (healthbar, background overlay, name/health text, framealpha, icons, squares, bars + their duration-hide wrappers): all re-register on every apply cycle, so only the border path had the stale window.

## Scope

This fixes the non-secret case (own HoTs, preview, out of combat). The in-combat case — where live aura times are secret and only the colour-curve path can detect the threshold — is tracked separately (lab bug #980) and needs the visibility-curve follow-up; this PR should not close it.

## Notes for a follow-up (not in this PR)

Two adjacent latent issues surfaced during the trace, both pre-existing: the shared ticker drops hidden elements from its registry (which makes icon/square-type Show-When-Missing trackers structurally unreliable — visibility for them is effectively event-driven only), and `IsAuraExpiring` in `AuraDesigner/Engine.lua` is dead code (no callers).

## User workaround until release

Enabling **Expiring Color Override** on the affected border activates the self-healing curve path.
