### PR TITLE
Text Designer: engage the colour override on first picker change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* (Text Designer) **Element colour edits now apply while you pick** — changing an element's Color previously took effect only after closing the colour picker with OK; while the picker was open the text kept rendering the default colour (usually white) no matter what you chose, so the setting looked broken — the swatch showed your colour while the text refused to change. The per-element colour override now engages on the first change, so the preview and live frames follow the picker immediately. (by Krathe)
+* (Text Designer) Element colour changes now take effect immediately while the colour picker is open, instead of only after closing it with OK. (by Krathe)
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * (Text Designer) Element colour changes now take effect immediately while the colour picker is open, instead of only after closing it with OK. (by Krathe)
+* (Interface) Opening a colour picker no longer counts as a colour change — the picker fired its change handlers once during setup, which could commit settings (such as a Text Designer element's colour override) without any edit. (by Krathe)
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Text Designer) **Element colour edits now apply while you pick** — changing an element's Color previously took effect only after closing the colour picker with OK; while the picker was open the text kept rendering the default colour (usually white) no matter what you chose, so the setting looked broken — the swatch showed your colour while the text refused to change. The per-element colour override now engages on the first change, so the preview and live frames follow the picker immediately. (by Krathe)
+
 ## [4.7.0]
 
 ### Bug Fixes

--- a/GUI/GUI.lua
+++ b/GUI/GUI.lua
@@ -4013,9 +4013,18 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
         
         -- Store original values for cancel
         local originalColor = {r = c.r, g = c.g, b = c.b, a = c.a or 1}
+
+        -- Blizzard's SetupColorPickerAndShow fires swatchFunc once DURING
+        -- setup (its SetColorRGB triggers OnColorSelect — the source comments
+        -- it). That spurious fire re-writes the unchanged colour and runs the
+        -- change callbacks on mere open: it commits per-element override flags
+        -- (Text Designer) and triggers a pointless full refresh. Suppress
+        -- callbacks until setup has returned.
+        local settingUp = true
         
         local info = {
             swatchFunc = function()
+                if settingUp then return end
                 local r, g, b = ColorPickerFrame:GetColorRGB()
                 local a = 1
                 if hasAlpha and ColorPickerFrame.GetColorAlpha then
@@ -4042,6 +4051,7 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
             end,
             hasOpacity = hasAlpha,
             opacityFunc = hasAlpha and function()
+                if settingUp then return end
                 if ColorPickerFrame.GetColorAlpha then
                     local a = ColorPickerFrame:GetColorAlpha()
                     if a then
@@ -4123,6 +4133,7 @@ function GUI:CreateColorPicker(parent, label, dbTable, dbKey, hasAlpha, callback
         -- Mark this as a DandersFrames color picker call
         GUI:MarkColorPickerCall()
         ColorPickerFrame:SetupColorPickerAndShow(info)
+        settingUp = false
     end)
     
     container.SetEnabled = function(self, enabled)

--- a/TextDesigner/Options.lua
+++ b/TextDesigner/Options.lua
@@ -828,6 +828,16 @@ local function BuildAppearanceSection(GUI, parent, elem, card, yStart)
     end, function()
         -- Throttled refresh while dragging: preview every tick, live frames
         -- ~30/s — live but not laggy. Full RefreshAll runs once on close.
+        --
+        -- The override flag must be set HERE too, not only in the full
+        -- callback above: in lightweight mode the full callback only fires
+        -- when the picker closes via OK, but the value binding writes
+        -- elem.color on every change. Without the flag the renderer keeps
+        -- resolving globalDefaults (white) for the whole picker session —
+        -- the swatch shows the new colour while the text refuses to change,
+        -- which reads as "the color setting doesn't work". First touch of
+        -- the picker = the user wants a per-element colour; flag it then.
+        elem.overrides.color = true
         if DF.TextDesigner.Preview then DF.TextDesigner.Preview:RefreshThrottled() end
     end, true)
     colorPicker:SetPoint("TOPLEFT", parent, "TOPLEFT", 14, y)


### PR DESCRIPTION
Fixes a user report: "I've set the Text Designer health element's color to black but it stubbornly shows white."

## Root cause

Text Designer elements resolve appearance through an override system — the renderer honours `elem.color` only when `elem.overrides.color` is set, otherwise it falls back to `globalDefaults` (white). The element editor sets that flag **only in the colour picker's full callback**, and in lightweight mode (which the TD editor uses for smooth drag previews) the full callback fires **exclusively when the picker closes via OK** (through the close watcher's change detection).

Meanwhile the widget's value binding writes `elem.color` on every change. Net effect during the entire picker session: the swatch shows the chosen colour, every preview/live refresh re-resolves the *global default*, and the text refuses to change — dead feedback that reads exactly as "the colour setting doesn't work". A user who reasonably closes with Cancel/Esc at that point also reverts the value, making the failure permanent from their perspective. Closing with OK did apply the colour, but by then most users have concluded it's broken.

Font, size and outline were unaffected — their callbacks fire immediately on change; colour was uniquely broken by the lightweight split.

## Fix

Set `elem.overrides.color = true` in the lightweight (per-change) callback as well: the first touch of the picker is the user asking for a per-element colour, and the flag should never lag the value. One file, one insertion.

Review follow-up (second commit): Blizzard's `SetupColorPickerAndShow` fires `swatchFunc` once during setup (confirmed in wow-ui-source — "This must come last, since it triggers a call to swatchFunc"), so the first commit alone would let merely opening the picker engage the override. The second commit adds a `settingUp` guard to the shared `GUI:CreateColorPicker`: the flag spans the synchronous setup call and `swatchFunc`/`opacityFunc` return early while it's set, suppressing the spurious setup-fire for every picker addon-wide (it also removes a pointless full refresh on open in non-lightweight mode). All three wrapper branches in `GUI/ColorPicker.lua` are covered — the DF-internal picker path already skipped its own init callbacks; the raw-Blizzard and global-override branches did not.

Known nuance, deliberately accepted: once the user has touched the picker, the element keeps its colour override even if they cancel (previously the cancel path set the flag too, via the full callback — so this isn't a behaviour change, just noting it). The rendered colour on cancel is still correctly reverted.

## Verification notes

Traced the full resolve path for the report's scenario: `resolveAppearance` override fallback, group-item colour escapes (`colorize` is black-safe: `0 or 1` keeps 0), class-colour gating (picker correctly greys and disables when Use Class Colour is on), and the picker's close watcher (Blizzard's frame stays technically shown behind the custom picker, so the watcher fires correctly on OK). The lightweight-callback gap was the only path that reproduces "swatch black, text white".
