### PR TITLE
12.1: retire container border animation, missing-buff spill, orbit/pixel fix

### DIFF
--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -336,15 +336,12 @@ local function renameBorderTypeKeys(t)
             if t.BorderTexture == nil then t.BorderTexture = "DF Glow" end
             if t.BorderSize    == nil then t.BorderSize    = thickness end
         elseif style == "DASHED" or style == "ANIMATED" then
+            -- The legacy dashed/animated styles drew a size-0 border made visible
+            -- ONLY by a container border animation, which 12.1 retired (aura buttons
+            -- go forbidden while auras are secret). Fold them to a visible static
+            -- border so an upgraded config renders something rather than nothing.
             t.BorderStyle = "SOLID"
-            if t.BorderSize == nil then t.BorderSize = 0 end
-            if t.BorderAnimationType == nil then
-                t.BorderAnimationType      = "DF_DASH"
-                t.BorderAnimationFrequency = (style == "ANIMATED") and 1 or 0
-                t.BorderAnimationThickness = thickness
-                t.BorderAnimationColor     = color
-                t.BorderAnimationInset     = inset
-            end
+            if t.BorderSize == nil then t.BorderSize = thickness end
         elseif style == "CORNERS" then
             t.BorderStyle = "SOLID"
             if t.BorderSize == nil then t.BorderSize = 0 end
@@ -3961,7 +3958,6 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
-                    animate = true,
                 },
                 -- IMPORTANT: AD's per-aura proxy only triggers
                 -- RefreshLiveFramesThrottled + RefreshPreviewLightweight
@@ -4092,7 +4088,6 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
-                    animate = true,
                 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
@@ -4214,7 +4209,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 parent  = parent,
                 include = {
                     inset = true, blendMode = true, gradient = true,
-                    shadow = true, alpha = true, animate = true,
+                    shadow = true, alpha = true,
                 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
@@ -4301,13 +4296,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
-                    animate = true,
                 },
-                -- DF Flash / DF Proc are centre-anchored proc-glow flares sized to
-                -- the icon; this border wraps the WHOLE frame, so they'd bloom to an
-                -- absurd size. Exclude them here (they stay available on the icon /
-                -- square / bar indicators, whose borders are icon-sized).
-                animExcludeTypes = { DF_FLASH = 1, DF_PROC = 1 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
                 lightColors   = RPL,
@@ -7490,9 +7479,7 @@ local function AddGroupAppearanceSection(body, group, bodyWidth, by, cardKey)
             include = {
                 inset = true, offset = true, blendMode = true,
                 gradient = true, shadow = true, alpha = true,
-                animate = true,
             },
-            animExcludeTypes = { DF_FLASH = true, DF_PROC = true },
             fullUpdate    = refresh,
             lightUpdate   = refresh,
             lightColors   = refresh,

--- a/AuraDesigner/Options.lua
+++ b/AuraDesigner/Options.lua
@@ -3285,6 +3285,9 @@ local function RefreshPreviewEffects()
     -- Every type skips hidden blocks (eye toggle, enabled == false) — same as pickWinner.
     if auraCfg.border and auraCfg.border.enabled ~= false and auraCfg.border.ShowBorder ~= false then
         local spec = DF.Border:BuildSpec(auraCfg.border, "")
+        spec.animation = nil   -- AD border animation retired on 12.1; the preview must match the
+                               -- live render (which strips it at the container chokepoint) so a
+                               -- stuck-on BorderAnimationType from an old profile doesn't animate here.
         if not spec.color then spec.color = { r = 1, g = 1, b = 1, a = 1 } end
         spec.enabled = true
         if auraCfg.border.borderMode == "custom" then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ DandersFrames has been rebuilt for WoW 12.1 (Midnight), which fundamentally chan
 * (Aura Designer) The editor's preview canvas renders through the real 12.1 engine — what you see while styling is exactly what ships to the frames, including out-of-range fading.
 * (Aura Designer) Test mode previews the Aura Designer through the real engine — every placed indicator renders with its configured spell, styling and animations, exactly as live.
 * (Interface) **Border animations are now entirely DF's own.** Four new effects — DF Chase, DF Flash, DF Pixel and DF Proc — join DF Pulsate, DF Dash and Blink; the old library-backed effects are retired.
-* (Auras) **Animated borders are back on the Defensive and Missing-Buff icons**, with the full DF animation set. The animation driver is now shared, so animated borders are lighter across the board.
+* (Auras) **Animated borders are available on the Missing-Buff icons**, with the full DF animation set. The animation driver is now shared, so animated borders are lighter across the board.
+* (Auras) Border animations aren't offered on the aura icons themselves — buff, debuff, defensive and Aura Designer indicators. On 12.1 the game hides aura data in combat and forbids addons from touching aura icons while it's hidden, so an animated border there would break; those borders are static. Frame borders, the Missing-Buff badge and targeted-spell highlights are unaffected and still animate.
 * (Auras) Out-of-range and dead-unit fading works on the 12.1 aura displays again — live and in test mode.
 * (Aura Designer) The spell picker shows one unified grid — the separate "Inferred Tracking" section is gone; every tracked aura now works the same way.
 * (Aura Designer) Filter and debuff group boxes in the editor preview show greyed example icons, sized and arranged to your layout settings.

--- a/Features/Auras.lua
+++ b/Features/Auras.lua
@@ -1219,6 +1219,41 @@ local function buildMissingCellConfig(info, unit, size)
     }
 end
 
+-- Outward reach (px) of the missing-buff border animation — how far it extends BEYOND
+-- the icon. The clip window keeps this much transparent margin around the badge so the
+-- animation shows outside the icon when the buff is missing, and the layout-push grows to
+-- match so it does NOT leak onto buffed units (the badge + its spill both clear the window
+-- when the buff is present). Returns 0 when there's no border animation, so a non-animated
+-- badge keeps the exact icon-sized window as before. Conservative — over-estimating is
+-- harmless (the extra margin is transparent, and a bigger push still just clips off-window):
+--   negative inset pushes the art out · offset shifts it · the effect's own glow/particles
+--   reach ~half the icon at scale 1.
+local function missingAnimSpill(db, badgeSize)
+    if db.missingBuffIconShowBorder == false then return 0 end
+    local t = db.missingBuffIconBorderAnimationType
+    if not t or t == "NONE" then return 0 end
+    local inset = db.missingBuffIconBorderAnimationInset or 0
+    local offX  = math.abs(db.missingBuffIconBorderAnimationOffsetX or 0)
+    local offY  = math.abs(db.missingBuffIconBorderAnimationOffsetY or 0)
+    local scale = math.max(1, db.missingBuffIconBorderAnimationScale or 1)
+    -- The anim rect (host) is the icon inset-adjusted by the animation inset (negative =
+    -- larger). Some effects flare well past their steady state during the one-shot INTRO —
+    -- Proc's contracting burst (PROC_BURST_SCALE 150/42 of the host) and Flash's opening
+    -- outer glow (2F, F = host*1.4) — so size the window to the intro, not the loop, else
+    -- the intro clips at the window edge. Others hug the border ~half the icon.
+    local host = badgeSize - 2 * inset
+    local artOut
+    if t == "DF_PROC" then
+        artOut = (host * (150 / 42) - badgeSize) / 2
+    elseif t == "DF_FLASH" then
+        artOut = (host * 2 * 1.4 - badgeSize) / 2
+    else
+        artOut = math.max(0, -inset) + badgeSize * 0.5 * scale
+    end
+    local out = math.max(0, artOut) + math.max(offX, offY)
+    return math.min(badgeSize * 5, math.max(0, math.ceil(out)))
+end
+
 -- Paint one cell's badge: spell icon + unified DF.Border (missingBuffIcon* keys).
 -- The badge frame's POSITION derives from the container's secret size (§20c):
 -- never pixel-snap it or read its rect; secretRect borders render anchor-only.
@@ -1342,12 +1377,17 @@ function DF:DriveMissingBuffFactory(frame, db)
         frame.missingFactory = cells
         frame.missingFactorySig = sig
         frame.dfMissingFactoryVersion = DF.auraLayoutVersion or 0
+        local spill = missingAnimSpill(db, badgeSize)
         for i = 1, #tracked do
             local info = tracked[i]
-            local h = DF.AuraContainer:Create(strip, buildMissingCellConfig(info, frame.unit, badgeSize))
+            local cellCfg = buildMissingCellConfig(info, frame.unit, badgeSize)
+            cellCfg.badge.spill = spill   -- transparent room for the border animation to spill outside the icon
+            local h = DF.AuraContainer:Create(strip, cellCfg)
             if h then
                 h:ClearAllPoints()
-                h:SetPoint("LEFT", strip, "LEFT", (i - 1) * (badgeSize + MISSING_BADGE_GAP), 0)
+                -- Shift the (spill-enlarged) window left by the spill so the CENTRED badge
+                -- still lands on the badge-pitch grid — icon position unchanged, window grows.
+                h:SetPoint("LEFT", strip, "LEFT", (i - 1) * (badgeSize + MISSING_BADGE_GAP) - spill, 0)
                 styleMissingBadge(h, db, frame, info)
                 cells[info[2]] = h
             end
@@ -1411,13 +1451,17 @@ function DF:DriveMissingBuffFactory(frame, db)
     if frame.dfMissingFactoryVersion ~= ver and not InCombatLockdown() then
         frame.dfMissingFactoryVersion = ver
         layoutMissingStrip(frame, db, strip, #tracked)
+        local spill = missingAnimSpill(db, badgeSize)
         for i = 1, #tracked do
             local info = tracked[i]
             local h = cells[info[2]]
             if h then
                 if h.SetBadgeSize then h:SetBadgeSize(badgeSize, badgeSize) end
+                -- Live-apply the animation spill (grows window/push, re-centres badge) with
+                -- no teardown, so a slider drag re-flows the spill without restarting the anim.
+                if h.SetBadgeSpill then h:SetBadgeSpill(spill) end
                 h:ClearAllPoints()
-                h:SetPoint("LEFT", strip, "LEFT", (i - 1) * (badgeSize + MISSING_BADGE_GAP), 0)
+                h:SetPoint("LEFT", strip, "LEFT", (i - 1) * (badgeSize + MISSING_BADGE_GAP) - spill, 0)
                 styleMissingBadge(h, db, frame, info)
             end
         end

--- a/Frames/AuraContainer.lua
+++ b/Frames/AuraContainer.lua
@@ -1089,11 +1089,12 @@ function NativeBackend:build()
     local maxCount = handle:_slotCount()
     local groupLayout
     if isMissing then
-        -- The cell IS the push distance: >= badge width guarantees the badge clears the
-        -- window entirely when the tracked buff is present.
+        -- The cell IS the push distance: >= badge width + 2*spill guarantees the badge AND
+        -- its animation spill clear the window entirely when the tracked buff is present.
         local bw = (config.badge and config.badge.w) or 24
         local bh = (config.badge and config.badge.h) or 24
-        groupLayout = { elementWidth = bw + MISSING_PAD, elementHeight = bh }
+        local sp = (config.badge and config.badge.spill) or 0
+        groupLayout = { elementWidth = bw + 2 * sp + MISSING_PAD, elementHeight = bh }
     elseif not isOverlay then
         groupLayout = buildGroupLayout(config)
     end
@@ -1196,6 +1197,10 @@ function NativeBackend:build()
     -- The badge's rect now derives from the container's SECRET size: render-side only,
     -- never read its position in Lua (no pixel-snap, no GetLeft) — §20c rules.
     if isMissing and handle.badge then
+        -- Centre the badge in the (badge + 2*spill) window: the -MISSING_PAD container pin
+        -- and the +MISSING_PAD badge inset still cancel to park it on the window when empty;
+        -- the +spill / -spill centres it inside the enlarged window.
+        local sp = (handle.config.badge and handle.config.badge.spill) or 0
         handle.badge:ClearAllPoints()
         if testMode then
             -- P5 preview: the container stays DISABLED all test session (the
@@ -1203,9 +1208,9 @@ function NativeBackend:build()
             -- resolvable rect (its secret SetSize only runs while enabled) — a
             -- badge anchored to it renders NOTHING (live-caught). Park the
             -- badge on the WINDOW instead: that IS the "missing" position.
-            handle.badge:SetPoint("TOPLEFT", handle.frame, "TOPLEFT", 0, 0)
+            handle.badge:SetPoint("TOPLEFT", handle.frame, "TOPLEFT", sp, -sp)
         else
-            handle.badge:SetPoint("TOPLEFT", c, "TOPLEFT", MISSING_PAD, 0)
+            handle.badge:SetPoint("TOPLEFT", c, "TOPLEFT", MISSING_PAD + sp, -sp)
         end
         handle.badge:Show()
     end
@@ -1683,18 +1688,51 @@ function Handle:SetBadgeSize(w, h)
     self.config.badge = badge
     if badge.w == w and badge.h == h then return end
     badge.w, badge.h = w, h
-    self.frame:SetSize(w, h)
+    local sp = badge.spill or 0
+    self.frame:SetSize(w + 2 * sp, h + 2 * sp)
     self.badge:SetSize(w, h)
     local backend = self.backend
     local c = backend and backend.container
     if c and backend.groupKeys and c.SetAuraGroupLayout then
-        local cellLayout = { elementWidth = w + MISSING_PAD, elementHeight = h }
+        local cellLayout = { elementWidth = w + 2 * sp + MISSING_PAD, elementHeight = h }
         for _, key in ipairs(backend.groupKeys) do
             pcall(function() c:SetAuraGroupLayout(key, cellLayout) end)
         end
         if not InCombatLockdown() then
             pcall(function() c:Hide(); c:Show() end)
         end
+    end
+end
+
+-- Live-update the animation SPILL margin (px of transparent room the clip window keeps
+-- around the badge so a border animation can extend OUTSIDE the icon). Grows the window +
+-- re-centres the badge + grows the layout-push so the badge AND its spill still clear the
+-- window when the buff is present (no leak onto buffed units). No teardown -> the running
+-- animation is NOT restarted; the caller re-offsets the strip cell by -spill so the badge's
+-- on-screen position is unchanged. The push mutator applies on the next aura event, which is
+-- fine: the push only matters once the buff is present (the badge is hidden then anyway).
+function Handle:SetBadgeSpill(sp)
+    if self.config.mode ~= "missing" or not self.badge then return end
+    sp = math.max(0, math.floor(sp or 0))
+    local badge = self.config.badge or {}
+    self.config.badge = badge
+    if (badge.spill or 0) == sp then return end
+    badge.spill = sp
+    local bw, bh = badge.w or 24, badge.h or 24
+    self.frame:SetSize(bw + 2 * sp, bh + 2 * sp)
+    self.badge:ClearAllPoints()
+    local backend = self.backend
+    local c = backend and backend.container
+    if c then
+        self.badge:SetPoint("TOPLEFT", c, "TOPLEFT", MISSING_PAD + sp, -sp)
+        if backend.groupKeys and c.SetAuraGroupLayout then
+            local cellLayout = { elementWidth = bw + 2 * sp + MISSING_PAD, elementHeight = bh }
+            for _, key in ipairs(backend.groupKeys) do
+                pcall(function() c:SetAuraGroupLayout(key, cellLayout) end)
+            end
+        end
+    else
+        self.badge:SetPoint("TOPLEFT", self.frame, "TOPLEFT", sp, -sp)
     end
 end
 -- Returns the DESIRED unit; while in combat the backend retarget may still be deferred to regen.
@@ -2136,15 +2174,22 @@ function AuraContainer:Create(parent, config)
         -- button's cell width pushes it out ("present" renders NOTHING). Zero reads.
         local bw = (cfg.badge and cfg.badge.w) or 24
         local bh = (cfg.badge and cfg.badge.h) or 24
+        -- spill = transparent margin the clip window keeps AROUND the badge so a border
+        -- ANIMATION can extend OUTSIDE the icon (missing state) without the window clipping
+        -- it. The badge sits CENTRED; the layout-push (below) grows by 2*spill so the badge
+        -- AND its spill still clear the window when the buff is present (no leak onto buffed
+        -- units). Derived from the animation config by the caller (0 when no animation, so
+        -- the non-animated case is byte-identical to before). Live-updated by SetBadgeSpill.
+        local sp = (cfg.badge and cfg.badge.spill) or 0
         h.frame:SetClipsChildren(true)
-        h.frame:SetSize(bw, bh)
+        h.frame:SetSize(bw + 2 * sp, bh + 2 * sp)
         -- The badge is handle-owned (survives container rebuilds). It starts HIDDEN and
         -- parked on the window: with no live container we must not claim "missing"
         -- (false-negative until regen beats a false-positive). The backend shows it and
         -- re-anchors it to the container when a build lands; teardown re-parks it.
         h.badge = CreateFrame("Frame", nil, h.frame)
         h.badge:SetSize(bw, bh)
-        h.badge:SetPoint("TOPLEFT", h.frame, "TOPLEFT", 0, 0)
+        h.badge:SetPoint("TOPLEFT", h.frame, "TOPLEFT", sp, -sp)
         h.badge:Hide()
     else
         -- Row/overlay: h.frame occupies the unit-frame rect (row layout anchors are

--- a/Frames/AuraContainer.lua
+++ b/Frames/AuraContainer.lua
@@ -464,22 +464,22 @@ local function styleButton_regions(slot, config)
                     -- configured slot size so the dashes size from it, not the secret rect.
                     if spec then spec.knownWidth, spec.knownHeight = sx, sy end
                 end
-                -- ANIMATION FILTER (single chokepoint for BOTH row and overlay).
-                -- The LCG glows re-SetParent pooled glow frames onto the host, which
-                -- taints on a native AuraButton (lab-proven), so they stay forbidden.
-                -- But the DF-owned animations in SAFE_OVERLAY_ANIM (edge-alpha ticks,
-                -- DF_DASH marching ants, Wipe/Ripple/etc overlays) run off our OWN border
-                -- textures via the external UIParent driver (secretRect path), so they're
-                -- taint-safe. OVERLAY-mode (frame-level AD) borders always recover them; a
-                -- ROW-mode container opts in with config.adBorderAnim (the Aura Designer
-                -- PLACED icon/square/bar borders) — the #205 buff/debuff rows do NOT set
-                -- the flag, so they still strip in row mode. Any type outside the set is
-                -- stripped regardless of mode.
-                if spec and spec.animation and not
-                   ((config.mode == "overlay" or config.adBorderAnim) and SAFE_OVERLAY_ANIM[spec.animation.type]) then
+                -- ANIMATION FILTER (single chokepoint for every container border).
+                -- 12.1 PTR-5 made AuraButtons blanket-forbidden while auras are secret
+                -- (combat / M+ / encounters / PvP): once forbidden, ANY API call on the
+                -- button OR its children errors from our tainted code — including the
+                -- render setters our OnUpdate border driver uses (SetVertexColor / Hide /
+                -- SetPoint). Every animated border here lives on a container-button child,
+                -- so any animation spams a per-frame forbidden error in exactly the content
+                -- these indicators are for. Animation is therefore stripped on ALL
+                -- container borders unconditionally (the recovery that once let AD placed /
+                -- overlay borders animate via config.adBorderAnim is gone). DF-owned frames
+                -- OFF the container — unit-frame border, missing-buff badge, targeted-spell
+                -- highlight — are not forbidden and keep animating through their own paths.
+                if spec then
                     spec.animation = nil
+                    DF.Border:Apply(slot.dfBorder, spec)
                 end
-                if spec then DF.Border:Apply(slot.dfBorder, spec) end
             end)
             if not ok and not warnedBorder then
                 warnedBorder = true

--- a/Frames/AuraContainer.lua
+++ b/Frames/AuraContainer.lua
@@ -983,8 +983,7 @@ end
 -- container's flow layout (SetAuraLayout* translation lands in P1); overlay slots are
 -- addon-anchored via the button AddAuraSlot returns.
 --
--- Each backend owns its OWN plain container (Krathe's proven ContainerOverlay pattern —
--- reference ContainerOverlay.lua buildOverlay): insecure CreateFrame is combat-legal for the
+-- Each backend owns its OWN plain container: insecure CreateFrame is combat-legal for the
 -- aura pipeline (taint.log-proven; the earlier freeze was unrelated secret-value compares,
 -- since fixed). One container per consumer = one flow layout per row (independent
 -- positioning) and a trivial recreate-on-structural-change teardown. The container is
@@ -1005,7 +1004,7 @@ end
 
 function NativeBackend:isNativeSlots() return true end
 
--- Order (Krathe's ContainerOverlay.lua buildOverlay, proven live in combat on 68569):
+-- Build order (proven live in combat on 68569 — do not reorder):
 -- CreateFrame("AuraContainer", nil, ours, "CustomAuraContainerTemplate") -> SetAllPoints ->
 -- SetUnit -> AddAuraGroup/AddAuraSlot(each filter, initializeFrame) -> SetEnabled LAST.
 -- SetEnabled gates aura-event registration (IsVisible() and IsEnabled()); without the LAST
@@ -1017,14 +1016,14 @@ function NativeBackend:build()
     local config = handle.config
 
     -- Never stand up a container in combat: in-lockdown create/enable is a hard client
-    -- error pcall can't catch (ContainerOverlay gotcha 1). Every caller already gates this
+    -- error pcall can't catch. Every caller already gates this
     -- (Create / _rebuild / the regen handler); a stray path defers instead of dying.
     if InCombatLockdown() then handle:_deferRebuild(); return end
 
     -- OUR OWN plain per-consumer container, parented to the handle's anchor frame. Insecure
     -- creation is fine — taint.log proved the old combat freeze was unrelated secret-value
     -- compares (Config.lua SafeSetFont / Auras.lua legacy scan), both fixed — and this exact
-    -- plain-create pattern runs live in combat in the AD ContainerOverlay PoC.
+    -- plain-create pattern is confirmed to run live in combat.
     local ok, c = pcall(CreateFrame, "AuraContainer", nil, handle.frame, "CustomAuraContainerTemplate")
     if not ok or not c then
         if not warnedCreate then
@@ -1179,8 +1178,8 @@ function NativeBackend:build()
         end
     end
 
-    -- SetEnabled LAST — after the groups/slots + filters are declared (ContainerOverlay.lua
-    -- gotcha 2). This is what arms the parse + UNIT_AURA registration.
+    -- SetEnabled LAST — after the groups/slots + filters are declared. This is what arms
+    -- the parse + UNIT_AURA registration.
     -- TEST MODE: stay DISABLED until the provider bounce lands (the bounce enables
     -- us) — an enabled container parses the player's REAL auras for a tick first,
     -- creating buttons whose creation order no longer matches the sample set's
@@ -1292,8 +1291,8 @@ function NativeBackend:refresh()
     end
 end
 
--- The container is OURS (per-consumer): teardown mirrors ContainerOverlay's teardownEntry —
--- disable, drop its buttons, hide, release the ref. The next build creates a fresh container
+-- The container is OURS (per-consumer): teardown is disable, drop its buttons, hide, release
+-- the ref. The next build creates a fresh container
 -- (topology is add-only — no RemoveAuraGroup/Slot — so recreate IS the sanctioned removal).
 -- Callers gate teardown out of combat (Destroy/_rebuild defer to regen in lockdown).
 function NativeBackend:teardown()
@@ -2127,7 +2126,7 @@ function AuraContainer:Create(parent, config)
     AuraContainer._handles[h] = true   -- weak-keyed registry so a dropped handle GCs (else rebuild-forever on test toggle)
     ensureProviderWatch()              -- edit-mode guard (see above); one shared frame
     -- h.frame is the plain anchor frame DF positions; the backend parents its OWN
-    -- CustomAuraContainer to it (per-consumer container — Krathe's ContainerOverlay pattern).
+    -- CustomAuraContainer to it (one container per consumer).
     h.frame = CreateFrame("Frame", nil, parent)
     if cfg.mode == "missing" then
         -- MISSING mode (probe 32, live-confirmed 2026-07-10): h.frame is a CLIP WINDOW

--- a/Frames/Border.lua
+++ b/Frames/Border.lua
@@ -755,6 +755,12 @@ local function orbitTick(border, anim, dt)
     local tex = border.orbitTex;   if not tex then return end
     local w = border._knownW or host:GetWidth()
     local h = border._knownH or host:GetHeight()
+    -- Particles anchor to the animRect (host), which ensureAnimRect insets by anim.inset
+    -- (negative = larger). _knownW/_knownH are the BORDER's raw size (secret-rect safe), so
+    -- inset-adjust them to the host's actual size — else the perimeter walk and the anchor
+    -- box disagree and the loop "breaks" mid-cycle. (host:GetWidth() is already host-sized.)
+    if border._knownW then w = w - 2 * (anim.inset or 0) end
+    if border._knownH then h = h - 2 * (anim.inset or 0) end
     if not w or not h or w <= 0 or h <= 0 then return end
     local perimeter = 2 * (w + h)
     local bottomlim = h * 2 + w
@@ -946,6 +952,12 @@ local function pixelTick(border, anim, dt)
     local tex = border.pixelTex;   if not tex then return end
     local w = border._knownW or host:GetWidth()
     local h = border._knownH or host:GetHeight()
+    -- Particles anchor to the animRect (host), which ensureAnimRect insets by anim.inset
+    -- (negative = larger). _knownW/_knownH are the BORDER's raw size (secret-rect safe), so
+    -- inset-adjust them to the host's actual size — else the perimeter walk and the anchor
+    -- box disagree and the loop "breaks" mid-cycle. (host:GetWidth() is already host-sized.)
+    if border._knownW then w = w - 2 * (anim.inset or 0) end
+    if border._knownH then h = h - 2 * (anim.inset or 0) end
     if not w or not h or w <= 0 or h <= 0 then return end
     local perimeter = 2 * (w + h)
     local bottomlim = h * 2 + w

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -6418,13 +6418,13 @@ function DF:SetupGUIPages(GUI, CreateCategory, CreateSubTab, BuildPage)
             parent       = self.child,
             -- Class/Role colour makes sense here: at a glance, the border
             -- communicates WHO is using the defensive cooldown (their class
-            -- or role) without the user having to read the icon. Animation
-            -- is useful as a "needs attention" alert when a high-priority
-            -- defensive fires.
+            -- or role) without the user having to read the icon. (Animation is
+            -- not offered: the defensive icon is a container button, and 12.1
+            -- forbids driving its border while auras are secret — see
+            -- AuraContainer's animation chokepoint.)
             include      = { inset = true, offset = true, blendMode = true,
                              gradient = true, shadow = true, alpha = true,
-                             classColor = true, roleColor = true,
-                             animate = true },
+                             classColor = true, roleColor = true },
             fullUpdate   = function() if DF.UpdateAllDefensiveBars then DF:UpdateAllDefensiveBars() end end,
             lightUpdate  = function() DF:LightweightUpdateDefensiveIcons() end,
             lightColors  = function() DF:LightweightUpdateDefensiveIconColors() end,


### PR DESCRIPTION
Follow-up container work on top of v5.0.0-alpha.6.

**Border animation on aura-container indicators — retired (the important one).**
12.1 PTR-5 makes aura buttons forbidden objects while auras are secret (combat /
M+ / encounters / PvP): any tainted API call on the button or its children errors,
including the render setters our OnUpdate border driver uses. Every animated border
on a container-button child therefore spammed a per-frame forbidden error in exactly
the content those indicators are for. The animation is now stripped on all container
borders at the single chokepoint (existing saved configs included), and the now-dead
border-animation controls are removed from the Aura Designer indicator sections and
the Defensive Icon. DF-owned borders off the container (unit-frame, missing-buff
badge, targeted-spell) are unaffected and still animate.

**Missing buffs: border animations can extend outside the icon.**
The missing-buff badge is hidden by being pushed out of a clip window sized to the
icon, which clipped any spill (when missing) or leaked it onto buffed units (the push
only cleared the badge). The window/push now grow by the animation's derived outward
reach so the effect shows outside the icon when missing and fully clears when present;
one-shot intro flares (Proc's burst, Flash's 2F glow) are sized to the intro so they
don't clip. 0 when no animation, so a non-animated badge is byte-identical. A live
mutator re-flows it on slider changes without restarting the animation.

**Fix DF Orbit / DF Pixel breaking mid-loop with a non-zero inset** — a pre-existing
bug: they walked the perimeter off the raw secret-rect-safe size but anchored to the
inset-adjusted rect, so the path and box disagreed. Now inset-adjusted like proc/flash.

**Aura Designer preview** no longer animates a stuck-on BorderAnimationType (the editor
preview applied the spec directly, bypassing the live strip).

Also: the container gap-findings / exposure / implementation planning docs, and a
comment cleanup dropping references to the deleted ContainerOverlay.lua.