### PR TITLE
Click Casting: skip secret values when scanning Blizzard frames (combat-end crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Click Casting) Fixed a Lua error walking Blizzard unit frames after combat that could stop click-casting bindings from working on the default frames until reload — the frame scan now skips protected (secret) values introduced by recent client versions. (by Krathe)
+
 ## [4.7.0]
 
 ### Bug Fixes

--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -924,8 +924,16 @@ function CC:FindHealthManaBars(obj)
     
     local function traverse(current)
         if type(current) ~= "table" then return end
+        -- 12.x secret values: a protected frame/unit reference stored on a
+        -- Blizzard frame passes the type()=="table" check but throws the moment
+        -- it's used as a table key ("cannot be indexed with secret keys"). That
+        -- aborted RegisterBlizzardFrames on combat end, so Blizzard frames never
+        -- finished click-cast setup and bindings stopped working on them. We
+        -- never need to descend into secret subtrees (health/mana bars are plain
+        -- child frames), so skip them before `current` is used as a key below.
+        if issecretvalue(current) then return end
         if checked[current] then return end
-        
+
         checked[current] = true
         if not pcall(next, current) then return end
         for key, value in pairs(current) do


### PR DESCRIPTION
Fixes a live Lua error a user hit on combat end, and with it the root cause of separate "since the latest update my click-cast binds stopped working / the frame won't accept my bind" reports.

## The error

```
ClickCasting/Frames.lua:927: attempted to index a table that cannot be indexed with secret keys
  traverse (Frames.lua:927/937)
  FindHealthManaBars (942)
  FixBlizzardFrameStatusBars (950)
  registerBlizzardFrame (1031)
  RegisterBlizzardFrames (1037)
  OnCombatEnd (Events.lua:170)
```

## Root cause

`FindHealthManaBars` recursively walks a Blizzard unit frame's **entire Lua table graph** looking for `HealthBar`/`ManaBar` keys, deduping visited tables with `checked[current] = true` — i.e. using each visited table as a **key**. Under recent client versions' secret values, a protected frame/unit reference stored on the frame passes the `type(current) == "table"` check but throws the moment it's used as that table key.

The throw propagates up through `registerBlizzardFrame` and **aborts the `RegisterBlizzardFrames` loop on `OnCombatEnd`**, so every Blizzard frame after the failing one never reaches `RegisterFrame()` — click-casting silently stops working on the default frames until `/reload`. That matches the standalone user reports of binds "messed up" / the frame "not accepting" a new bind after combat.

Not introduced by a recent change — `traverse` predates 4.7.0; it's long-standing table-walk code meeting the client's newer secret values.

## Fix

One guard at the top of `traverse`, before the table is used as a key:

```lua
if issecretvalue(current) then return end
```

Health/mana bars are plain child frames, so skipping secret subtrees loses nothing. `Frames.lua` already defines an `issecretvalue` shim (line 8) and uses it elsewhere.

## Scope check

The sibling walker `PropagateMouseOnChildren` (called from the same `FixBlizzardFrameStatusBars`) uses `GetChildren()` + `IsForbidden` rather than raw table iteration and never keys a table by a frame — already safe. The frame-registration validator already bails on secret `protected`/`name` values. `traverse` was the only place walking the raw table graph, so this is the sole offender.

Optional follow-up (not in this PR): wrapping each `registerBlizzardFrame` call in `pcall` so a single future secret-value surprise degrades to "that one frame isn't set up" instead of aborting all registration.
