### PR TITLE
Fix health bars stuck green: missing-texture fallback on every update path + class colour vertex write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Bars) Fixed class-coloured health bars staying stuck on the gradient colour (usually green) after using or switching away from the Percent colour mode — the class/custom colour is now written directly to the bar texture, so it can no longer be masked by a leftover gradient tint. (by Krathe)
+
 ## [4.7.2]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* (Bars) **Fixed health bars rendering solid green when a profile references a bar texture you don't have** — imported profiles often point at another addon's texture files; if that addon isn't installed (or its files changed), the bar showed WoW's green missing-texture state and class colours appeared broken. All bar textures now fall back to the stock texture with a one-time warning, on every update path (the fallback previously only applied when a frame was first created and was immediately overwritten). (by Krathe)
 * (Bars) Fixed class-coloured health bars staying stuck on the gradient colour (usually green) after using or switching away from the Percent colour mode — the class/custom colour is now written directly to the bar texture, so it can no longer be masked by a leftover gradient tint. (by Krathe)
 
 ## [4.7.2]

--- a/Features/TargetedSpells.lua
+++ b/Features/TargetedSpells.lua
@@ -4338,7 +4338,7 @@ local function TargetedList_ApplyBarAppearance(bar, db)
     -- which clobbers the progress fill set by ApplyBarContent.
     local texturePath = db.targetedListTexture or "Interface\\TargetingFrame\\UI-StatusBar"
     if bar._lastTexturePath ~= texturePath then
-        bar.progress:SetStatusBarTexture(texturePath)
+        DF:SafeSetStatusBarTexture(bar.progress, texturePath)
         bar._lastTexturePath = texturePath
     end
 

--- a/Frames/Colors.lua
+++ b/Frames/Colors.lua
@@ -287,15 +287,31 @@ function DF:ApplyHealthColors(frame)
             end
         end
         frame.healthBar:SetStatusBarColor(r, g, b)
-        -- Apply alpha separately so range/dead fade can control it
-        if not deadFadeActive then
-            local tex = frame.healthBar:GetStatusBarTexture()
-            if tex then tex:SetAlpha(classColorAlpha) end
+        local tex = frame.healthBar:GetStatusBarTexture()
+        if tex then
+            -- ALSO write the colour to the texture's vertex directly (the same
+            -- channel PERCENT mode and ElementAppearance use). Without this,
+            -- switching from Percent to Class can leave the last gradient
+            -- colour visible: PERCENT painted the texture directly, so the
+            -- StatusBar's own cached colour may already equal the class colour
+            -- and SetStatusBarColor above no-ops, leaving the gradient stain
+            -- (typically green at full health) until /reload. Writing the same
+            -- rgb through the vertex guarantees the visible state either way,
+            -- and matches UpdateHealthBarAppearance's channel so the two
+            -- appliers can't fight.
+            tex:SetVertexColor(r, g, b)
+            -- Apply alpha separately so range/dead fade can control it
+            if not deadFadeActive then
+                tex:SetAlpha(classColorAlpha)
+            end
         end
     else
         -- Custom color mode - use RGBA
         local c = db.healthColor
         frame.healthBar:SetStatusBarColor(c.r, c.g, c.b, c.a or 1)
+        -- Same direct vertex write as the CLASS branch above (gradient-stain fix).
+        local tex = frame.healthBar:GetStatusBarTexture()
+        if tex then tex:SetVertexColor(c.r, c.g, c.b) end
     end
     
     -- Skip background color if dead fade with custom color is active

--- a/Frames/Update.lua
+++ b/Frames/Update.lua
@@ -81,7 +81,11 @@ function DF:ApplyFrameLayout(frame)
     if healthBar then
         -- Texture
         local healthTex = db.healthTexture or "Interface\\TargetingFrame\\UI-StatusBar"
-        healthBar:SetStatusBarTexture(healthTex)
+        -- Safe setter: falls back to the stock texture when the configured path
+        -- is missing (imported profiles referencing another addon's media render
+        -- solid green otherwise). Frame CREATION already used the safe setter,
+        -- but this per-update raw call immediately clobbered its fallback.
+        DF:SafeSetStatusBarTexture(healthBar, healthTex)
         
         -- Orientation
         local orientation = db.healthOrientation or "HORIZONTAL"
@@ -141,7 +145,7 @@ function DF:ApplyFrameLayout(frame)
         local absorbTex = db.absorbBarTexture or "Interface\\Buttons\\WHITE8x8"
         local absorbColor = db.absorbBarColor or {r = 0, g = 0.835, b = 1, a = 0.7}
         
-        absorbBar:SetStatusBarTexture(absorbTex)
+        DF:SafeSetStatusBarTexture(absorbBar, absorbTex)
         absorbBar:SetStatusBarColor(absorbColor.r, absorbColor.g, absorbColor.b, absorbColor.a)
         
         if absorbMode == "FLOATING" then
@@ -179,7 +183,7 @@ function DF:ApplyFrameLayout(frame)
         local healAbsorbTex = db.healAbsorbBarTexture or "Interface\\Buttons\\WHITE8x8"
         local healAbsorbColor = db.healAbsorbBarColor or {r = 0.4, g = 0.1, b = 0.1, a = 0.7}
         
-        healAbsorbBar:SetStatusBarTexture(healAbsorbTex)
+        DF:SafeSetStatusBarTexture(healAbsorbBar, healAbsorbTex)
         healAbsorbBar:SetStatusBarColor(healAbsorbColor.r, healAbsorbColor.g, healAbsorbColor.b, healAbsorbColor.a)
         
         if healAbsorbMode == "FLOATING" then

--- a/TestMode/TestMode.lua
+++ b/TestMode/TestMode.lua
@@ -471,7 +471,7 @@ function DF:UpdateTestFrameHealthOnly(frame, index)
             if not texture or texture == "" then
                 texture = db.healthTexture or "Interface\\TargetingFrame\\UI-StatusBar"
             end
-            frame.missingHealthBar:SetStatusBarTexture(texture)
+            DF:SafeSetStatusBarTexture(frame.missingHealthBar, texture)
             
             frame.missingHealthBar:Show()
         else
@@ -667,7 +667,7 @@ function DF:UpdateTestFrame(frame, index, applyLayout)
             if not texture or texture == "" then
                 texture = db.healthTexture or "Interface\\TargetingFrame\\UI-StatusBar"
             end
-            frame.missingHealthBar:SetStatusBarTexture(texture)
+            DF:SafeSetStatusBarTexture(frame.missingHealthBar, texture)
             
             frame.missingHealthBar:Show()
         else
@@ -2606,7 +2606,7 @@ function DF:ApplyTestFrameLayout(frame)
     if frame.healthBar then
         -- Texture
         local healthTex = db.healthTexture or "Interface\\TargetingFrame\\UI-StatusBar"
-        frame.healthBar:SetStatusBarTexture(healthTex)
+        DF:SafeSetStatusBarTexture(frame.healthBar, healthTex)
         
         -- Orientation
         local orientation = db.healthOrientation or "HORIZONTAL"
@@ -2634,7 +2634,7 @@ function DF:ApplyTestFrameLayout(frame)
             if not missingTex or missingTex == "" then
                 missingTex = healthTex
             end
-            frame.missingHealthBar:SetStatusBarTexture(missingTex)
+            DF:SafeSetStatusBarTexture(frame.missingHealthBar, missingTex)
             
             if orientation == "HORIZONTAL" then
                 frame.missingHealthBar:SetOrientation("HORIZONTAL")


### PR DESCRIPTION
Fixes the recent live reports of "class coloured health bars not working / stuck green".

## Root cause: missing bar textures, not broken colours

A statusbar texture path that fails to load renders **solid green** in the client — which looks exactly like "class colours are broken".

A reporter supplied their profile export and full SavedVariables, which gave a perfect discriminator: every broken profile×mode combination's `healthTexture` pointed at media files inside **another addon's folder** (paths carried in by imported profiles — texture pickers store the file *path*, and when the addon that owns the file isn't installed, or moved its media in an update, the stored path goes dead). Every working combination used our own or Blizzard textures. The colour settings themselves (`healthColorMode`, `classColors`) were verifiably correct in all broken profiles.

The reporter also confirmed the model: re-picking the same texture name from the dropdown (which rewrites the stored path to the currently-registered location) fixed it instantly.

## Why the existing fallback didn't catch this

#123 added `SafeSetStatusBarTexture` (unknown path → stock texture + one-time warning), but it only ran at frame **creation**. `ApplyFrameLayout` re-applies the db textures **raw** on every settings pass, immediately clobbering the stock fallback — so in practice the fallback never survived.

## Fix (commit 2)

Route every user-configurable bar texture through the safe setter:

- `Frames/Update.lua` — health, absorb, heal-absorb bars in `ApplyFrameLayout`
- `TestMode/TestMode.lua` — test-mode health bar + missing-health previews (4 sites)
- `Features/TargetedSpells.lua` — targeted-list progress bar

Internal constant textures (gradient LUTs, the Blizzard shield overlay) are untouched. Result: a dead texture path now falls back to the stock bar texture with the one-time warning, on every update path — bars stay class-coloured instead of turning green.

## Commit 1: class/custom colour written to the texture vertex

Found while chasing the reports — a real adjacent defect, though **not** the reporters' root cause. `ApplyHealthColors` paints PERCENT mode via `tex:SetVertexColor(gradient)` but CLASS/CUSTOM via `SetStatusBarColor` only; after a Percent render, switching back to Class could leave the gradient tint (green at full HP) on the texture until reload. The class/custom colour is now also written to the vertex channel (same rgb — the two channels are the same tint state, not a multiply), so a leftover gradient tint can no longer mask it.

## Caveat / possible follow-up

`C_UIFileAsset.IsKnownFile` can still return true for a file that an *installed* addon used to ship but removed — that narrower case would still render green. If it shows up in testing, the follow-up is a small SharedMedia name-heal: unknown path → look the basename up in the current statusbar registry → use (and write back) the live path. Not included here to keep the hotfix minimal.

## Testing

- Offline: decoded the reporter's export + parsed their SavedVariables; broken/working combos match the texture discriminator exactly, colour data pristine.
- In-game verify recipe: set `healthTexture` to a nonexistent path, confirm the bar renders with the stock texture + one-time chat warning instead of solid green; Percent→Class mode switch keeps class colours without a reload.
