### PR TITLE
Click casting: remove the stale-handle failure that killed hover binds until reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* (Click Casting) **Fixed keyboard and extra-mouse-button hover binds dying addon-wide mid-combat until a /reload** — hover binds are now owned by one permanent frame instead of the unit frame under the cursor, removing the cleanup step that could hit a dead frame reference and silently break every later hover. The 4.7.2 after-the-fact self-repair stays as a safety net, but the cause is gone. (by Krathe)
 * (Click Casting) Fixed keyboard and mouse-wheel click-cast binds being silently dropped mid-hover during combat — the safety check that removes hover binds could misread the cursor as off the frame while the frame's position was briefly unreadable, wiping the binds until the frame was re-hovered. Binds are now only removed when the cursor is provably off the frame. (by Krathe)
 
 ## [4.7.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Click Casting) Fixed keyboard and mouse-wheel click-cast binds being silently dropped mid-hover during combat — the safety check that removes hover binds could misread the cursor as off the frame while the frame's position was briefly unreadable, wiping the binds until the frame was re-hovered. Binds are now only removed when the cursor is provably off the frame. (by Krathe)
+
 ## [4.7.3]
 
 ### Bug Fixes

--- a/ClickCasting/Bindings.lua
+++ b/ClickCasting/Bindings.lua
@@ -533,11 +533,21 @@ function CC:ApplyBindings()
         self.needsBindingRefresh = true
         return
     end
-    
+
     -- Cancel any pending batch binding pass from a previous call
     if self.batchBindingTimer then
         self.batchBindingTimer:Cancel()
         self.batchBindingTimer = nil
+    end
+
+    -- Hover keyboard/scroll binds are owned by the click-cast header, so a
+    -- full rebuild starts by wiping the header's override bindings — any
+    -- bind from the outgoing set that is still active (e.g. the user is
+    -- hovering a frame right now) would otherwise survive with its OLD
+    -- action until the next leave/enter cycle. The next OnEnter re-applies
+    -- from the freshly built snippets.
+    if self.header then
+        pcall(ClearOverrideBindings, self.header)
     end
     
     -- Migrate existing macro bindings to have no fallbacks

--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -440,11 +440,20 @@ function CC:CreateClickCastHeader()
     self.header:SetAttribute("dfClickCastEnabled", self.db and self.db.enabled or false)
     
     -- Initialize secure environment variables
-    -- mouseoverbutton tracks the currently hovered frame (Cell's pattern)
+    -- mouseoverbutton tracks the currently hovered frame (handle, used ONLY
+    -- for geometry checks in the state driver and identity comparisons).
+    -- mouseovername mirrors it as a plain string for diagnostics, so no
+    -- snippet ever needs to call a method on a possibly-stale handle.
+    -- owner is a permanent handle to this header: ALL hover override bindings
+    -- are owned by it (set/cleared through it), so clearing bindings never
+    -- has to touch a unit-frame handle that may have gone stale. The header
+    -- lives for the whole session, so owner can never dangle.
     if self.header.Execute then
         pcall(function()
             self.header:Execute([[
+                owner = self
                 mouseoverbutton = nil
+                mouseovername = nil
             ]])
         end)
     end
@@ -479,13 +488,16 @@ function CC:CreateClickCastHeader()
             mouseoverbutton:SetAttribute("dfSDMouseY", y)
 
             -- Clear only when the rect is measurable and both cursor checks
-            -- agree the cursor is off the frame
+            -- agree the cursor is off the frame. Hover binds are owned by the
+            -- header (self here), so the binding wipe never touches the frame
+            -- handle — it only writes diagnostics to it.
             if rectKnown and not underMouse and not inBounds then
                 mouseoverbutton:SetAttribute("dfClearedBy", "statedriver")
-                mouseoverbutton:ClearBindings()
+                self:ClearBindings()
                 mouseoverbutton:SetAttribute("dfBindingsActive", nil)
                 mouseoverbutton:SetAttribute("dfIsSecureMouseover", nil)
                 mouseoverbutton = nil
+                mouseovername = nil
             end
         end
     ]])
@@ -1389,7 +1401,17 @@ function CC:SetupSecureHandlers(frame)
     
     if self.header and self.header.WrapScript then
         -- WrapScript OnEnter: Set up bindings
-        -- Also clears previous frame's bindings to avoid stacking
+        --
+        -- HANDLE-SAFETY INVARIANT: this snippet must never call a method on
+        -- any frame handle other than `self` (which is always fresh — the
+        -- frame the mouse just entered) or `owner` (the header, which lives
+        -- for the whole session). The previous design called
+        -- mouseoverbutton:ClearBindings() here to clean up the prior frame's
+        -- bindings; if that shared handle ever went stale, the call errored
+        -- and aborted EVERY frame's OnEnter at that step, killing keyboard
+        -- hover binds addon-wide until /reload. All hover binds are now owned
+        -- by the header, so the cross-frame cleanup is a single
+        -- owner:ClearBindings() that cannot dangle.
         local onEnterSnippet = [[
             -- Phase 0: Reset tracking for this enter cycle
             -- dfBindingsActive is cleared FIRST so a stale true from the previous
@@ -1408,32 +1430,32 @@ function CC:SetupSecureHandlers(frame)
             self:SetAttribute("dfWrapEnterCount", wrapCount)
             self:SetAttribute("dfEnterPhase", 1)
 
-            -- Phase 2: store what mouseoverbutton was before we change it
-            if mouseoverbutton then
-                self:SetAttribute("dfSecurePrevMouseover", mouseoverbutton:GetAttribute("dfFrameName") or "unknown")
-            else
-                self:SetAttribute("dfSecurePrevMouseover", "nil")
-            end
+            -- Phase 2: store what was hovered before us (string mirror, so no
+            -- method call on the possibly-stale previous handle)
+            self:SetAttribute("dfSecurePrevMouseover", mouseovername or "nil")
             self:SetAttribute("dfEnterPhase", 2)
 
-            -- Phase 3: Clear bindings from previous button if any
-            if mouseoverbutton and mouseoverbutton ~= self then
-                mouseoverbutton:ClearBindings()
-                mouseoverbutton:SetAttribute("dfBindingsActive", nil)
-                mouseoverbutton:SetAttribute("dfIsSecureMouseover", nil)
-            end
+            -- Phase 3: Wipe ALL hover binds owner-side. This covers the
+            -- previous frame's binds without touching its handle AT ALL — not
+            -- even SetAttribute, which would equally abort on a stale handle.
+            -- (The previous frame's dfBindingsActive/dfIsSecureMouseover are
+            -- reset by its own next OnEnter Phase 0; its OnLeave normally
+            -- already cleared them.)
+            owner:ClearBindings()
             self:SetAttribute("dfEnterPhase", 3)
 
             -- Phase 4: Set mouseoverbutton
             mouseoverbutton = self
+            mouseovername = self:GetName() or "unnamed"
             self:SetAttribute("dfIsSecureMouseover", true)
             self:SetAttribute("dfEnterPhase", 4)
 
-            -- Phase 5: Clear our own bindings first then re-apply
+            -- Phase 5: Clear any legacy frame-owned bindings (self is always
+            -- a fresh handle here, so this cannot dangle)
             self:ClearBindings()
             self:SetAttribute("dfEnterPhase", 5)
 
-            -- Phase 6: Run the binding snippet
+            -- Phase 6: Run the binding snippet (binds owner-owned, targeting self)
             local snippet = self:GetAttribute("dfBindingSnippet")
             if snippet and snippet ~= "" then
                 self:Run(snippet)
@@ -1450,7 +1472,7 @@ function CC:SetupSecureHandlers(frame)
                 self:SetAttribute("dfPostCheck", "ok")
             elseif mouseoverbutton then
                 -- mouseoverbutton changed to a DIFFERENT frame during OnEnter
-                self:SetAttribute("dfPostCheck", mouseoverbutton:GetAttribute("dfFrameName") or "other")
+                self:SetAttribute("dfPostCheck", mouseovername or "other")
             else
                 -- mouseoverbutton is nil — something wiped it during OnEnter
                 self:SetAttribute("dfPostCheck", "nil")
@@ -1466,21 +1488,19 @@ function CC:SetupSecureHandlers(frame)
             local leaveCount = (self:GetAttribute("dfWrapLeaveCount") or 0) + 1
             self:SetAttribute("dfWrapLeaveCount", leaveCount)
 
-            -- Debug: store who mouseoverbutton actually points to when leave fires
-            if mouseoverbutton then
-                self:SetAttribute("dfMouseoverOnLeave", mouseoverbutton:GetAttribute("dfFrameName") or "unknown")
-            else
-                self:SetAttribute("dfMouseoverOnLeave", "nil")
-            end
+            -- Debug: store who mouseoverbutton points to when leave fires
+            -- (string mirror — never a method call on the shared handle)
+            self:SetAttribute("dfMouseoverOnLeave", mouseovername or "nil")
             -- Store whether the mouseoverbutton==self check will pass
             self:SetAttribute("dfLeaveCheckPassed", mouseoverbutton == self)
 
             if mouseoverbutton == self then
                 self:SetAttribute("dfClearedBy", "onleave")
-                self:ClearBindings()
+                owner:ClearBindings()
                 self:SetAttribute("dfBindingsActive", nil)
                 self:SetAttribute("dfIsSecureMouseover", nil)
                 mouseoverbutton = nil
+                mouseovername = nil
             end
         ]]
         
@@ -1492,10 +1512,11 @@ function CC:SetupSecureHandlers(frame)
         local onHideSnippet = [[
             if mouseoverbutton == self then
                 self:SetAttribute("dfClearedBy", "onhide")
-                self:ClearBindings()
+                owner:ClearBindings()
                 self:SetAttribute("dfBindingsActive", nil)
                 self:SetAttribute("dfIsSecureMouseover", nil)
                 mouseoverbutton = nil
+                mouseovername = nil
             end
         ]]
 
@@ -1768,9 +1789,14 @@ function CC:UpdateFrameBindingAttributes(frame)
                             bindType == "scroll" and (binding.key == "SCROLLUP" and "MOUSEWHEELUP" or "MOUSEWHEELDOWN") or binding.key)
                     end
                     
-                    -- Build SetBindingClick call - FRAME owns bindings, targets SELF
+                    -- Build SetBindingClick call — the HEADER (owner) owns the
+                    -- binding, the click targets the hovered frame (self at
+                    -- snippet run time). Header ownership means every clear is
+                    -- an owner-side wipe that can never hit a stale frame
+                    -- handle. The snippet runs via self:Run() in the OnEnter
+                    -- wrap, so self = the frame; owner = the header env var.
                     table.insert(snippetLines, string.format(
-                        [[self:SetBindingClick(true, %q, self, %q)]],
+                        [[owner:SetBindingClick(true, %q, self, %q)]],
                         bindKey, virtualBtn
                     ))
                 end

--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -453,29 +453,34 @@ function CC:CreateClickCastHeader()
     -- Clears bindings when there's no mouseover unit (e.g., a Blizzard panel
     -- opens over the frame, stealing focus without firing WrapScript OnLeave).
     --
-    -- Guard uses BOTH IsUnderMouse() and GetMousePosition() — only clears if
-    -- both report the cursor is off the frame. Each API has independent failure
-    -- modes (IsUnderMouse() has historically returned nil during brief flickers
-    -- when the cursor sits on a child region of a parent unit button; the bounds
-    -- check on GetMousePosition() can also stutter), and a false clear here
-    -- silently wipes keyboard click-cast bindings mid-hover. Treating either
-    -- "over frame" signal as authoritative is the safe default: an extra
-    -- OnLeave cycle will catch the real exit when the mouse genuinely moves
-    -- off the frame.
+    -- The clear is gated on the frame's rect being MEASURABLE. IsUnderMouse()
+    -- and GetMousePosition() are not independent checks: both are computed in
+    -- the restricted environment from the same scrub(GetRect)/scrub(
+    -- GetEffectiveScale) values, so when the frame's geometry is briefly
+    -- unavailable they report "cursor off the frame" TOGETHER — a false clear
+    -- that silently wipes keyboard click-cast bindings mid-hover. GetRect()
+    -- exposes the difference the other two hide: rect present + cursor outside
+    -- it = provably off the frame (safe to clear); rect unavailable = cannot
+    -- know (keep the bindings — the OnLeave/OnHide wraps or the next driver
+    -- flip handle the genuine exit).
     self.header:SetAttribute("_onstate-mouseoverstate", [[
         if newstate == "false" and mouseoverbutton then
+            local l, b, w, h = mouseoverbutton:GetRect()
+            local rectKnown = l and w and h and w > 0 and h > 0
             local underMouse = mouseoverbutton:IsUnderMouse()
             local x, y = mouseoverbutton:GetMousePosition()
             local inBounds = x and y and x >= 0 and x <= 1 and y >= 0 and y <= 1
 
-            -- Store diagnostics from both checks
+            -- Store diagnostics from all checks
             mouseoverbutton:SetAttribute("dfStateDriverCount", (mouseoverbutton:GetAttribute("dfStateDriverCount") or 0) + 1)
             mouseoverbutton:SetAttribute("dfStateDriverUnderMouse", tostring(underMouse))
+            mouseoverbutton:SetAttribute("dfStateDriverRectKnown", tostring(rectKnown))
             mouseoverbutton:SetAttribute("dfSDMouseX", x)
             mouseoverbutton:SetAttribute("dfSDMouseY", y)
 
-            -- Only clear bindings if BOTH checks agree the cursor is off the frame
-            if not underMouse and not inBounds then
+            -- Clear only when the rect is measurable and both cursor checks
+            -- agree the cursor is off the frame
+            if rectKnown and not underMouse and not inBounds then
                 mouseoverbutton:SetAttribute("dfClearedBy", "statedriver")
                 mouseoverbutton:ClearBindings()
                 mouseoverbutton:SetAttribute("dfBindingsActive", nil)
@@ -1393,6 +1398,7 @@ function CC:SetupSecureHandlers(frame)
             self:SetAttribute("dfClearedBy", nil)
             self:SetAttribute("dfStateDriverCount", nil)
             self:SetAttribute("dfStateDriverUnderMouse", nil)
+            self:SetAttribute("dfStateDriverRectKnown", nil)
             self:SetAttribute("dfSDMouseX", nil)
             self:SetAttribute("dfSDMouseY", nil)
             self:SetAttribute("dfEnterPhase", 0)
@@ -1655,12 +1661,13 @@ function CC:SetupSecureHandlers(frame)
             local clearedBy = self:GetAttribute("dfClearedBy") or "nobody"
             local stateDriverCount = self:GetAttribute("dfStateDriverCount") or 0
             local stateDriverUnderMouse = self:GetAttribute("dfStateDriverUnderMouse")
+            local stateDriverRectKnown = self:GetAttribute("dfStateDriverRectKnown")
             local sdMouseX = self:GetAttribute("dfSDMouseX")
             local sdMouseY = self:GetAttribute("dfSDMouseY")
             DF:DebugError("CLICK", "BINDINGS STILL ACTIVE after OnLeave %s! wrapLeave=%s mouseoverbutton=%s checkPassed=%s isSecureMO=%s postCheck=%s",
                 frameName, tostring(wrapLeaveFired), mouseoverOnLeave, tostring(leaveCheckPassed), tostring(isSecureMouseover), postCheck)
-            DF:DebugError("CLICK", "  clearedBy=%s stateDriverFired=%d underMouse=%s mousePos=%s,%s",
-                clearedBy, stateDriverCount, tostring(stateDriverUnderMouse), tostring(sdMouseX), tostring(sdMouseY))
+            DF:DebugError("CLICK", "  clearedBy=%s stateDriverFired=%d underMouse=%s rectKnown=%s mousePos=%s,%s",
+                clearedBy, stateDriverCount, tostring(stateDriverUnderMouse), tostring(stateDriverRectKnown), tostring(sdMouseX), tostring(sdMouseY))
         end
     end)
 

--- a/ClickCasting/Frames.lua
+++ b/ClickCasting/Frames.lua
@@ -1916,18 +1916,23 @@ function CC:RunBindingRepair(reason, force)
 
     DF:DebugWarn("CLICK", "Running binding repair (%s)", tostring(reason))
 
-    -- 1. Reset restricted-env hover tracking. A stale mouseoverbutton
-    --    reference aborts every OnEnter WrapScript at the cross-frame
-    --    cleanup step, killing keyboard binds addon-wide until /reload.
+    -- 1. Reset restricted-env hover tracking (handle + string mirror).
+    --    OnEnter no longer method-calls the shared handle, but the
+    --    mouseoverstate driver still reads geometry through it, so a stale
+    --    reference can still waste driver runs until something resets it.
     if self.header and self.header.Execute then
         pcall(function()
-            self.header:Execute([[ mouseoverbutton = nil ]])
+            self.header:Execute([[ mouseoverbutton = nil mouseovername = nil ]])
         end)
     end
 
     -- 2. Clear stray override bindings + hover state. After the env reset
     --    the OnLeave wrap can no longer clear these (mouseoverbutton ~= self),
     --    so clear them here or keys would stay stolen from the action bars.
+    --    Hover binds are owned by the HEADER now, so that is the wipe that
+    --    matters; the per-frame wipe stays to cover any legacy frame-owned
+    --    override from an older code path.
+    pcall(ClearOverrideBindings, self.header)
     local function scrub(frame)
         if frame.GetAttribute and frame:GetAttribute("dfBindingsActive") then
             pcall(ClearOverrideBindings, frame)


### PR DESCRIPTION
Structural fix for the "click-cast keyboard / MMO side-button binds suddenly stop working mid-combat until /reload" reports (bug #976 class). The 4.7.2 self-heal repairs this state after the fact; this PR removes the cause. In-game tested (party + raid, in/out of combat, hover-across-roster-changes, follower dungeon, bind changes while hovering).

## Root cause chain

Hover keyboard/scroll binds are override bindings applied on a secure OnEnter wrap and removed on leave. Two independent defects made them fragile:

**1. Cross-frame cleanup through a shared frame handle (the reload-class killer).** Each unit frame *owned* its own hover binds, so entering a frame had to clear the *previous* frame's binds by calling `ClearBindings()` through a shared restricted-env handle. If that handle went stale (frame hidden without its wraps firing), the call errored — and since the restricted environment has no error handling, it aborted **every** frame's OnEnter at that step. No frame could ever apply hover binds again until `/reload`. Left/right/middle clicks kept working because they ride frame attributes, which is exactly the asymmetry users reported.

**2. A clear-guard built on two APIs that fail together (the silent mid-hover drop).** The mouseover state driver cleared binds when both `IsUnderMouse()` and `GetMousePosition()` said the cursor was off the frame — assuming independent signals. Blizzard's restricted-environment source (`Blizzard_RestrictedAddOnEnvironment/RestrictedFrames.lua`, 12.0.7) shows both are computed from the same `scrub(GetRect)` / `scrub(GetEffectiveScale)` values: when a frame's geometry is briefly unavailable mid-combat, both report "off the frame" **simultaneously**, and the guard wiped binds while the mouse never left the frame.

## The fixes (one commit each)

**Commit 1 — rect-gated clear guard.** `GetRect()` exposes the distinction the other two APIs hide: rect present + cursor outside it = provably off the frame (clear); rect unavailable (scrubbed or anchoring-restricted, per the Blizzard source) = cannot know (keep the binds; the OnLeave/OnHide wraps or the next driver flip handle a genuine exit). Adds `rectKnown` to the state-driver diagnostics.

**Commit 2 — header-owned hover binds.** All hover binds are now owned by the click-cast header via a permanent `owner` env handle set once at header creation: snippet lines become `owner:SetBindingClick(true, key, self, virtualBtn)`, and every clear — OnEnter cross-frame cleanup, OnLeave, OnHide, state driver — is a single owner-side `ClearBindings()` that cannot dangle. The OnEnter wrap now holds a handle-safety invariant: it never calls a method on any handle except `self` (always fresh) and `owner` (lives for the session); diagnostics that read through the shared handle now use a plain-string `mouseovername` mirror. Failure mode 1 is eliminated by construction.

Dispatch is unchanged: the click still lands on the hovered frame's own virtual-button attributes using the frame's own unit — per-spec bindings, per-frame scoping (our frames vs other frames), combat conditionals, scroll, meta-mouse, and hovercast all keep their exact semantics. Wipe-then-set on every enter preserves per-frame key scoping.

**Commit 3 — insecure-side follow-through.** `ApplyBindings` full rebuilds start by wiping the header's overrides (an active bind from the outgoing set can no longer survive with its old action while hovering), and the self-heal repair wipes the header alongside its legacy per-frame scrub. The repair's env reset also clears the new string mirror.

## What remains, honestly

The `[@mouseover, exists]` flap itself is client-side and stays. Post-fix its worst case shrinks from "binds dead addon-wide until reload" to "binds inactive until the frame is re-hovered," with the 4.7.2 self-heal remaining as the outer safety net. The state driver still reads geometry through the hovered frame's handle; an abort there is now self-limiting (it can no longer poison OnEnter, whose handle-safety invariant is the load-bearing change).

## Testing

- In-game pass: party + raid hover casting with keyboard/scroll/modified binds, rapid frame sweeps, hover across combat start/end, unit removed while hovered then hover elsewhere (the old killer sequence), bind edits while hovering, key release verified off-frame, follower dungeon run (highest flap frequency).
- Offline: guard semantics cross-checked against the restricted-environment implementations in the client's 12.0.7 interface source.
