### PR TITLE
Pinned frames: fix stuck drag-handle boxes (orphaned sets now pruned by a visibility invariant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Pinned Frames) Fixed a leftover pinned-frame handle (an empty "drag to move" box, often orange) that could stay stuck on screen and survive reloads. It appeared after switching to a profile with fewer pinned sets than the previous one — the extra set's frame was left behind with no way to hide it. Pinned frames now clean up sets the active profile no longer has. (by Krathe)
+
 ### Improvements
 
 * (Click Casting) Enabling a targeting fallback (Global, Target, Self or Always Cast) on a key that already does something in WoW now asks for confirmation and names exactly what the key will stop doing — these options make the key active everywhere, not just over the frames. The fallback tooltips explain this too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* (Pinned Frames) Fixed a leftover pinned-frame handle (an empty "drag to move" box, often orange) that could stay stuck on screen and survive reloads. It appeared after switching to a profile with fewer pinned sets than the previous one — the extra set's frame was left behind with no way to hide it. Pinned frames now clean up sets the active profile no longer has. (by Krathe)
+* (Pinned Frames) Fixed a leftover pinned-frame handle (an empty "drag to move" box, often orange) that could stay stuck on screen and survive reloads. The confirmed trigger was switching to a profile with fewer pinned sets than the previous one — the extra set's frame was left behind with no way to hide it. The cleanup now enforces the full rule at every login, profile switch and party/raid change: any pinned frame that the active profile doesn't define, has disabled, or that belongs to the other mode is hidden — so a stuck box is cleaned up no matter how it got stranded. (by Krathe)
 
 ### Improvements
 

--- a/Core.lua
+++ b/Core.lua
@@ -6055,6 +6055,16 @@ function DF:FullProfileRefresh()
     
     -- === REFRESH PINNED FRAMES IF ACTIVE ===
     if DF.PinnedFrames and DF.PinnedFrames.initialized then
+        -- Reap sets the NEW profile no longer defines. Profile switching does
+        -- NOT rebuild pinned frames (this function refreshes headers in place),
+        -- so switching from a profile with more sets to one with fewer leaves
+        -- the extra containers/movers live but untracked, and every hide path
+        -- gates on the current profile's GetSetDB — so nothing removes them
+        -- (the "stuck pinned box that survives everything" reports). Prune them
+        -- before refreshing the survivors.
+        if DF.PinnedFrames.PruneOrphanedSets then
+            DF.PinnedFrames:PruneOrphanedSets()
+        end
         -- Sync each set's visibility to the NEW profile FIRST — hide sets it
         -- disables, show/create sets it enables — so a set shown under the
         -- previous profile doesn't linger in a stale state after the switch.

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -2579,48 +2579,78 @@ function PinnedFrames:Initialize()
         if set then self:SetEnabled(i, set.enabled) end
     end
 
+    -- Enforce the visibility invariant over ALL pinned frames — including
+    -- untracked strays from before this init (profile-switch orphans, frames
+    -- from a previous session's state). Runs on every init so login itself
+    -- cleans a stuck frame no matter how it was stranded.
+    self:PruneOrphanedSets()
+
     DF:Debug("PINNED", "Initialized pinned frames")
 end
 
--- Hide + untrack any pinned frame whose set no longer exists in the current
--- profile/mode. Pinned containers/movers/labels are parented to UIParent under
--- fixed global names and outlive the module's self.containers references, so a
--- set-count drop can strand them: the classic case is switching from a profile
--- with two sets to one with a single set — the index-2 frame stays live but
--- untracked, and every hide path gates on GetSetDB (now nil for that index), so
--- nothing ever hides it (the "stuck orange box" reports). This reaps both the
--- tracked leftovers and any untracked orphan, across BOTH mode suffixes and the
--- suffix-less mover/label, for every index the current profile/mode no longer
--- defines. Combat-safe (Hide + attribute-free).
+-- Enforce the pinned visibility invariant: nothing pinned may be visible unless
+-- the CURRENT profile/mode justifies it. Pinned containers/movers/labels are
+-- parented to UIParent under fixed global names and can outlive the module's
+-- self.containers references (profile switch to a fewer-set profile is the
+-- confirmed case: the extra index's frames stay live but untracked, and every
+-- hide path gates on GetSetDB — so nothing ever hides them; the "stuck orange
+-- box that survives everything" reports). Rather than only reaping known
+-- orphans, this asserts the full invariant by global name so ANY stranded or
+-- wrongly-shown frame is cleaned regardless of how it got that way:
+--   1. inactive-mode containers: never legitimate — always hidden
+--   2. set missing at an index: everything for that index hidden + untracked
+--   3. set disabled / solo-gated: container+label hidden; mover also requires
+--      the global unlock (moversShown)
+-- Runs at the end of Initialize (login + every rebuild) and on profile switch
+-- (FullProfileRefresh). Skips live-frame writes during test mode (live frames
+-- are hidden then; ExitTestMode re-asserts state on the way out). Combat-safe:
+-- only non-secure frames are touched in lockdown; the secure header's Hide()
+-- is deferred (it renders nothing without members anyway — the visible box is
+-- always the non-secure mover/container).
 function PinnedFrames:PruneOrphanedSets()
+    if self.testModeActive then return end
     local inCombat = InCombatLockdown()
+    local activeSuffix = (GetActualMode() == "raid") and "Raid" or "Party"
+
     for i = 1, PinnedFrames.MAX_SETS do
-        if not GetSetDB(i) then
-            -- The header is a SecureGroupHeaderTemplate — its Hide() is protected
-            -- in combat. It renders nothing for an orphan (no members), so the
-            -- visible box is always the non-secure mover/container; defer the
-            -- header hide to the next out-of-combat prune if we're locked.
+        -- 1) Inactive-mode containers are never legitimate (runtime frames only
+        --    exist for the active mode) — hide by name, tracked or not.
+        for _, suffix in ipairs({ "Party", "Raid" }) do
+            if suffix ~= activeSuffix then
+                local c = _G["DandersPinned" .. i .. suffix .. "Container"]
+                if c then c:Hide() end
+            end
+        end
+
+        local set = GetSetDB(i)
+        local mover = _G["DandersPinned" .. i .. "Mover"]
+        local label = _G["DandersPinned" .. i .. "Label"]
+        local activeC = _G["DandersPinned" .. i .. activeSuffix .. "Container"]
+
+        if not set then
+            -- 2) No set at this index in the current profile/mode: hide + untrack
+            --    everything. Header Hide() is combat-protected; defer if locked.
             if self.headers[i] and not inCombat then
                 self.headers[i]:Hide()
                 self.headers[i] = nil
             end
-            -- Non-secure frames (plain UIParent children) — safe to hide anytime.
             if self.containers[i] then
                 if self.containers[i].mover then self.containers[i].mover:Hide() end
                 self.containers[i]:Hide()
                 self.containers[i] = nil
             end
-            if self.labels[i] then self.labels[i]:Hide(); self.labels[i] = nil end
-
-            -- Untracked orphans by global name (mover/label have no mode suffix).
-            local mover = _G["DandersPinned" .. i .. "Mover"]
+            if self.labels[i] then self.labels[i]:Hide() end
+            self.labels[i] = nil
             if mover then mover:Hide() end
-            local label = _G["DandersPinned" .. i .. "Label"]
             if label then label:Hide() end
-            local partyC = _G["DandersPinned" .. i .. "PartyContainer"]
-            if partyC then partyC:Hide() end
-            local raidC = _G["DandersPinned" .. i .. "RaidContainer"]
-            if raidC then raidC:Hide() end
+            if activeC then activeC:Hide() end
+        else
+            -- 3) Set exists: chrome may only show when the set is effectively
+            --    visible; the mover additionally requires the global unlock.
+            local visible = set.enabled and PinnedSoloAllowed(set)
+            if mover and (not visible or not self.moversShown) then mover:Hide() end
+            if label and (not visible or not set.showLabel) then label:Hide() end
+            if activeC and not visible then activeC:Hide() end
         end
     end
 end
@@ -2685,13 +2715,7 @@ function PinnedFrames:Reinitialize()
     end
 
     self.initialized = false
-    self:Initialize()
-
-    -- Belt for stranded frames the tracked teardown above cannot reach: an
-    -- index whose set no longer exists in the current profile/mode, whose
-    -- container/mover was orphaned (e.g. by a profile switch to a
-    -- fewer-set profile) and left untracked. See PruneOrphanedSets.
-    self:PruneOrphanedSets()
+    self:Initialize()  -- ends with PruneOrphanedSets: reaps untracked strays too
 
     -- If Test Mode was active before Reinitialize (e.g. user changed
     -- frame type in the settings panel while test mode was on), re-enter

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -3126,6 +3126,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
                         local set = GetSetDB(i)
                         if set then PinnedFrames:SetEnabled(i, set.enabled) end
                     end
+                    -- And the hide side of the invariant: reap strays/disabled
+                    -- chrome on every zone-in, not just logins and mode changes.
+                    PinnedFrames:PruneOrphanedSets()
                     PinnedFrames:RequestProcessAllSets()
                 end
             end

--- a/Features/PinnedFrames.lua
+++ b/Features/PinnedFrames.lua
@@ -2582,7 +2582,49 @@ function PinnedFrames:Initialize()
     DF:Debug("PINNED", "Initialized pinned frames")
 end
 
--- Reinitialize for mode change (party <-> raid)
+-- Hide + untrack any pinned frame whose set no longer exists in the current
+-- profile/mode. Pinned containers/movers/labels are parented to UIParent under
+-- fixed global names and outlive the module's self.containers references, so a
+-- set-count drop can strand them: the classic case is switching from a profile
+-- with two sets to one with a single set — the index-2 frame stays live but
+-- untracked, and every hide path gates on GetSetDB (now nil for that index), so
+-- nothing ever hides it (the "stuck orange box" reports). This reaps both the
+-- tracked leftovers and any untracked orphan, across BOTH mode suffixes and the
+-- suffix-less mover/label, for every index the current profile/mode no longer
+-- defines. Combat-safe (Hide + attribute-free).
+function PinnedFrames:PruneOrphanedSets()
+    local inCombat = InCombatLockdown()
+    for i = 1, PinnedFrames.MAX_SETS do
+        if not GetSetDB(i) then
+            -- The header is a SecureGroupHeaderTemplate — its Hide() is protected
+            -- in combat. It renders nothing for an orphan (no members), so the
+            -- visible box is always the non-secure mover/container; defer the
+            -- header hide to the next out-of-combat prune if we're locked.
+            if self.headers[i] and not inCombat then
+                self.headers[i]:Hide()
+                self.headers[i] = nil
+            end
+            -- Non-secure frames (plain UIParent children) — safe to hide anytime.
+            if self.containers[i] then
+                if self.containers[i].mover then self.containers[i].mover:Hide() end
+                self.containers[i]:Hide()
+                self.containers[i] = nil
+            end
+            if self.labels[i] then self.labels[i]:Hide(); self.labels[i] = nil end
+
+            -- Untracked orphans by global name (mover/label have no mode suffix).
+            local mover = _G["DandersPinned" .. i .. "Mover"]
+            if mover then mover:Hide() end
+            local label = _G["DandersPinned" .. i .. "Label"]
+            if label then label:Hide() end
+            local partyC = _G["DandersPinned" .. i .. "PartyContainer"]
+            if partyC then partyC:Hide() end
+            local raidC = _G["DandersPinned" .. i .. "RaidContainer"]
+            if raidC then raidC:Hide() end
+        end
+    end
+end
+
 function PinnedFrames:Reinitialize()
     -- Cannot reinitialize during combat
     if InCombatLockdown() then
@@ -2641,9 +2683,15 @@ function PinnedFrames:Reinitialize()
         end
         self.labels[i] = nil
     end
-    
+
     self.initialized = false
     self:Initialize()
+
+    -- Belt for stranded frames the tracked teardown above cannot reach: an
+    -- index whose set no longer exists in the current profile/mode, whose
+    -- container/mover was orphaned (e.g. by a profile switch to a
+    -- fewer-set profile) and left untracked. See PruneOrphanedSets.
+    self:PruneOrphanedSets()
 
     -- If Test Mode was active before Reinitialize (e.g. user changed
     -- frame type in the settings panel while test mode was on), re-enter


### PR DESCRIPTION
Fixes the "stuck pinned-frame box" reports: an empty drag-handle box (orange in raid colours) stuck on screen that the user cannot move, hide or remove — with all pinned sets disabled — persisting across reloads.

## Confirmed root cause (from the reporter's SavedVariables)

**Profile switching never tears pinned frames down.** `SetProfile` → `FullProfileRefresh` refreshes pinned headers *in place*; nothing rebuilds or removes them. Switching from a profile with more pinned sets to one with fewer strands the extra index's frames: they are parented to UIParent under fixed global names, the module drops its references, and **every hide path gates on the current profile's `GetSetDB`** — nil for that index — so lock, disable, `Reinitialize` and the state refreshes all skip the stray forever.

The reporter's SavedVariables shows exactly this shape: five profiles with **two** pinned sets (indices 1–2), the active profile with **one** — and the stuck frame is the index-2 mover/container (fstack: created at the live `CreateSetFrames` site), i.e. born under a 2-set profile and orphaned by the switch.

## The fix: enforce the visibility rule, not just the known cause

The reporter also observed the box after a solo login, which we could not reproduce from their data — so rather than enumerating creation paths, `PinnedFrames:PruneOrphanedSets()` asserts the invariant itself, **by global name, tracked or not**:

1. **Inactive-mode containers are always hidden** — runtime frames only exist for the active mode, so a Raid container visible in party mode (the observed state) is never legitimate.
2. **No set at an index** → that index's container/mover/label hidden and untracked.
3. **Set disabled or solo-gated** → container and label hidden; the mover additionally requires the global unlock.

It runs at the end of `Initialize` (every login and rebuild), in `FullProfileRefresh` (every profile switch), after `Reinitialize` (party↔raid, solo↔group, `/dfpinned reinit` — which also heals already-affected installs), and on every `PLAYER_ENTERING_WORLD` (loading screens). Whatever strands or wrongly shows a pinned frame, the next of those events reaps it.

Safety properties: the fix is **hide-only** (zero new `Show()` calls — it can only remove chrome the config doesn't justify); it skips during test mode (live frames are hidden there; exiting re-asserts state); and it is combat-safe — only non-secure frames are touched under lockdown, with the secure header's `Hide()` deferred (a memberless header renders nothing anyway; the visible box is always the non-secure mover/container).

## Commits

1. `b95bf768` — prune orphaned sets on profile switch (the confirmed cause)
2. `ec9e00a6` — strengthen the prune into the full visibility invariant (disabled sets, inactive-mode containers, login coverage)
3. `f333a829` — enforce on zone-in as well (loading screens, not just logins/mode changes)

## Testing

- Repro: create a 2-set profile and a 1-set profile → on the 2-set profile unlock frames (movers visible) → switch to the 1-set profile. Before: the extra set's box lingers with no way to remove it. After: it disappears on the switch.
- Invariant checks: a disabled set's chrome never appears after any reload/zone-in; a manufactured stray is cleared by the next loading screen; `/dfpinned reinit` clears an existing stuck box (gives affected users a fix without waiting for a relog).
- Verified hide-only by diff audit; the show paths are untouched.
