### PR TITLE
Click casting: don't switch to spec 1's profile when spec data isn't ready (first-arena-of-the-day binds dead)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (Click Casting) **Fixed all binds being dead in the first arena/dungeon of a fresh session until a reload.** At the first login of a session, the per-spec profile auto-switch could run before the game had your specialization ready — and instead of waiting, it fell back to spec 1 and switched your click-casting to the wrong spec's profile for the rest of the session. The check now recognises when spec data isn't ready yet and re-runs automatically as soon as it arrives (and again at loading screens and arena preparation as a safety net); it is also deferred instead of skipped when it lands during combat. (by Krathe)
+
 ### Improvements
 
 * (Click Casting) Enabling a targeting fallback (Global, Target, Self or Always Cast) on a key that already does something in WoW now asks for confirmation and names exactly what the key will stop doing — these options make the key active everywhere, not just over the frames. The fallback tooltips explain this too.

--- a/ClickCasting/Bindings.lua
+++ b/ClickCasting/Bindings.lua
@@ -2408,13 +2408,55 @@ end
 
 -- Process all bindings and build unified macro map
 -- Returns: { [keyString] = { macroText = "...", templateBinding = binding } }
+-- Re-resolve click-casting state once cold-start data becomes available. Two
+-- things can be built before GetSpecialization() resolves at the first login
+-- of a session, and both used to stay wrong all day until a /reload:
+--   * loadoutCheckUnresolved (CheckLoadoutProfileSwitch): the spec→profile
+--     auto-switch could not run (or, before the guard, ran with the `or 1`
+--     spec fallback and switched to the WRONG spec's profile) — the field
+--     report: "none of my binds work in my first arena of the day"
+--   * macroMapUnresolved (BuildUnifiedMacroMap): loadSpec-scoped bindings
+--     were dropped from the map (legacy/import-only config; belt)
+-- Debounced; each resolver clears its own flag on success and self-defers in
+-- combat (pendingLoadoutCheck / needsBindingRefresh). No-op in steady state,
+-- so the extra triggers cost nothing.
+function CC:ResolveProvisionalMap(reason)
+    if not (self.macroMapUnresolved or self.loadoutCheckUnresolved) then return end
+    if not (self.db and self.db.enabled) then return end
+    if self.provisionalResolveTimer then self.provisionalResolveTimer:Cancel() end
+    self.provisionalResolveTimer = C_Timer.NewTimer(0.5, function()
+        CC.provisionalResolveTimer = nil
+        if CC.loadoutCheckUnresolved then
+            DF:Debug("CLICK", "Re-running deferred loadout profile check (%s)", tostring(reason))
+            CC:CheckLoadoutProfileSwitch()
+        end
+        if CC.macroMapUnresolved then
+            DF:Debug("CLICK", "Rebuilding provisional binding map (%s)", tostring(reason))
+            CC:ApplyBindings()
+        end
+    end)
+end
+
 function CC:BuildUnifiedMacroMap()
     local macroMap = {}
-    
+
+    -- Cold-start guard: ShouldBindingLoad drops every loadSpec-scoped binding
+    -- while GetSpecialization() is still nil (first login of a session, before
+    -- spec data resolves). The map is built once and cached, so a map built in
+    -- that window silently loses those bindings — and an all-spec-scoped setup
+    -- comes up EMPTY, which downstream disables clicks on our frames entirely
+    -- ("none of my binds work in my first arena of the day until I reload").
+    -- Record the condition on the module; the resolve watchers (SPELLS_CHANGED /
+    -- PLAYER_SPECIALIZATION_CHANGED / arena prep) rebuild when data arrives, and
+    -- ApplyBindingsToFrameUnified refuses to wipe a frame off a suspect map.
+    local specKnown = GetSpecialization() ~= nil
+    local anySpecScoped = false
+
     -- Group all bindings by their key string
     local keyGroups = {}
     for i, binding in ipairs(self.db.bindings) do
         if binding.enabled ~= false then
+            if binding.loadSpec then anySpecScoped = true end
             local keyString = self:GetBindingKeyString(binding)
             if keyString then
                 if not keyGroups[keyString] then
@@ -2423,6 +2465,11 @@ function CC:BuildUnifiedMacroMap()
                 table.insert(keyGroups[keyString], {binding = binding, index = i})
             end
         end
+    end
+
+    self.macroMapUnresolved = (anySpecScoped and not specKnown) or nil
+    if self.macroMapUnresolved then
+        DF:DebugWarn("CLICK", "BuildUnifiedMacroMap: spec unknown with spec-scoped bindings — map is provisional")
     end
     
     -- Build macro for each key group
@@ -2529,17 +2576,16 @@ function CC:ApplyBindingsToFrameUnified(frame, skipKeyboardUpdate)
             frameName, debugstack(2, 1, 0) or "unknown")
     end
 
-    -- Clear existing bindings first
-    self:ClearBindingsFromFrame(frame)
-    
     -- Build unified macro map if not already built
     if not self.unifiedMacroMap then
         self.unifiedMacroMap = self:BuildUnifiedMacroMap()
         -- Refresh keyboard bindings on all frames since map was just built
         self:RefreshKeyboardBindings()
     end
-    
-    -- Check if this frame has ANY bindings that apply to it
+
+    -- Check if this frame has ANY bindings that apply to it — BEFORE the
+    -- destructive clear below, so a provisional (cold-start) map can bail out
+    -- without touching the frame's existing state.
     local hasAnyBindings = false
     local isDandersFrame = frame.dfIsDandersFrame == true
     local isBlizzardFrame = frame.dfIsBlizzardFrame == true
@@ -2565,6 +2611,16 @@ function CC:ApplyBindingsToFrameUnified(frame, skipKeyboardUpdate)
 
     -- If no bindings apply to this frame
     if not hasAnyBindings then
+        -- Provisional map (spec not yet resolved at build time): the emptiness
+        -- is almost certainly the cold-start drop, not the user's config. Do
+        -- NOT clear/disable anything — leave the frame exactly as it is; the
+        -- resolve watchers rebuild and re-apply once spec data arrives.
+        if self.macroMapUnresolved then
+            DF:Debug("CLICK", "ApplyBindings %s deferred — provisional map (spec unresolved)", frameName)
+            return
+        end
+        -- Genuinely no bindings for this frame: clean it up.
+        self:ClearBindingsFromFrame(frame)
         if isDandersFrame then
             -- For DandersFrames, completely disable clicks when no bindings apply
             -- Our own frames get type1/type2 set in InitializeHeaderChild as a safety net
@@ -2579,7 +2635,11 @@ function CC:ApplyBindingsToFrameUnified(frame, skipKeyboardUpdate)
         end
         return
     end
-    
+
+    -- Clear existing bindings first (moved below the applicability check so a
+    -- provisional-map bailout above never strips a frame's working state)
+    self:ClearBindingsFromFrame(frame)
+
     -- Register for clicks based on castOnDown option
     if frame.RegisterForClicks then
         local castOnDown = self.profile and self.profile.options and self.profile.options.castOnDown

--- a/ClickCasting/Events.lua
+++ b/ClickCasting/Events.lua
@@ -29,6 +29,9 @@ function CC:RegisterEvents()
     -- Nameplate events for click-casting on nameplates
     eventFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
     eventFrame:RegisterEvent("NAME_PLATE_UNIT_REMOVED")
+
+    -- Spell data arrival — resolves a provisional (cold-start) binding map
+    eventFrame:RegisterEvent("SPELLS_CHANGED")
     
     eventFrame:SetScript("OnEvent", function(_, event, ...)
         if event == "PLAYER_REGEN_ENABLED" then
@@ -39,6 +42,12 @@ function CC:RegisterEvents()
         elseif event == "PLAYER_SPECIALIZATION_CHANGED" or event == "ACTIVE_PLAYER_SPECIALIZATION_CHANGED" then
             -- Spec changed - check for profile switch
             CC:OnSpecChanged()
+            -- Cold-start resolve: a map built before GetSpecialization()
+            -- resolved dropped every spec-scoped binding — rebuild it now
+            CC:ResolveProvisionalMap("spec-resolved")
+        elseif event == "SPELLS_CHANGED" then
+            -- Spell data arrived/changed — no-op unless the map is provisional
+            CC:ResolveProvisionalMap("spells-changed")
         elseif event == "TRAIT_CONFIG_UPDATED" or event == "TRAIT_CONFIG_CREATED" or event == "ACTIVE_COMBAT_CONFIG_CHANGED" then
             -- Loadout/talent changed - check for profile switch and reapply bindings (with debounce)
             if not InCombatLockdown() then
@@ -96,6 +105,12 @@ function CC:RegisterEvents()
                 -- so a broken hover-bind state never survives a zone change
                 CC:RunBindingRepair("zone-in", true)
 
+                -- Cold-start resolve: if the login build ran before spec data
+                -- was available, the map is provisional — rebuild it on the
+                -- first loading screen so it is correct BEFORE the first
+                -- arena/dungeon of the session, not only after a /reload
+                CC:ResolveProvisionalMap("zone-in")
+
                 -- Check for loadout-based profile on initial load
                 C_Timer.After(1, function()
                     if not InCombatLockdown() then
@@ -105,6 +120,8 @@ function CC:RegisterEvents()
             end)
         elseif event == "ARENA_PREP_OPPONENT_SPECIALIZATIONS" then
             -- Arena frames should now exist
+            -- Belt: never enter an arena on a provisional (cold-start) map
+            CC:ResolveProvisionalMap("arena-prep")
             CC:OnArenaPrep()
         elseif event == "INSTANCE_ENCOUNTER_ENGAGE_UNIT" then
             -- Boss frames should now exist

--- a/ClickCasting/Profiles.lua
+++ b/ClickCasting/Profiles.lua
@@ -492,10 +492,27 @@ end
 -- Check and auto-switch profile based on current loadout
 function CC:CheckLoadoutProfileSwitch()
     if InCombatLockdown() then
-        -- Will be called again when combat ends
+        -- Defer, don't drop: entering an arena/dungeon starts combat quickly,
+        -- and silently losing the check leaves the previous spec's profile
+        -- active for the whole match. OnCombatEnd drains pendingLoadoutCheck.
+        self.pendingLoadoutCheck = true
         return
     end
-    
+
+    -- Cold-start guard: at the first login of a session this can run BEFORE
+    -- GetSpecialization() resolves. GetCurrentSpec()'s `or 1` fallback would
+    -- then MASK the missing data and switch to spec 1's profile — the wrong
+    -- profile for anyone whose actual spec is 2+ ("none of my binds work in
+    -- my first arena of the day until I reload"). Record the unresolved state
+    -- and let the resolve watchers (spec/spell events, loading screens, arena
+    -- prep) re-run this check once real data arrives.
+    if not GetSpecialization() then
+        self.loadoutCheckUnresolved = true
+        DF:Debug("CLICK", "CheckLoadoutProfileSwitch: spec data not ready — deferred to resolve watchers")
+        return
+    end
+    self.loadoutCheckUnresolved = nil
+
     local specIndex = GetCurrentSpec()
     local loadoutID = GetCurrentLoadoutConfigID()
     local assignedProfile, isSpecific = self:GetProfileForLoadout(specIndex, loadoutID)


### PR DESCRIPTION
Fixes a post-4.7.5 report: *"the first arena I load into fresh on a new day won't work. None of the binds work. I have to reload and I don't usually find out until after the arena starts."*

## Root cause

`CheckLoadoutProfileSwitch` (which auto-switches the click-casting profile for your spec/loadout) runs at `PLAYER_ENTERING_WORLD + 1s`. It reads the spec via `GetCurrentSpec()`, whose `or 1` fallback **masks unresolved spec data**:

```lua
local function GetCurrentSpec()
    return GetSpecialization() or 1
end
```

At the **first login of a session**, spec data can still be unresolved when that check fires. Instead of skipping, the fallback made it look like **spec 1** — so the addon actively switched click-casting to spec 1's profile for anyone actually playing spec 2+. That profile's bindings reference the wrong spec's spells, so every press no-ops: *none of the binds work*.

Nothing re-ran the check when spec data arrived, so it stayed wrong for the whole session. A `/reload` re-ran it with warm data (fixed), and every later check that day was warm too — which is exactly why it's *"the first arena of a new day"* and never reproduces afterwards.

Two adjacent holes made it stickier:
- the function's in-combat branch did a bare `return` — its "will be called again when combat ends" comment was wrong, nothing set `pendingLoadoutCheck`;
- the `PLAYER_ENTERING_WORLD` call site also skips under combat, so a check racing an arena load could be silently lost.

## The fix

- **`CheckLoadoutProfileSwitch`** — a nil `GetSpecialization()` now records `loadoutCheckUnresolved` and defers, so the `or 1` fallback can never pick a profile from missing data. Its in-combat path sets `pendingLoadoutCheck` (drained by the existing `OnCombatEnd`) instead of dropping the check.
- **`CC:ResolveProvisionalMap(reason)`** — debounced cold-start resolver that re-runs the deferred loadout check once data arrives. No-op unless something is actually unresolved, so steady-state cost is zero.
- **Resolve triggers** — `PLAYER_SPECIALIZATION_CHANGED` / `ACTIVE_PLAYER_SPECIALIZATION_CHANGED`, the newly-registered `SPELLS_CHANGED`, every loading screen (`PLAYER_ENTERING_WORLD`), and `ARENA_PREP_OPPONENT_SPECIALIZATIONS` — so an arena cannot begin on an unresolved profile.
- **Belt for an adjacent legacy leg** — `BuildUnifiedMacroMap` marks the map provisional when `loadSpec`-scoped bindings exist while spec is nil (`loadSpec` is legacy/import-only config; no current UI writes it), and `ApplyBindingsToFrameUnified` now runs its applicability check **before** the destructive clear and refuses to wipe or disable a frame off a provisional map. Previously an empty map took the `RegisterForClicks()` path, disabling clicks on our frames entirely.

## Testing

In-game, on the branch build:

- **Resolver fires:** with `loadoutCheckUnresolved` set synthetically, a loading screen produced `Re-running deferred loadout profile check (zone-in)` exactly once, and the correct profile was kept. No such line without the flag (steady-state no-op confirmed).
- **No false positives:** ordinary reloads produce no "spec data not ready" deferral — the guard only trips on genuinely missing data.
- **In-combat deferral:** loadout/spec change during combat no longer drops the check; it applies on leaving combat.
- **Regression sweep of the debug log:** no stuck-bind fingerprints (`PreClick … hovered=false` after leave), no `BINDINGS STILL ACTIVE`, no `MISSING TYPE`; normal hover-casting and enter/leave pairing throughout.

The true trigger needs a genuinely cold session, so final confirmation is the reporter's next fresh-day arena on this build — but the synthetic path exercises the same resolver, and the in-combat deferral reproduces one of the real broken paths on demand.

## Note for the reviewer

`binding.loadSpec` is read by `ShouldBindingLoad` but nothing in the current UI writes it — per-spec click-casting is done via loadout-assigned profiles. It's handled here defensively (imported/legacy profiles could carry it) rather than relied upon; worth a separate cleanup decision on whether to retire the field.
