### PR TITLE
Fix layout groups rendering only their first member (5.1.0 regression)

### DIFF
--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -3138,9 +3138,18 @@ local function buildMemberGroupConfig(frame, group, recs, mine, defs)
             -- Resolved per member, so a self-only aura drops the caster filter for
             -- its own record while every neighbour keeps theirs.
             filter = poolFilter(group, rm),
-            -- Keyed by the member's stable indicator id, not its ordinal: reordering
-            -- the group must move icons, not re-key every group and force a rebuild.
-            key = "m" .. tostring(r.indicatorID),
+            -- ☠ THE AURA NAME IS LOAD-BEARING, NOT DECORATION. Indicator ids are
+            -- unique only WITHIN one aura (nextIndicatorID is a per-aura counter
+            -- starting at 1), so "m1" collided for every user who placed one
+            -- indicator per spell -- and the engine ASSERTS on a duplicate group
+            -- key ("aura group 'm1' already exists", CustomAuraContainer), which
+            -- our pcall swallowed. First member rendered, the rest silently never
+            -- did. Shipped that way; two field reports on release day. It passed
+            -- in-game testing only because a dev profile's add/delete history
+            -- happens to produce distinct ids.
+            -- Still keyed by identity rather than ordinal: reordering the group
+            -- must move icons, not re-key every group and force a rebuild.
+            key = "m:" .. tostring(r.auraName) .. ":" .. tostring(r.indicatorID),
             candidateFilters = { includeSpellIDs = r.map },
             style = {
                 button      = buildPlacedStyle(r.indicator, r.isSquare, r.borderSpec, defs),
@@ -4269,6 +4278,7 @@ local function collectGroupMembers(frame, group, auras, idSpec, defs, mine)
                 recs = recs or {}
                 recs[#recs + 1] = {
                     indicatorID = m.indicatorID,
+                    auraName    = m.auraName,
                     indicator   = ind,
                     map         = map,
                     -- ☠ PER MEMBER, not per group. Symbiotic Relationship's copy on


### PR DESCRIPTION
Hotfix for a regression in the layout-group work that shipped in 5.1.0. Two field
reports within hours of release: **a layout group renders only its first member on
live frames, while the editor shows all of them.**

- seven-beacon Holy Paladin group → only Beacon of Light drew
- four-member Preservation "Hots" group → one drew

## Cause

`buildMemberGroupConfig` keyed each member's aura group by its indicator id alone.
Indicator ids are unique only **within one aura** — `nextIndicatorID` is a per-aura
counter starting at 1 — so a user who places one indicator per spell, which is the
ordinary way to build a group, has id 1 on every member and every member group was
keyed `"m1"`.

`CustomAuraContainerSharedMixin:AddAuraGroup` asserts on a duplicate key:

```
assertf(not self:HasAuraGroup(groupKey), "aura group '%s' already exists with this key.", ...)
```

The `pcall` around our call swallowed that assert into a `DebugWarn`, so every member
after the first was silently never declared. The editor preview was unaffected because
the canvas never reaches the engine — which is exactly why both reports say "it's there
in the designer, gone from my frames".

## Fix

The key now carries the aura name, which is the storage key and unique per member:
`"m:<auraName>:<indicatorID>"`. Two different spells differ in the name half; two
indicators on the same spell differ in the number half.

Still identity-based rather than positional, so reordering a group still moves icons
rather than re-keying every group and forcing a rebuild.

**No data change and no migration.** Indicator ids are untouched — duplicate ids were
never the problem, using one alone as a unique name was. Affected groups start working
on reload; nothing needs rebuilding, and nobody's saved setup was corrupted.

## Why it got through

A dev profile's add/delete history produces distinct indicator ids, so the failing
shape never occurs on one — it belongs to users who place one indicator per spell and
had no reason to ever hit it. Test mode cannot reproduce it either, since the preview
path never calls `AddAuraGroup`. The review round verified the compaction logic, which
is correct; the defect is in what an indicator id means outside its own aura.

## Verification

Static plus an offline check of the key construction: the seven-member collision case
yields seven unique keys under the new scheme and collided on six under the old.
⚠ **Not yet confirmed in game** — the maintainer's own profile cannot reproduce the
original bug for the reason above, so confirmation is coming from the reporters.

No changelog entry included, per the house rule that one is written only after an
in-game confirmation. Suggested wording when it lands:

> * (Aura Designer) Fix a layout group showing only its first icon on your frames while
>   the editor showed them all. Groups built from spells that each had a single
>   indicator were affected; nothing needs re-adding, they work again on reload.
