### PR TITLE
Cinematic filter recovery, self-contained test mode, and absorb-over-dispel layering

### DIFF
--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -521,6 +521,7 @@ DF.DEBUG_GROUP_NAMES = {
 DF.DEBUG_GROUP_OF = {
     auras = "auras", auradata = "auras", dispel = "auras", auraexp = "auras",
     duration = "auras", idgate = "auras", ppdump = "auras", ppbadge = "auras",
+    ownpreview = "auras",
     admissing = "auras", cbt = "auras",
 
     headers = "frames", flatraid = "frames", secure = "frames", sort = "frames",
@@ -5768,6 +5769,7 @@ DF._MainEventDispatcher = function(self, event, arg1)
         -- Not logging, despite the old wording: it window-parks the badge so the
         -- anchor stays live and the badge shows even when the buff is present.
         sub("ppbadge",      "force the missing-buff badge to stay visible (geometry probe)", true)
+        sub("ownpreview",   "A/B test mode: our own frames (default) vs the global sample provider", true)
         sub("admissing",    "Aura Designer missing-buff trace (add 'mark')", true, "[mark]")
         sub("cbt",          "colour-by-time curve dump", true, "<spellID>")
         -- Data integrity. Both dev-gated for the same reason as /df debug duration: they
@@ -6449,6 +6451,11 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 -- Pixel-perfect geometry ground truth for aura containers (physical-px
                 -- rects + grid deviation per anchor-chain element)
                 if DF.AuraContainer and DF.AuraContainer.DebugDumpPP then DF.AuraContainer.DebugDumpPP() end
+            elseif msg == "ownpreview" then
+                -- A/B the test-mode route: our own pooled frames (default) versus the
+                -- engine's per-slot groups fed by the GLOBAL sample provider, which
+                -- also fills every other addon's aura containers.
+                if DF.AuraContainer and DF.AuraContainer.ToggleOwnPreview then DF.AuraContainer.ToggleOwnPreview() end
             elseif msg == "ppbadge" then
                 -- Diagnostic: window-park missing badges (bypasses the container's secret
                 -- self-size) — proves/disproves the last missing-badge pp drift source

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -1901,7 +1901,14 @@ function DF:LightweightUpdateFrameLevel(elementType)
         local frameBaseLevel = frame:GetFrameLevel()
         
         if elementType == "absorb" and frame.dfAbsorbBar then
-            frame.dfAbsorbBar:SetFrameLevel(frame:GetFrameLevel() + (db.absorbBarFrameLevel or 11))
+            -- ☠ MODE-AWARE. This applied absorbBarFrameLevel unconditionally, but that
+            -- slider is FLOATING-only by design -- so it dragged a BOUND absorb bar down
+            -- to frame+11, under the dispel overlay's gradient, where it stayed (
+            -- UpdateAbsorb's fast path returns before its own level block). One shared
+            -- derivation now; see DF:ResolveAbsorbBarLevel for the whole story.
+            local lvl = DF.ResolveAbsorbBarLevel and DF:ResolveAbsorbBarLevel(frame, db)
+            frame.dfAbsorbBar:SetFrameLevel(lvl
+                or (frame:GetFrameLevel() + (db.absorbBarFrameLevel or 11)))
         elseif elementType == "role" and frame.roleIcon then
             frame.roleIcon:SetFrameLevel(frameBaseLevel + (db.roleIconFrameLevel or 30))
         elseif elementType == "leader" and frame.leaderIcon then

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -86,6 +86,12 @@ AuraContainer.stats = AuraContainer.stats or { builds = 0, teardowns = 0, defers
 
 local DBG = "AURACONTAINER"
 
+-- ★ OWN-FRAME TEST PREVIEW, default ON. Test mode paints our own pooled frames
+-- rather than declaring AuraGroups fed by the GLOBAL sample provider — see
+-- Handle:_buildOwnPreview for why the engine route cannot be scoped to us.
+-- Runtime A/B: /df debug ownpreview (AuraContainer.ToggleOwnPreview).
+AuraContainer._ownTestPreview = true
+
 -- One-time-per-process warning latches so a guarded failure (curve bug, border
 -- taint, native dispel reject) logs ONCE, not once per button.
 local warnedCurve, warnedBorder, warnedNativeDispel = false, false, false
@@ -516,11 +522,21 @@ function AuraContainer.SetTestMode(on)
     if on then
         AuraContainer._ownsProviderSwitch = true
         rebuildAll()
-        AuraContainer._queueTestBounce()
+        -- ★ Own-frame preview never switches the global provider (see
+        -- Handle:_buildOwnPreview), so there is nothing to bounce and no other
+        -- addon's containers are touched. The builds above painted themselves.
+        if not AuraContainer._ownTestPreview then
+            AuraContainer._queueTestBounce()
+        end
         -- No ticker start here: countdowns arm natively per slot (armTestDuration),
         -- and only a slot that FAILS to arm starts the fallback ticker.
     else
         AuraContainer._stopTestTicker()
+        -- ☠ The reset runs REGARDLESS of the current toggle state. Own-preview may
+        -- have been switched on mid-session while the engine route already held the
+        -- provider, and leaving it on the sample source strands every container in
+        -- the client on fake auras. _ownsProviderSwitch records that we took it;
+        -- resetting when we did not is harmless (it is the real provider either way).
         pcall(function()
             if C_UnitAuras.ResetAuraDataProvider then C_UnitAuras.ResetAuraDataProvider()
             else C_UnitAuras.SwitchAuraDataProvider(true) end
@@ -2477,7 +2493,14 @@ function NativeBackend:build()
     self.slotButtons = (isOverlay or isSingleSlot) and {} or nil
     handle._idGateVulnerable = nil   -- re-derived from this build's records (see the record loop)
     handle._idGateSourceRelative = nil   -- PLAYER-token / isFromPlayerOrPlayerPet pools (visibility gate)
-    if testMode and not isOverlay and not isMissing then
+    -- ★ OWN-FRAME PREVIEW (see Handle:_buildOwnPreview). When on, test mode declares
+    -- NOTHING to the engine and paints our own frames instead, so the global sample
+    -- provider is never switched and no other addon's containers are disturbed.
+    -- The per-slot-group shape below is the engine route, kept behind the toggle so
+    -- the two can be compared side by side in game (/df debug ownpreview).
+    if testMode and AuraContainer._ownTestPreview and not isOverlay and not isMissing then
+        filters = {}   -- declare nothing; the loop below is skipped
+    elseif testMode and not isOverlay and not isMissing then
         -- PER-SLOT TEST GROUPS (P5). Two hard-won facts drive this shape:
         --  * The flow lays buttons out by the container's own aura ordering, NOT
         --    by button creation order — indexing the curated paint/hover zones by
@@ -2685,7 +2708,23 @@ function NativeBackend:build()
 
     -- TEST MODE: every native build while the sample provider should be active
     -- queues the coalesced bounce — this container was born deaf to the switch.
-    if testMode then AuraContainer._queueTestBounce() end
+    -- ★ Own-frame preview needs neither: it declares nothing to the engine, so there
+    -- is no container to feed and no reason to touch the global provider.
+    -- ☠ THE GUARD IS ON THE BOUNCE, NOT ON THE ROW SHAPE. First cut wrote this as
+    -- "own-preview AND a row" / "elseif testMode", which still bounced for OVERLAY
+    -- and MISSING containers -- and one bounce is a GLOBAL switch, so a single dispel
+    -- overlay building during test mode re-filled every other addon's containers and
+    -- the leak looked untouched. Neither of those two needs the sample source anyway:
+    -- MISSING deliberately stays disabled for the whole test session so its groups
+    -- never fill, and the dispel overlay takes its preview type from our own pool
+    -- (DF:GetTestDebuffDispelType), not from engine auras.
+    if testMode and AuraContainer._ownTestPreview then
+        if not isOverlay and not isMissing then
+            handle:_buildOwnPreview()
+        end
+    elseif testMode then
+        AuraContainer._queueTestBounce()
+    end
 
     -- MISSING mode: arm the push geometry — hook the badge onto the live container's
     -- TOPLEFT (+pad puts it exactly on the window while the group is empty) and show it.
@@ -3708,6 +3747,188 @@ function Handle:_paintTestSlot(slot, index)
     end
 end
 
+-- ============================================================
+-- OWN-FRAME PREVIEW — test mode without the global sample provider
+-- ============================================================
+-- ☠ WHY THIS EXISTS. The engine has no per-container sample source: the only lever
+-- is C_UnitAuras.SwitchAuraDataProvider, which fires the client-wide
+-- AURA_DATA_PROVIDER_SWITCH that EVERY aura container registers for intrinsically
+-- (Blizzard_AuraContainer.lua). Flipping it for our preview therefore fills every
+-- OTHER addon's containers with sample icons too — nameplates, unit frames, the lot.
+-- The per-container flag exists (useEditModeSource) but its setter is on the private
+-- mixin, and none of the 19 public container methods touches the data source, so it
+-- can be neither set for us nor suppressed for anyone else.
+--
+-- ★ AND THE ENGINE'S SAMPLE DATA WAS NEVER THE POINT. Its auras carry no spell IDs,
+-- durations or raid flags (see the per-slot-group header), so every icon, name,
+-- count and timer in the preview was ALREADY painted by _paintTestSlot from our own
+-- TestData. The switch bought exactly one thing: presence — engine-created buttons
+-- to paint onto. Supplying those ourselves costs nothing and drops the global blast
+-- radius entirely.
+--
+-- ★ THE SEAMS ARE ALL PRE-EXISTING, which is what keeps this honest:
+--   * _acceptSlot   — registers into self.buttons and runs the SAME styleButton_regions
+--                     the engine path runs, so styling cannot diverge.
+--   * _paintTestSlot— the SAME painter, untouched. The AD editor canvas has painted
+--                     plain CreateFrame("Frame") slots this way since it shipped.
+--   * layoutRow     — the SAME positioner live uses off config.layout, including the
+--                     pixel-perfect snap. No second layout implementation exists to
+--                     drift, which is the failure mode this whole design is avoiding.
+-- Everything downstream (ApplyStyle, the test ticker, teardown) already iterates
+-- self.buttons and does not care where a button came from.
+--
+-- ⚠ Frames are pooled per handle and REUSED across rebuilds — creating fresh ones per
+-- rebuild is what made the engine route allocate ~530 MB over four test toggles.
+-- ☠ PLACEMENT MUST COME FROM THE ENGINE'S FLOW, NOT layoutRow.
+-- First cut positioned the preview with layoutRow and the commit claimed that was
+-- "the same positioner live uses". It is not: NATIVE rows are placed by the
+-- container's own AnchorUtil flow (see applyContainerLayout), and layoutRow is the
+-- legacy fallback's maths. Two implementations off one config is exactly the
+-- preview/live divergence this whole design exists to avoid, and it would have
+-- shown up first on the awkward cases (CENTER growth, wrapping, UP/LEFT growth,
+-- the duration-strip reservation that shifts row stride).
+--
+-- So the preview drives AnchorUtil.CreateFlowLayout() -- the SAME public flow the
+-- container uses -- configured from the SAME resolveGrowthLayout / buildGroupLayout
+-- / stripReservation derivations applyContainerLayout feeds it. The box frame stands
+-- in for the container: pinned with the identical pin point, offsets, pp snap and
+-- scale, so the flow lays out in the same space.
+--
+-- Returns false on any doubt (no AnchorUtil, an enum that will not resolve, Apply
+-- throwing) and the caller falls back to layoutRow — a slightly-off preview beats no
+-- preview, and this must never be the thing that breaks test mode.
+function Handle:_flowPreviewLayout(slots, count)
+    local AU = AnchorUtil
+    if not (AU and AU.CreateFlowLayout and AU.FlowDirection) then return false end
+    local box = self._ownPreviewBox
+    if not box then return false end
+
+    local config = self.config
+    local L = config.layout or {}
+    local G = resolveGrowthLayout(L)
+    local scale = tonumber(L.scale) or 1
+    local wrap = tonumber(L.wrap) or 0
+
+    -- Strip reservation -> flow padding. Same exclusive branch as applyContainerLayout.
+    local resv, topStrip = stripReservation(config)
+    if resv > 0 and self._pp then resv = ppSnapScaled(resv, scale) end
+    local padTop, padBottom = 0, 0
+    if resv > 0 then
+        if G.vName == "Up" then
+            if not topStrip then padBottom = resv end
+        elseif topStrip then
+            padTop = resv
+        end
+    end
+
+    -- Pin the box exactly where the container pins itself.
+    local px = (L.offsetX or 0) + G.pinX
+    local py = (L.offsetY or 0) + G.pinY
+    if self._pp then
+        px, py = snapPinOffsets(self.frame, G.anchor, px, py, scale)
+    end
+    local okPin = pcall(function()
+        box:SetScale(scale)
+        box:ClearAllPoints()
+        box:SetPoint(G.pinPoint, self.frame, G.anchor, px, py)
+    end)
+    if not okPin then return false end
+
+    -- Row cap, including the half-icon headroom that stops the flow wrapping one
+    -- icon early on the measured button width (see applyContainerLayout).
+    local headroom = G.sx * 0.5
+    local rowWidth
+    if G.verticalPrimary then
+        rowWidth = G.sx + headroom
+    elseif wrap >= 1 then
+        rowWidth = wrap * G.sx + (wrap - 1) * G.spX + headroom
+    end
+
+    local h = resolveEnum(AU.FlowDirection, G.hName)
+    local v = resolveEnum(AU.FlowDirection, G.vName)
+    if h == nil or v == nil then return false end
+
+    local gl = buildGroupLayout(config)
+    local elements = {}
+    for i = 1, count do elements[i] = slots[i] end
+
+    return pcall(function()
+        local layout = AU.CreateFlowLayout()
+        -- Mirror CustomAuraContainerFlowLayoutMixin: the GROUP's declared cell wins
+        -- over the measured button, which is what folds the strip reservation into
+        -- the row stride.
+        layout.GetElementSize = function(_, _, element, group)
+            local w, hgt = element:GetSize()
+            return group.elementWidth or w, group.elementHeight or hgt
+        end
+        layout:SetAnchorPoint(G.flowAnchor)
+        layout:SetGrowthDirection(h, v)
+        layout:SetMaximumLineSize(rowWidth or math.huge)
+        layout:SetPadding(0, 0, padTop, padBottom)
+        layout:Apply(box, { {
+            elements       = elements,
+            elementSpacing = gl.elementSpacing,
+            lineSpacing    = gl.lineSpacing,
+            elementWidth   = gl.elementWidth,
+            elementHeight  = gl.elementHeight,
+        } })
+    end)
+end
+
+function Handle:_buildOwnPreview()
+    local config = self.config
+    local pool = testPoolFor(config)
+    local want = testSlotCount(config, pool)
+    self._ownPreviewSlots = self._ownPreviewSlots or {}
+    local slots = self._ownPreviewSlots
+
+    -- The box stands in for the container: the flow lays out INSIDE it and sizes it
+    -- on completion, and it carries the layout scale, so slots parent to it rather
+    -- than to the frame (parenting to the frame would leave the scale unapplied).
+    local box = self._ownPreviewBox
+    if not box then
+        box = CreateFrame("Frame", nil, self.frame)
+        self._ownPreviewBox = box
+    end
+    pcall(function()
+        box:SetFrameStrata(self.frame:GetFrameStrata())
+        box:SetFrameLevel(self.frame:GetFrameLevel() + 5)
+    end)
+    box:Show()
+
+    for i = 1, want do
+        local slot = slots[i]
+        if not slot then
+            slot = CreateFrame("Frame", nil, box)
+            slots[i] = slot
+        end
+        slot:Show()
+        -- Same styling seam as a native button. _acceptSlot fills self.buttons[i],
+        -- so ApplyStyle / teardown pick these up unchanged.
+        self:_acceptSlot(slot, i)
+        self:_paintTestSlot(slot, i)
+    end
+
+    -- A shorter preview than last time (pool cap, Max Icons dropped): park the
+    -- surplus and drop it from self.buttons so no cell is reserved for a frame
+    -- nobody can see.
+    for i = want + 1, #slots do
+        slots[i]:Hide()
+        self.buttons[i] = nil
+    end
+
+    if want > 0 then
+        if not self:_flowPreviewLayout(slots, want) then
+            -- Fallback only: positions from DF's own maths rather than the engine
+            -- flow, so it can differ from live on the awkward growth cases.
+            DF:DebugWarn(DBG, "own preview: flow layout unavailable, falling back to layoutRow")
+            layoutRow(self)
+        end
+    elseif box then
+        box:Hide()
+    end
+end
+
 -- Shared ticker driving the preview countdowns (test mode only; started and
 -- stopped by SetTestMode). Loops each timer + swipe at zero and drains the
 -- duration bar in step so the preview animates indefinitely. Buttons die with
@@ -4682,6 +4903,19 @@ function Handle:_teardownContainer(park)
         wipe(self.buttons)
         self._slotCounter = 0   -- restart the lazy-batch index for the next build
     end
+    -- Own-frame preview slots are OURS, not the container's, so nothing above
+    -- reaches them: the wipe drops self.buttons' references but the frames stay
+    -- parented and visible. Park them here. Kept for reuse rather than destroyed —
+    -- they are pooled per handle precisely so a rebuild does not re-allocate.
+    if self._ownPreviewSlots then
+        for _, slot in pairs(self._ownPreviewSlots) do
+            if slot then
+                if DF.Border and slot.dfBorder then DF.Border:StopAnimation(slot.dfBorder) end
+                slot:Hide()
+            end
+        end
+    end
+    if self._ownPreviewBox then self._ownPreviewBox:Hide() end
     -- Test-mode hover tips are handle-owned (anchored over the dying buttons):
     -- hide the lot; a test build re-anchors/re-shows the ones it needs.
     if self._testTips then
@@ -6548,6 +6782,28 @@ end
 -- off-grid source. Rebuilds every missing handle on toggle. NOT a fix: the
 -- layout-push can't hide a window-anchored badge, so present buffs still show
 -- their badge while this is on.
+-- ★ OWN-FRAME PREVIEW toggle (/df debug ownpreview) — the A/B for the new test-mode
+-- route. ON (the default): test mode paints our own pooled frames and never touches
+-- C_UnitAuras.SwitchAuraDataProvider, so no other addon's containers are disturbed.
+-- OFF: the previous engine route, per-slot AuraGroups fed by the global sample
+-- provider, kept so the two can be compared side by side on the same settings.
+-- Flip it with test mode ON: every test container rebuilds on the spot.
+function AuraContainer.ToggleOwnPreview()
+    AuraContainer._ownTestPreview = not AuraContainer._ownTestPreview or nil
+    local n = 0
+    for h in pairs(AuraContainer._handles or {}) do
+        if h.builtInTestMode or AuraContainer._testMode then
+            n = n + 1
+            pcall(function() h:_rebuild() end)
+        end
+    end
+    DF:Say(("Own-frame preview %s — %d test container(s) rebuilt. %s"):format(
+        AuraContainer._ownTestPreview and "ON" or "OFF", n,
+        AuraContainer._ownTestPreview
+            and "Our own frames; the global sample provider is never switched."
+            or "Engine route: per-slot groups + the GLOBAL provider switch (other addons will show sample icons)."))
+end
+
 function AuraContainer.ToggleBadgeParkDebug()
     AuraContainer._badgeParkDebug = not AuraContainer._badgeParkDebug or nil
     local n = 0

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -4220,6 +4220,7 @@ function Handle:_applyVisibility()
     -- shows and hides the whole subtree, which is the entire reason for nesting.
     if self.config and self.config.parentDrivenVisibility then return end
     local want = (self._intendedShown ~= false) and not self._idGateHidden
+        and not self._cineLatched
     -- Respect the fake-data park (Edit Mode etc.): while parked, this handle is
     -- hidden regardless of intent/gate — otherwise a hover-deferred retry could
     -- ping-pong against the park's own deferred hide.
@@ -4289,6 +4290,18 @@ end
 -- still fires, which is the first-login case.
 -- Re-entrancy: the flag is stored BEFORE Refresh(), so a re-entrant gate pass sees
 -- true and cannot bounce again.
+-- CINEMATIC LATCH (see the cineWatch block at the bottom of the file). While set,
+-- the handle stays hidden through _applyVisibility's existing composition -- the
+-- same combat-safe render-side lever the identity gate uses. The latch exists so
+-- the fail-open parse a cinematic leaves behind is never SEEN: the frames come
+-- back only after the recovery re-parse below has run.
+function Handle:_setCineLatch(on)
+    on = on or nil
+    if self._cineLatched == on then return end
+    self._cineLatched = on
+    self:_applyVisibility()
+end
+
 function Handle:_noteGateRecovery(can)
     local was = self._idGateAssist
     self._idGateAssist = can and true or false
@@ -4296,6 +4309,9 @@ function Handle:_noteGateRecovery(can)
         DF:Debug("AURACONTAINER", "gate recovered for unit=%s - re-parsing (pool was fail-open)",
             tostring(self.config and self.config.unit))
         self:Refresh()
+        -- AFTER the bounce, deliberately: the whole point of the cinematic latch
+        -- is that the frames reappear already re-parsed, not one frame before.
+        self:_setCineLatch(nil)
     end
 end
 
@@ -5782,7 +5798,7 @@ end
 function SlotHandle:_pushFilter()
     local c = self.owner and self.owner.container
     if not c then return false end
-    local want = (self.parked or self._gateHidden) and "" or self.liveFilter
+    local want = (self.parked or self._gateHidden or self._cineLatched) and "" or self.liveFilter
     return pcall(c.SetAuraSlotFilterString, c, self.key, want)
 end
 
@@ -5850,22 +5866,47 @@ end
 --
 -- For a slot the gate DID hide, the transition below already re-pushes the string, so
 -- this edge is what covers the case the gate never hides at all: your own frame.
+-- CINEMATIC LATCH, slot half (see cineWatch at the bottom of the file). A slot has
+-- no frame of its own, so the latch actuates the way the slot gate does: through
+-- _pushFilter, where an empty string matches nothing (proven in game). Same failure
+-- contract as Park/Restore -- a refused CLEAR would otherwise leave the slot dark
+-- forever, so failure or lockdown queues the regen replay, which re-derives from
+-- whatever the latch state is by drain time.
+function SlotHandle:_setCineLatch(on)
+    on = on or nil
+    if self._cineLatched == on then return end
+    self._cineLatched = on
+    local ok = self:_pushFilter()
+    if not ok or InCombatLockdown() then
+        self._pendingTuning = true
+        registerSlotRegen(self)
+    end
+end
+
 function SlotHandle:_noteGateRecovery(can)
     local was = self._idGateAssist
     self._idGateAssist = can and true or false
-    if was ~= false or not self._idGateAssist then return end
+    if was ~= false or not self._idGateAssist then
+        return
+    end
     local c = self.owner and self.owner.container
     if not c or self._lastCandidateFilters == nil then return end
     DF:Debug(DBG, "slot gate recovered for key=%s unit=%s - re-parsing (pool was fail-open)",
         tostring(self.key), tostring(self.owner and self.owner.unit))
     -- ☠ No native tuning setter runs in lockdown (see ApplyTuning). Queue the standard
     -- replay, which re-pushes candidates, verdict and filter together on the way out.
+    -- The latch flag clears NOW in both branches -- the replay's _pushFilter derives
+    -- from the flag at drain time, so leaving it set would re-park the slot the
+    -- moment combat dropped.
     if InCombatLockdown() then
+        self._cineLatched = nil
         self._pendingTuning = true
         registerSlotRegen(self)
         return
     end
     pcall(c.SetAuraSlotCandidateFilters, c, self.key, self._lastCandidateFilters)
+    -- After the bounce, matching the Handle: the slot un-parks already re-parsed.
+    self:_setCineLatch(nil)
 end
 
 function SlotHandle:_applyIdentityGate()
@@ -6339,6 +6380,97 @@ idGateWatch:SetScript("OnEvent", function(_, event)
         C_Timer.After(2, IdentityGateSweep)
         C_Timer.After(6, IdentityGateSweep)
     end
+end)
+
+-- ============================================================
+-- CINEMATIC LATCH — no flash of the fail-open parse
+-- ============================================================
+-- A cinematic flips UNIT_FACTION, the identity gate fails open, and the engine
+-- keeps rendering that unfiltered parse until the recovery bounce re-parses it
+-- (see Handle:_noteGateRecovery). The bounce is event-driven, so there was a
+-- visible half-second of every-buff icons between the UI coming back and
+-- UNIT_FACTION reaching us. The delay is upstream — Blizzard's own event timing
+-- plus one parse tick; other addons report the identical residue — so the only
+-- lever left is not SHOWING the frames until the re-parse has happened.
+--
+-- Shape: START latches every vulnerable handle/slot hidden (both events are
+-- SynchronousEvent, so the latch lands before the first cinematic frame — and the
+-- UI is hidden during playback anyway, so latching costs nothing visible). The
+-- recovery edge clears each latch AFTER its bounce, so frames reappear already
+-- re-parsed. STOP runs the gate sweep immediately (catching an assist restore
+-- that raced ahead of our 50ms coalesce), then clears any handle whose assist
+-- never dropped — its parse was never fail-open, nothing to wait for.
+--
+-- ☠ The fallback timer is NOT optional. Fail-safe direction here is SHOW (a
+-- wrongly-hidden row is worse than one garbage frame — the gate's own rule), so
+-- whatever is still latched 3s after STOP shows regardless, which degrades to
+-- exactly the pre-latch behaviour and never below it. This is also what bounds
+-- the mid-combat case, where the slot pushes defer to the regen replay.
+--
+-- ⚠ Accepted gap: a handle CREATED during a cinematic misses the START arm and
+-- can still flash. Rebuilding mid-cinematic is rare enough that wiring
+-- InCinematic() into the build path is not worth the coupling.
+local cineWatch = CreateFrame("Frame")
+cineWatch:RegisterEvent("CINEMATIC_START")
+cineWatch:RegisterEvent("CINEMATIC_STOP")
+cineWatch:RegisterEvent("PLAY_MOVIE")
+cineWatch:RegisterEvent("STOP_MOVIE")
+local cineGen = 0
+local function CineLatchAll(on)
+    for h in pairs(AuraContainer._handles or {}) do
+        if not on then
+            pcall(function() h:_setCineLatch(nil) end)
+        elseif h._idGateVulnerable then
+            pcall(function() h:_setCineLatch(true) end)
+        end
+    end
+    -- ⚠ Slots live in their own registry — the gate sweep above records why
+    -- forgetting them is how the AD path once had no gate at all.
+    for h in pairs(AuraContainer._slotHandles or {}) do
+        if not on then
+            pcall(function() h:_setCineLatch(nil) end)
+        elseif h._idGateVulnerable then
+            pcall(function() h:_setCineLatch(true) end)
+        end
+    end
+end
+cineWatch:SetScript("OnEvent", function(_, event)
+    cineGen = cineGen + 1
+    if event == "CINEMATIC_START" or event == "PLAY_MOVIE" then
+        -- Test mode shows fake data — nothing to protect, don't touch it.
+        -- ☠ The guard sits HERE and not on the whole handler: STOP must always
+        -- run, because test mode entered mid-cinematic would otherwise skip both
+        -- the clear and the fallback timer while the gate guard suppresses the
+        -- recovery edge — a latch stuck until reload.
+        if AuraContainer._testMode then return end
+        DF:Debug(DBG, "cinematic start (%s): latching vulnerable pools", event)
+        CineLatchAll(true)
+        return
+    end
+    -- STOP: fire any pending recovery NOW rather than waiting out the coalesce —
+    -- if the engine restored assist before this event, the sweep bounces and
+    -- clears those latches in one pass.
+    IdentityGateSweep()
+    -- A handle whose assist never dropped was never fail-open; show it.
+    for h in pairs(AuraContainer._handles or {}) do
+        if h._cineLatched and h._idGateAssist ~= false then
+            pcall(function() h:_setCineLatch(nil) end)
+        end
+    end
+    for h in pairs(AuraContainer._slotHandles or {}) do
+        if h._cineLatched and h._idGateAssist ~= false then
+            pcall(function() h:_setCineLatch(nil) end)
+        end
+    end
+    -- Whatever is still latched is waiting on a restore that has not reached us.
+    -- Hold — that is the whole point — but never past the fail-safe window.
+    local gen = cineGen
+    C_Timer.After(3, function()
+        if gen == cineGen then
+            DF:Debug(DBG, "cinematic latch fallback: showing whatever is still held")
+            CineLatchAll(false)
+        end
+    end)
 end)
 
 -- /df debug idgate — identity-gate ground truth: EVERY handle (not just the

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -454,6 +454,39 @@ function DF:GetAbsorbEdgeInset(frame, db)
     return inset
 end
 
+-- ☠ THE ONE DERIVATION OF THE ABSORB BAR'S FRAME LEVEL. Two paths set it and they
+-- disagreed: this file's layout pass (mode-aware) and the Frame Level slider's live
+-- preview in Core.lua, which applied absorbBarFrameLevel UNCONDITIONALLY -- even
+-- though that slider is FLOATING-only by design (Pages/Auras.lua, levelSlider.hideOn).
+-- A bound bar therefore landed at frame+11, BELOW the dispel overlay's gradient at
+-- ~frame+17, and UpdateAbsorb's fast path returns before the level block, so the wrong
+-- value stuck for the rest of the session.
+--
+-- Field-reported (Kaldoran, 5.1.0): with a shield up and a dispellable debuff applied,
+-- the absorb vanished behind the dispel wash. ★ It only became visible when the
+-- day-one fix made "Show On Current Health Only" clip correctly to the FILLED health
+-- -- which is exactly where a bound absorb lives. The layering conflict predates that
+-- fix; the fix is what gave it something to collide with.
+--
+-- A bound absorb MUST sit above the wash: the wash covers the filled health, so an
+-- absorb underneath it is invisible for as long as any dispellable debuff is up --
+-- i.e. the shield is hidden precisely when the frame matters most (Krathe's call).
+-- FLOATING is a free-standing bar the user places and levels themselves, so it keeps
+-- the slider.
+function DF:ResolveAbsorbBarLevel(frame, db)
+    if not frame or not frame.GetFrameLevel then return nil end
+    local mode = (db and db.absorbBarMode) or "ATTACHED_OVERFLOW"
+    if mode == "FLOATING" then
+        return frame:GetFrameLevel() + ((db and db.absorbBarFrameLevel) or 11)
+    end
+    -- Bound to the health bar (OVERLAY / ATTACHED / ATTACHED_OVERFLOW): derived, and
+    -- deliberately clear of the dispel overlay band. healthBar is frame+3, so +15
+    -- lands ~frame+18 against the gradient's ~+17.
+    local hb = frame.healthBar and frame.healthBar:GetFrameLevel()
+        or (frame:GetFrameLevel() + 3)
+    return hb + 15
+end
+
 function DF:UpdateAbsorb(frame, testIndex)
     if not frame then return end
     if not frame.healthBar then return end
@@ -652,7 +685,7 @@ function DF:UpdateAbsorb(frame, testIndex)
     -- say +11. Whether the bound modes SHOULD move to +11 is a design call needing in-game
     -- measurement, not arithmetic. See [[zorder_layer_map]].
     local healthLevel = frame.healthBar:GetFrameLevel()
-    local absorbLevel = healthLevel + 15
+    local absorbLevel = DF:ResolveAbsorbBarLevel(frame, db) or (healthLevel + 15)
 
     customBar:SetParent(frame)
     customBar:SetFrameStrata(frame:GetFrameStrata())


### PR DESCRIPTION
Three independent fixes off current `main`. Two are confirmed in game; one is not, and
is marked below.

## 1. Buffs render unfiltered after a cinematic ✅ confirmed in game

A cinematic changes the unit's faction, so it stops being assistable. The identity gate
fails OPEN on that — `includeSpellIDs` is skipped wholesale and every helpful aura
passes. The engine only re-parses when an aura CHANGES, so once assistability came back
the unfiltered pool simply stayed, which is why the only workarounds anyone found
(toggling test mode, toggling any filter) were pure rebuilds.

12.1 forces a cinematic on first login, which is what produced the reports of buffs
showing unfiltered "after upgrading". It was never a migration problem and it happens
on a profile that has only ever known v5.

`UNIT_FACTION` was already registered and the sweep already visited the right handles —
the vulnerability flags carry no unit, so the player's own container was in the set all
along. The sweep just recomputed a hide flag and never asked anything to re-parse. It
now records the assist answer and bounces on the false→true edge; edge-only, because
bouncing every sweep would re-parse every vulnerable handle on every roster and phase
event. Handles bounce their backend; slots re-push **candidates**, not the filter string
— `includeSpellIDs` is a candidate filter, so re-sending the string carries none of the
narrowing that was skipped.

A latch then holds vulnerable pools hidden across the recovery window so the fail-open
parse is never *seen*: the delay is upstream (Blizzard's event timing plus a parse tick,
and other implementations report the same residue), so the only lever is not showing the
frames until the re-parse has happened. A 3s fallback shows them regardless — the rule
here is that a wrongly-hidden row is worse than one garbage frame.

## 2. Test mode no longer disturbs other addons ✅ confirmed in game

Entering test mode filled every other addon's aura containers with sample icons.
`SwitchAuraDataProvider` fires a client-wide event that every aura container registers
for intrinsically; the per-container flag exists but its setter is private, and no public
container method touches the data source. It cannot be scoped.

It also was not needed. The engine's sample auras carry no spell IDs, durations or raid
flags, so every icon, name, stack and timer was already painted from our own `TestData`.
The switch bought only *presence* — buttons to paint onto. Test mode now supplies pooled
frames itself and never touches `C_UnitAuras`.

Styling and placement stay shared with live rather than reimplemented: `_acceptSlot` runs
the same `styleButton_regions`, `_paintTestSlot` is untouched, and placement goes through
`AnchorUtil.CreateFlowLayout()` — the same public flow the container uses, from the same
derivations. Behind `_ownTestPreview` (default on) with `/df debug ownpreview` to A/B the
two routes live.

## 3. A bound absorb bar sat under the dispel overlay ⚠ NOT yet confirmed in game

Field-reported on 5.1.0: with a shield active and a dispellable debuff applied, the
absorb showed only over the *missing* health, never the filled part.

Two paths set the absorb bar's frame level and disagreed. The layout pass derives it per
mode (≈frame+18, clear of the dispel gradient at ≈frame+17); the Frame Level preview
applied `absorbBarFrameLevel` unconditionally — but that slider is FLOATING-only by
design, so it dragged bound bars to frame+11, under the gradient. It stuck, because
`UpdateAbsorb`'s fast path returns before its own level block. One derivation now,
`DF:ResolveAbsorbBarLevel`, called by both.

The layering conflict predates the day-one dispel work; that fix is what made it visible,
by giving "Show On Current Health Only" a correct clip to the filled health — which is
exactly where a bound absorb lives. The header in `Bars.lua` had already flagged the
disagreement as open and wanting an in-game call rather than arithmetic; this is that
call. A wash that covers the filled health makes an absorb underneath it invisible for as
long as any dispellable debuff is up.

⚠ Reported as "only with poison". It is not poison-specific — `Poison` appears once in
the overlay file, for an icon atlas, and no dispel colour carries its own alpha. Poison
is simply the colour that swallows a cyan absorb most completely; the absorb was behind
for every type. Worth knowing so nobody hunts a poison-only path that does not exist.

## Verification

Offline where it is meaningful: the absorb resolver was checked across all four modes
(three bound modes land above the gradient, FLOATING still honours its slider). 1 and 2
were confirmed in game. **3 has not been seen in game with a shield and a dispellable
debuff at the same time** — that is the test it wants.

No changelog entries: the house rule is one is written only after in-game confirmation,
and one of the three is still outstanding.
