### PR TITLE
Z-order ladder, aura identity gate, and defensive stack count options

### DIFF
--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -5980,6 +5980,64 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 o:Section("Frame")
                 o:Field("level", frame:GetFrameLevel(), "NEUTRAL")
                 o:Field("strata", tostring(frame:GetFrameStrata()), "NEUTRAL")
+
+                -- ★ THE BAR BAND. Everything below covers the aura rows, which is the
+                -- half of the ladder that never appears in a report about a covered
+                -- absorb, a tinted reduced-max region or a buried resource bar. Six
+                -- rounds of exactly that got diagnosed from source instead, because the
+                -- numbers were not in this dump (Krathe, 2026-08-13).
+                -- ☠ Each row is checked against THE SAME RESOLVER THE LAYOUT CALLS, not
+                -- against a hardcoded number -- a dump carrying its own copy of the
+                -- ladder can agree with itself while disagreeing with the frame. What
+                -- this is for is catching the resolver and reality drifting apart.
+                -- Strata is printed per row too: it outranks level, so a row that looks
+                -- correctly ordered here can still render wrong if one member escaped
+                -- the frame's strata.
+                o:Section("Bars")
+                local base = frame:GetFrameLevel()
+                local bdb = DF.GetFrameDB and DF:GetFrameDB(frame)
+                local absLvl = DF.ResolveAbsorbBarLevel and DF:ResolveAbsorbBarLevel(frame, bdb)
+                local ov = frame.dfDispelOverlay
+                for _, e in ipairs({
+                    { "healthBar",       frame.healthBar,            3 },
+                    { "dfHealAbsorbBar", frame.dfHealAbsorbBar,      8 },
+                    { "dfAbsorbBar",     frame.dfAbsorbBar,          absLvl and (absLvl - base) },
+                    { "absorbOverflow",  frame.absorbOverflowBar,    absLvl and (absLvl - base) },
+                    { "dfHealPrediction", frame.dfHealPredictionBar,
+                        (bdb and bdb.healPredictionFrameLevel) or 12 },
+                    { "dispelOverlay",   ov,                         nil },
+                    { "dispel gradient", ov and ov.gradient,
+                        DF.ResolveDispelGradientLevel and DF:ResolveDispelGradientLevel(0, bdb) },
+                    { "dfPowerBar",      frame.dfPowerBar,
+                        (bdb and bdb.resourceBarFrameLevel) or 20 },
+                    { "contentOverlay",  frame.contentOverlay,       25 },
+                }) do
+                    local nm, w, want = e[1], e[2], e[3]
+                    if not w or not w.GetFrameLevel then
+                        print(("    %-16s |cff888888(absent)|r"):format(nm))
+                    else
+                        -- pcall: some of these carry 12.1 forbidden aspects, and a dump
+                        -- that throws is worse than one that says it could not read.
+                        local ok, lvl, shown, st = pcall(function()
+                            return w:GetFrameLevel(), w:IsShown(), w:GetFrameStrata()
+                        end)
+                        if not ok then
+                            print(("    %-16s |cffff4040(read refused)|r"):format(nm))
+                        else
+                            local off = lvl - base
+                            local tag = ""
+                            if want and off ~= want then
+                                tag = ("  |cffff4040<- EXPECTED +%d|r"):format(want)
+                            end
+                            if st and st ~= frame:GetFrameStrata() then
+                                tag = tag .. ("  |cffff4040strata=%s|r"):format(tostring(st))
+                            end
+                            print(("    %-16s level=%-4d (+%-3d) shown=%-5s%s")
+                                :format(nm, lvl, off, tostring(shown), tag))
+                        end
+                    end
+                end
+
                 local rows = {
                     { "buff", frame.buffFactory }, { "debuff", frame.debuffFactory },
                     { "defensive", frame.defensiveFactory },

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -6000,11 +6000,20 @@ DF._MainEventDispatcher = function(self, event, arg1)
                 local ov = frame.dfDispelOverlay
                 for _, e in ipairs({
                     { "healthBar",       frame.healthBar,            3 },
-                    { "dfHealAbsorbBar", frame.dfHealAbsorbBar,      8 },
+                    { "dfHealAbsorbBar", frame.dfHealAbsorbBar,
+                        DF.ResolveHealAbsorbBarLevel
+                        and select(2, pcall(function()
+                            local v = DF:ResolveHealAbsorbBarLevel(frame, bdb)
+                            return v and (v - base)
+                        end)) },
                     { "dfAbsorbBar",     frame.dfAbsorbBar,          absLvl and (absLvl - base) },
                     { "absorbOverflow",  frame.absorbOverflowBar,    absLvl and (absLvl - base) },
                     { "dfHealPrediction", frame.dfHealPredictionBar,
-                        (bdb and bdb.healPredictionFrameLevel) or 12 },
+                        DF.ResolveHealPredictionBarLevel
+                        and select(2, pcall(function()
+                            local v = DF:ResolveHealPredictionBarLevel(frame, bdb)
+                            return v and (v - base)
+                        end)) },
                     { "dispelOverlay",   ov,                         nil },
                     { "dispel gradient", ov and ov.gradient,
                         DF.ResolveDispelGradientLevel and DF:ResolveDispelGradientLevel(0, bdb) },

--- a/DandersFrames/Core/Config.lua
+++ b/DandersFrames/Core/Config.lua
@@ -1772,6 +1772,18 @@ DF.PartyDefaults = {
     defensiveIconScale = 1,
     defensiveIconShowBorder = true,
     defensiveIconShowDuration = true,
+    -- Stack ("count") text on a defensive icon. Was a hardcoded 14pt table in
+    -- Features/Auras.lua with no keys at all, so 12.1's three-digit stacks could not be
+    -- shrunk — only the duration text could (user report, 2026-08-13).
+    -- ☠ These reproduce that fixed look EXACTLY: baseSize 14 × Scale 1 = 14pt.
+    -- ☠ NO Font and NO Color key on purpose. Absent reads nil, and BuildSpec treats nil
+    -- as "DF default font" / "don't touch the colour" — which is what the old table did
+    -- by omitting them. Adding either default here would restyle every existing profile.
+    defensiveIconStackAnchor = "BOTTOMRIGHT",
+    defensiveIconStackOutline = "OUTLINE",
+    defensiveIconStackScale = 1,
+    defensiveIconStackX = 2,
+    defensiveIconStackY = -1,
     -- 26 (Krathe, 2026-08-08; was 30). ⚠ RAID keeps its own smaller value — see
     -- RAID_DEFAULT_OVERRIDES at the bottom of this file.
     defensiveIconSize = 26,

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -2674,18 +2674,28 @@ function DF:BuildDefensiveRowConfig(db, unit)
             tooltip  = buildTooltipSpec(db, "Defensive"),
             -- Duration bar strip (nil when disabled — byte-neutral; see the buff row).
             bar      = DF:BuildDurationBarSpec(db, "defensiveDurationBar"),
-            -- TextStyle-shaped spec (defensive stacks have no db keys — legacy fixed
-            -- look, size/outline explicit now that TextStyle owns the render defaults).
+            -- Shared TextStyle spec, same as the buff and debuff rows. This was a
+            -- hardcoded table whose own comment read "defensive stacks have no db keys —
+            -- legacy fixed look", which is precisely what a user ran into: 12.1 pushed
+            -- some stack counts to three digits and only the DURATION text could be
+            -- resized.
+            -- ☠ THE DEFAULTS RENDER IDENTICALLY TO THAT TABLE: baseSize 14 × Scale 1 =
+            -- 14, same anchor and offsets, Outline defaulted to "OUTLINE" in Config.
+            -- Font and Color get NO defaults on purpose — an absent key reads nil, which
+            -- BuildSpec treats as "DF default font" and "don't touch the colour", exactly
+            -- what the old table did by omission. Seeding either would silently restyle
+            -- every existing profile, which is not what a size request asked for.
             -- No formatter: forbidden on container rows (secret trap — see the
             -- GetStacksFormatter tombstone above). Native default = counts > 1.
-            stacks = {
-                show      = true,
-                anchor    = "BOTTOMRIGHT",
-                offsetX   = 2,
-                offsetY   = -1,
-                size      = 14,
-                outline   = "OUTLINE",
-            },
+            stacks = (function()
+                local st = DF.TextStyle:BuildSpec(db, "defensiveIconStack", {
+                    baseSize = 14, defaultAnchor = "BOTTOMRIGHT",
+                    defaultOffsetX = 2, defaultOffsetY = -1,
+                    boxW = db.defensiveIconSize or 24, boxH = db.defensiveIconSize or 24,
+                })
+                st.show = true
+                return st
+            end)(),
         },
     }
 end

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -161,6 +161,31 @@ end
 -- optional layering parents (the unit frame passes healthBar/contentOverlay;
 -- a slot button passes nothing and everything hangs off the widget itself).
 -- No caching here — callers own the widget's home.
+-- ☠ THE WASH'S LEVEL IS THE WHOLE "Show On Current Health Only" CONTRACT.
+-- Offsets are from the gradient's parent (the healthBar, frame+3), against the
+-- ladder documented in BuildDispelOverlayWidget below:
+--
+--   FULL FRAME (option OFF)  -> +14 (frame+17): over EVERYTHING -- absorb, heal
+--       prediction, reduced-max. That is what "full frame" means, and it is the
+--       mode to use with a low-alpha wash if you want to see through it.
+--
+--   SHOW ON CURRENT HEALTH   -> +1 (frame+4): above the health FILL and nothing
+--       else. It must stay under heal-absorb (+8), reduced-max (+9), absorb (+11)
+--       and heal prediction (+12), because the entire point of the option is that
+--       the wash marks the HEALTH and leaves those indicators readable. Burying
+--       them loses the information the option exists to preserve -- and at full
+--       health with a solid blend the wash swallowed the frame whole
+--       (Kaldoran/Lethas, 5.1.1; reproduced in test mode).
+--
+-- ⚠ Reported as "only with poison". It is not type-specific: Poison appears once in
+-- this file, for an icon atlas, and no dispel colour carries its own alpha. Green
+-- just swallows a cyan absorb most completely -- the absorb was under the wash for
+-- every type, and only the BLEND/ADD difference made it obvious.
+function DF:ResolveDispelGradientLevel(parentLevel, db)
+    local onCurrentHealth = db and db.dispelGradientOnCurrentHealth ~= false
+    return (parentLevel or 0) + (onCurrentHealth and 1 or 14)
+end
+
 local function BuildDispelOverlayWidget(host, gradientHost, iconHost)
     local overlay = CreateFrame("Frame", nil, host)
     overlay:SetAllPoints(host)
@@ -658,6 +683,12 @@ local function ApplyOverlayLayout(overlay, db, frame)
         -- a mismatch between the two decisions shows different coverage in the
         -- preview than in a group.
         --
+        -- ★ The level follows the option, every layout pass. Creation picks a default
+        -- before any db is in scope, so this is where the two modes actually diverge.
+        local gp = overlay.gradient:GetParent()
+        overlay.gradient:SetFrameLevel(
+            DF:ResolveDispelGradientLevel(gp and gp:GetFrameLevel() or 0, db))
+
         if onCurrentHealth and frame then
             -- Position gradient to match health bar
             overlay.gradient:SetAllPoints(gradientParent)
@@ -1339,7 +1370,14 @@ local function EnsureSlotWidget(btn, frame)
         -- +13/+14 clears both (frame+16/+17) and still sits under the resource bar at 20
         -- and the content overlay at 25. (Z-order review, 2026-08-07.)
         w:SetFrameLevel(hbLvl + 13)
-        w.gradient:SetFrameLevel(hbLvl + 14)
+        -- ★ The GRADIENT's level is not fixed: it follows "Show On Current Health Only"
+        -- (see DF:ResolveDispelGradientLevel). Full frame keeps +14 and covers the band;
+        -- current-health drops under absorb / heal prediction / reduced-max so those stay
+        -- readable. The widget frame above keeps +13 either way -- it carries the ring and
+        -- icons, not the wash.
+        w.gradient:SetFrameLevel(DF:ResolveDispelGradientLevel(hbLvl,
+            (frame.isRaidFrame and DF.GetRaidDB and DF:GetRaidDB())
+            or (DF.GetDB and DF:GetDB())))
         if w.borderRingHost then w.borderRingHost:SetFrameLevel(base + 7) end   -- legacy overlay(+6)+1
         local iconLevel = ((frame.contentOverlay and frame.contentOverlay:GetFrameLevel())
             or (base + 25)) + 1                -- legacy contentOverlay+26

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -690,10 +690,41 @@ local function ApplyOverlayLayout(overlay, db, frame)
             DF:ResolveDispelGradientLevel(gp and gp:GetFrameLevel() or 0, db))
 
         if onCurrentHealth and frame then
-            -- Position gradient to match health bar
-            overlay.gradient:SetAllPoints(gradientParent)
-            if overlay.gradientDarken then
-                overlay.gradientDarken:SetAllPoints(gradientParent)
+            -- ☠ ANCHOR TO THE HEALTH BAR, NOT THE FULL-FRAME PROXY.
+            -- dfGradientAnchorProxy spans the whole padded frame ON PURPOSE: "Clip
+            -- Health Bar" shrinks the healthBar to the un-reduced portion, and an EDGE
+            -- gradient that shrank with it stopped short of the frame edge (live-caught,
+            -- Top Edge). That reasoning is right for the edge styles and wrong here.
+            --
+            -- "Show On Current Health Only" means the wash marks the CURRENT HEALTH, and
+            -- the reduced-max region is by definition not health -- it is max health that
+            -- has been taken away. With the proxy the wash spanned it anyway and bled
+            -- through the reduced bar's striped texture, so the region read as tinted
+            -- (field-caught with Clip Health Bar ON; with it off the two rects coincide,
+            -- which is why the setting looked like the trigger).
+            -- The clipped healthBar already IS "the health", so anchoring to it gets the
+            -- reduced region excluded for free and stays correct when the user toggles
+            -- clipping.
+            --
+            -- ⚠ Falls back to the proxy if there is no healthBar or the anchor is
+            -- refused: on the 12.1 slot path the carrier's anchor chain must terminate at
+            -- the aura button (see the proxy's own note), and a wash one region too wide
+            -- beats a wash that fails to render.
+            local healthAnchor = frame.healthBar
+            local anchored = false
+            if healthAnchor then
+                anchored = pcall(function()
+                    overlay.gradient:SetAllPoints(healthAnchor)
+                    if overlay.gradientDarken then
+                        overlay.gradientDarken:SetAllPoints(healthAnchor)
+                    end
+                end)
+            end
+            if not anchored then
+                overlay.gradient:SetAllPoints(gradientParent)
+                if overlay.gradientDarken then
+                    overlay.gradientDarken:SetAllPoints(gradientParent)
+                end
             end
             
             -- Match health bar orientation and fill direction

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -181,8 +181,18 @@ end
 -- this file, for an icon atlas, and no dispel colour carries its own alpha. Green
 -- just swallows a cyan absorb most completely -- the absorb was under the wash for
 -- every type, and only the BLEND/ADD difference made it obvious.
+-- ☠ THE STYLE GATE IS NOT OPTIONAL. "Show On Current Health Only" is a FULL-style
+-- setting; the EDGE styles ignore it and always span the whole bar. The first cut of
+-- this function tested the checkbox alone, so Top Edge with the box still ticked --
+-- which is the shipped default, and invisible in the UI because the option does not
+-- apply to that style -- dropped the wash to the low band and the absorb bar at +11
+-- covered it. The edge band rendered over the health and vanished across the absorb
+-- (field-caught, Krathe). This condition MUST stay byte-identical to the layout's own
+-- (`gradientStyle == "FULL" and ...`), or the level and the geometry disagree again.
 function DF:ResolveDispelGradientLevel(parentLevel, db)
-    local onCurrentHealth = db and db.dispelGradientOnCurrentHealth ~= false
+    local style = (db and db.dispelGradientStyle) or "FULL"
+    local onCurrentHealth = style == "FULL"
+        and db and db.dispelGradientOnCurrentHealth ~= false
     return (parentLevel or 0) + (onCurrentHealth and 1 or 14)
 end
 

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -162,14 +162,14 @@ end
 -- a slot button passes nothing and everything hangs off the widget itself).
 -- No caching here — callers own the widget's home.
 -- ☠ THE WASH'S LEVEL IS THE WHOLE "Show On Current Health Only" CONTRACT.
--- Offsets are from the gradient's parent (the healthBar, frame+3), against the
--- ladder documented in BuildDispelOverlayWidget below:
+-- Offsets are from the FRAME, against the ladder documented in
+-- BuildDispelOverlayWidget below:
 --
---   FULL FRAME (option OFF)  -> +14 (frame+17): over EVERYTHING -- absorb, heal
+--   FULL FRAME (option OFF)  -> +17: over EVERYTHING -- absorb, heal
 --       prediction, reduced-max. That is what "full frame" means, and it is the
 --       mode to use with a low-alpha wash if you want to see through it.
 --
---   SHOW ON CURRENT HEALTH   -> +1 (frame+4): above the health FILL and nothing
+--   SHOW ON CURRENT HEALTH   -> +4: above the health FILL and nothing
 --       else. It must stay under heal-absorb (+8), reduced-max (+9), absorb (+11)
 --       and heal prediction (+12), because the entire point of the option is that
 --       the wash marks the HEALTH and leaves those indicators readable. Burying
@@ -189,11 +189,23 @@ end
 -- covered it. The edge band rendered over the health and vanished across the absorb
 -- (field-caught, Krathe). This condition MUST stay byte-identical to the layout's own
 -- (`gradientStyle == "FULL" and ...`), or the level and the geometry disagree again.
-function DF:ResolveDispelGradientLevel(parentLevel, db)
+--
+-- ☠☠ THE BASE IS THE FRAME, never whatever the gradient happens to be parented to.
+-- Everything else in the ladder is frame + N (Bars.lua). The wash was the one
+-- exception: <its own parent>:GetFrameLevel() + N. That parent is chosen ONCE, in
+-- BuildDispelOverlayWidget, and it is the health bar's pulse box (frame+3) only when
+-- frame.healthBar already exists. healthBar is nil for a pass during init (the slot
+-- path documents that window itself), the gradient family then falls back to `overlay`
+-- at frame+16, and the wash sits at frame+30 for the life of that frame -- over the
+-- resource bar, over the icons, over everything, in BOTH modes. Two frames, identical
+-- settings, one broken and its neighbour fine, decided purely by build order
+-- (field-caught, Krathe). Measuring from the frame removes the dependency rather than
+-- adding another number to compensate for it.
+function DF:ResolveDispelGradientLevel(frameLevel, db)
     local style = (db and db.dispelGradientStyle) or "FULL"
     local onCurrentHealth = style == "FULL"
         and db and db.dispelGradientOnCurrentHealth ~= false
-    return (parentLevel or 0) + (onCurrentHealth and 1 or 14)
+    return (frameLevel or 0) + (onCurrentHealth and 4 or 17)
 end
 
 local function BuildDispelOverlayWidget(host, gradientHost, iconHost)
@@ -695,9 +707,14 @@ local function ApplyOverlayLayout(overlay, db, frame)
         --
         -- ★ The level follows the option, every layout pass. Creation picks a default
         -- before any db is in scope, so this is where the two modes actually diverge.
-        local gp = overlay.gradient:GetParent()
+        -- ☠ Base it on the FRAME, not on overlay.gradient's parent -- that parent is
+        -- whichever host existed at build time and is frame+16 instead of frame+3 when
+        -- the widget was built before frame.healthBar (see ResolveDispelGradientLevel).
+        -- `overlay`'s own parent is the host the widget was built on, which is the frame
+        -- on this path, so it is the correct fallback when no frame was passed in.
+        local levelHost = frame or overlay:GetParent()
         overlay.gradient:SetFrameLevel(
-            DF:ResolveDispelGradientLevel(gp and gp:GetFrameLevel() or 0, db))
+            DF:ResolveDispelGradientLevel(levelHost and levelHost:GetFrameLevel() or 0, db))
 
         if onCurrentHealth and frame then
             -- ☠ ANCHOR TO THE HEALTH BAR, NOT THE FULL-FRAME PROXY.
@@ -1412,11 +1429,13 @@ local function EnsureSlotWidget(btn, frame)
         -- and the content overlay at 25. (Z-order review, 2026-08-07.)
         w:SetFrameLevel(hbLvl + 13)
         -- ★ The GRADIENT's level is not fixed: it follows "Show On Current Health Only"
-        -- (see DF:ResolveDispelGradientLevel). Full frame keeps +14 and covers the band;
-        -- current-health drops under absorb / heal prediction / reduced-max so those stay
-        -- readable. The widget frame above keeps +13 either way -- it carries the ring and
-        -- icons, not the wash.
-        w.gradient:SetFrameLevel(DF:ResolveDispelGradientLevel(hbLvl,
+        -- (see DF:ResolveDispelGradientLevel). Full frame lands at frame+17 and covers the
+        -- band; current-health drops to frame+4, under absorb / heal prediction /
+        -- reduced-max so those stay readable. The widget frame above keeps +13 either way
+        -- -- it carries the ring and icons, not the wash.
+        -- ☠ `base`, not `hbLvl`: the resolver's offsets are measured from the FRAME now,
+        -- so passing the health bar's level would land the wash three levels high.
+        w.gradient:SetFrameLevel(DF:ResolveDispelGradientLevel(base,
             (frame.isRaidFrame and DF.GetRaidDB and DF:GetRaidDB())
             or (DF.GetDB and DF:GetDB())))
         if w.borderRingHost then w.borderRingHost:SetFrameLevel(base + 7) end   -- legacy overlay(+6)+1

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -4536,6 +4536,36 @@ function Handle:_noteGateRecovery(can)
     end
 end
 
+-- ★ THE BOARDING WINDOW. `UnitCanAssist` does not flip the instant you take control of
+-- an NPC -- it flips once the seated state lands, and the gap is a visible flash of
+-- unfiltered icons on your own frame (Krathe, on 851917eb, which fixed the steady state
+-- and left this).
+--
+-- `UnitUsingVehicle` is true through the BOARDING and EXITING transitions as well as the
+-- seated state, so it closes that gap. This is a better SIGNAL, not another event to
+-- catch -- the same correction as measuring a level from the frame rather than from
+-- whatever it happens to be parented to.
+--
+-- ⚠ Self only, deliberately. Another player in a vehicle is still assistable and their
+-- pool is still filtered; it is the OCCUPANT whose own identity data goes away.
+-- ☠ `UnitIsUnit`, not `unit == "player"` -- in raid frames your own token is `raidN`, so
+-- a string compare misses your own frame entirely. (The existing `isOwn` below still uses
+-- the string compare; it only feeds branch (2), where the test is belt-and-braces,
+-- but it is the same latent bug and worth a look.)
+-- Fail-open on a refused or secret read, matching every other probe in this gate: any
+-- doubt SHOWS.
+local function SelfIsUsingVehicle(unit)
+    if not unit then return false end
+    local okSame, same = pcall(UnitIsUnit, unit, "player")
+    if not okSame or not same then return false end
+    local probe = UnitUsingVehicle or UnitInVehicle
+    if not probe then return false end
+    local ok, v = pcall(probe, "player")
+    if not ok then return false end
+    if issecretvalue and issecretvalue(v) then return false end
+    return v and true or false
+end
+
 function Handle:_applyIdentityGate()
     local hide = false
     if (self._idGateVulnerable or self._idGateSourceRelative) and not AuraContainer._testMode then
@@ -4566,6 +4596,13 @@ function Handle:_applyIdentityGate()
                 local ok, can = pcall(UnitCanAssist, "player", unit)
                 if ok then
                     if issecretvalue and issecretvalue(can) then can = true end
+                    -- ★ Overrides a still-true assist during the boarding window, before
+                    -- the seated state lands — see SelfIsUsingVehicle. Folded into `can`
+                    -- rather than straight into `hide` on purpose: _noteGateRecovery then
+                    -- records the false, so leaving the vehicle is a real false→true edge
+                    -- and re-parses. Setting `hide` alone would hide correctly and never
+                    -- rebuild the pool.
+                    if can and SelfIsUsingVehicle(unit) then can = false end
                     self:_noteGateRecovery(can)
                     -- ☠ NOT `and not isOwn` — see the block above. Cinematics are the
                     -- latch's job; this branch is what covers a vehicle.
@@ -6173,6 +6210,8 @@ function SlotHandle:_applyIdentityGate()
                 local ok, can = pcall(UnitCanAssist, "player", unit)
                 if ok then
                     if issecretvalue and issecretvalue(can) then can = true end
+                    -- ★ Boarding window — see SelfIsUsingVehicle and the Handle twin.
+                    if can and SelfIsUsingVehicle(unit) then can = false end
                     self:_noteGateRecovery(can)
                     if not can then hide = true end
                 end
@@ -6605,6 +6644,13 @@ idGateWatch:RegisterEvent("GROUP_ROSTER_UPDATE")
 idGateWatch:RegisterEvent("PLAYER_ENTERING_WORLD")
 idGateWatch:RegisterEvent("PLAYER_TARGET_CHANGED")
 idGateWatch:RegisterEvent("PLAYER_FOCUS_CHANGED")
+-- ★ Vehicle occupancy flips your own assistability. Confirmed by /etrace on a live
+-- boarding: none of the events above fire at the moment control is TAKEN — the ones that
+-- do (PARTY_MEMBER_ENABLE / UNIT_PHASE / UNIT_FACTION) arrive ~350ms later, at the end of
+-- the transition, which is the flash.
+idGateWatch:RegisterEvent("UNIT_ENTERING_VEHICLE")
+idGateWatch:RegisterEvent("UNIT_ENTERED_VEHICLE")
+idGateWatch:RegisterEvent("UNIT_EXITED_VEHICLE")
 local gateSweepQueued
 local function IdentityGateSweep()
     gateSweepQueued = nil
@@ -6623,6 +6669,19 @@ local function IdentityGateSweep()
     end
 end
 idGateWatch:SetScript("OnEvent", function(_, event)
+    -- ★ TWO LANES. The 0.05s debounce exists for the noisy events — roster, name and
+    -- phase updates arrive in bursts and a sweep per event would re-probe every
+    -- vulnerable handle each time. Vehicle edges are the opposite: rare, so there is no
+    -- storm to coalesce, and the deferral is precisely what reads on screen as a flash of
+    -- unfiltered icons on your own frame. So they sweep on the spot.
+    -- ⚠ Cinematics deliberately stay OUT of this lane. They are the latch's job
+    -- (cineWatch, below) and that path is confirmed working — an immediate sweep here
+    -- would be redundant work at best and a second writer racing the latch at worst.
+    if event == "UNIT_ENTERING_VEHICLE" or event == "UNIT_ENTERED_VEHICLE"
+        or event == "UNIT_EXITED_VEHICLE" then
+        IdentityGateSweep()
+        return
+    end
     if not gateSweepQueued then
         gateSweepQueued = true
         C_Timer.After(0.05, IdentityGateSweep)

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -4554,17 +4554,35 @@ end
 -- but it is the same latent bug and worth a look.)
 -- Fail-open on a refused or secret read, matching every other probe in this gate: any
 -- doubt SHOWS.
--- ★ DELIBERATELY NOT PROBED: connection state and dead/ghost.
--- A peer's gate additionally requires UnitIsConnected and not UnitIsDeadOrGhost before
--- treating a unit as identity-sound. That is a DIFFERENT POLICY, not a gap we have: they
--- hide whenever identity is doubtful; this gate hides only where the engine demonstrably
--- drops the filter. Neither state does that — an offline or dead unit has no aura data
--- streaming, so there is no pool to fail open, and UnitCanAssist stays true for both (you
--- can still rez and still assist a corpse). Adding them would blank correctly-filtered
--- rows for every dead raider in a wipe, which is a false positive of exactly the kind
--- this gate exists to avoid.
--- ⇒ If either is ever added, it needs a live repro showing unfiltered auras on an
--- offline/dead unit first. Presence in someone else's implementation is not evidence.
+-- ★ DISCONNECTED and DEAD/GHOST — two more states with no identity to filter on.
+--
+-- ☠ THESE WERE EXCLUDED EARLIER THE SAME DAY AND THE REASONING WAS WRONG. It ran:
+-- "an offline or dead unit has no aura data streaming, so there is no pool to fail open."
+-- Ghost auras stream. A user reported unfiltered debuffs on players who had died and were
+-- carrying the ghost aura (Discord, 2026-08-13) — which is exactly the evidence that
+-- exclusion named as the condition for reversing it, so it is reversed here rather than
+-- argued with. ★ Worth keeping as the shape of the mistake: the claim was about the
+-- ENGINE's behaviour and was reasoned out rather than measured, in a file where that has
+-- now cost a full day.
+--
+-- ⚠ NON-SELF ONLY, matching the assist probe's own shape. Your own frame while dead is
+-- still yours to read, and blanking it is the failure the original isOwn exemption was
+-- written to prevent.
+-- ⚠ Accepted cost, Krathe's call with the tradeoff stated: filtered rows go EMPTY for
+-- every corpse in a wipe. They currently render unfiltered, so empty is the better
+-- failure — but it is a visible change, not a silent one.
+-- Fail-open on a refused or secret read, like every other probe in this gate.
+local function IdentityUnavailable(unit)
+    local okC, connected = pcall(UnitIsConnected, unit)
+    if okC and not (issecretvalue and issecretvalue(connected)) and connected == false then
+        return true
+    end
+    local okD, dead = pcall(UnitIsDeadOrGhost, unit)
+    if okD and not (issecretvalue and issecretvalue(dead)) and dead == true then
+        return true
+    end
+    return false
+end
 local function SelfIsUsingVehicle(unit)
     if not unit then return false end
     local okSame, same = pcall(UnitIsUnit, unit, "player")
@@ -4620,6 +4638,11 @@ function Handle:_applyIdentityGate()
                     -- and re-parses. Setting `hide` alone would hide correctly and never
                     -- rebuild the pool.
                     if can and SelfIsUsingVehicle(unit) then can = false end
+                    -- ★ Disconnected / dead / ghost — see IdentityUnavailable. Folded
+                    -- into `can` like the vehicle probe, so a rez or a reconnect is a
+                    -- real false→true edge and re-parses the pool rather than just
+                    -- un-hiding a stale one.
+                    if can and not isOwn and IdentityUnavailable(unit) then can = false end
                     self:_noteGateRecovery(can)
                     -- ☠ NOT `and not isOwn` — see the block above. Cinematics are the
                     -- latch's job; this branch is what covers a vehicle.
@@ -6250,6 +6273,11 @@ function SlotHandle:_applyIdentityGate()
                     if issecretvalue and issecretvalue(can) then can = true end
                     -- ★ Boarding window — see SelfIsUsingVehicle and the Handle twin.
                     if can and SelfIsUsingVehicle(unit) then can = false end
+                    -- ★ Disconnected / dead / ghost — see IdentityUnavailable. Folded
+                    -- into `can` like the vehicle probe, so a rez or a reconnect is a
+                    -- real false→true edge and re-parses the pool rather than just
+                    -- un-hiding a stale one.
+                    if can and not isOwn and IdentityUnavailable(unit) then can = false end
                     self:_noteGateRecovery(can)
                     if not can then hide = true end
                 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -4541,11 +4541,23 @@ function Handle:_applyIdentityGate()
     if (self._idGateVulnerable or self._idGateSourceRelative) and not AuraContainer._testMode then
         local unit = self.config and self.config.unit
         -- ☠ `unit ~= "player"` USED TO SIT ON THIS LINE, so your own frame was never
-        -- probed at all. That exemption is right about HIDING (a frame you cannot see
-        -- during a cinematic needs no hiding, and hiding your own frame is a worse
-        -- failure than one garbage row) — but it also meant nothing ever NOTICED your
-        -- own pool falling open, so it never got re-parsed. The exemption now sits on
-        -- the two hide branches instead: probe always, hide only others.
+        -- probed at all — nothing ever NOTICED your own pool falling open, so it never
+        -- got re-parsed. Probing always is what fixed that.
+        --
+        -- ☠☠ IT THEN SURVIVED ON THE ASSIST HIDE BRANCH BELOW, AND THAT WAS WRONG.
+        -- The reasoning was "a frame you cannot see during a cinematic needs no hiding" —
+        -- true when written, and made obsolete by the cinematic latch that landed after
+        -- it. CineLatchAll (bottom of this file) latches EVERY vulnerable handle with no
+        -- isOwn check, and _noteGateRecovery unlatches only AFTER the recovery Refresh,
+        -- so own frames are already hidden through a cinematic and come back re-parsed.
+        -- The exemption was therefore contributing nothing to the case it was written
+        -- for, and its only live effect was the case with no cinematic and no latch:
+        -- ★ a VEHICLE. Take control of an NPC and UnitCanAssist goes false for minutes
+        -- while you look straight at the frame -- /df debug idgate showed every party1
+        -- handle hidden and every player handle open (field-caught, Krathe 2026-08-13).
+        -- Removing it costs a comparison and needs no timer, event or new state.
+        -- ⚠ Branch (2) keeps isOwn: you are always UnitIsVisible to yourself, so it is
+        -- belt-and-braces there rather than a behaviour decision.
         if type(unit) == "string" and UnitExists(unit) then
             local isOwn = (unit == "player")
             -- (1) Cross-faction / non-assistable: includeSpellIDs / category tokens
@@ -4555,7 +4567,9 @@ function Handle:_applyIdentityGate()
                 if ok then
                     if issecretvalue and issecretvalue(can) then can = true end
                     self:_noteGateRecovery(can)
-                    if not can and not isOwn then hide = true end
+                    -- ☠ NOT `and not isOwn` — see the block above. Cinematics are the
+                    -- latch's job; this branch is what covers a vehicle.
+                    if not can then hide = true end
                 end
             end
             -- (2) Not in your visible world (different instance/phase): the
@@ -6148,8 +6162,11 @@ function SlotHandle:_applyIdentityGate()
     if (self._idGateVulnerable or self._idGateSourceRelative) and not AuraContainer._testMode then
         local unit = self.owner and self.owner.unit
         -- ☠ See Handle:_applyIdentityGate — the `unit ~= "player"` exemption moved off
-        -- this line onto the hide branches, so the player's own slot is PROBED (and so
-        -- can be re-parsed on recovery) while still never being hidden.
+        -- this line onto the hide branches so the player's own slot is PROBED, and has
+        -- now been dropped from the ASSIST branch as well: the cinematic latch already
+        -- hides own handles (CineLatchAll takes no isOwn), so the exemption only ever
+        -- applied to the un-latched case — a vehicle — where it left the player's own
+        -- slots rendering an unfiltered pool.
         if type(unit) == "string" and UnitExists(unit) then
             local isOwn = (unit == "player")
             if self._idGateVulnerable then
@@ -6157,7 +6174,7 @@ function SlotHandle:_applyIdentityGate()
                 if ok then
                     if issecretvalue and issecretvalue(can) then can = true end
                     self:_noteGateRecovery(can)
-                    if not can and not isOwn then hide = true end
+                    if not can then hide = true end
                 end
             end
             if not hide and not isOwn and self._idGateSourceRelative then

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -4554,6 +4554,17 @@ end
 -- but it is the same latent bug and worth a look.)
 -- Fail-open on a refused or secret read, matching every other probe in this gate: any
 -- doubt SHOWS.
+-- ★ DELIBERATELY NOT PROBED: connection state and dead/ghost.
+-- A peer's gate additionally requires UnitIsConnected and not UnitIsDeadOrGhost before
+-- treating a unit as identity-sound. That is a DIFFERENT POLICY, not a gap we have: they
+-- hide whenever identity is doubtful; this gate hides only where the engine demonstrably
+-- drops the filter. Neither state does that — an offline or dead unit has no aura data
+-- streaming, so there is no pool to fail open, and UnitCanAssist stays true for both (you
+-- can still rez and still assist a corpse). Adding them would blank correctly-filtered
+-- rows for every dead raider in a wipe, which is a false positive of exactly the kind
+-- this gate exists to avoid.
+-- ⇒ If either is ever added, it needs a live repro showing unfiltered auras on an
+-- offline/dead unit first. Presence in someone else's implementation is not evidence.
 local function SelfIsUsingVehicle(unit)
     if not unit then return false end
     local okSame, same = pcall(UnitIsUnit, unit, "player")
@@ -4589,7 +4600,13 @@ function Handle:_applyIdentityGate()
         -- ⚠ Branch (2) keeps isOwn: you are always UnitIsVisible to yourself, so it is
         -- belt-and-braces there rather than a behaviour decision.
         if type(unit) == "string" and UnitExists(unit) then
-            local isOwn = (unit == "player")
+            -- ☠ UnitIsUnit, not a string compare: in raid layouts your own token is
+            -- `raidN`, so `unit == "player"` never matched your own frame there and the
+            -- exemption below silently did not apply to you. A no-op in practice today
+            -- (you are always visible and same-phase to yourself, so neither probe trips)
+            -- — but the compare is wrong, and the next probe added here may not be as kind.
+            local okOwn, ownSame = pcall(UnitIsUnit, unit, "player")
+            local isOwn = (okOwn and ownSame) and true or false
             -- (1) Cross-faction / non-assistable: includeSpellIDs / category tokens
             --     fail open. Signal: UnitCanAssist.
             if self._idGateVulnerable then
@@ -4618,6 +4635,21 @@ function Handle:_applyIdentityGate()
                 local okv, vis = pcall(UnitIsVisible, unit)
                 if okv and not (issecretvalue and issecretvalue(vis)) and not vis then
                     hide = true
+                end
+                -- ☠ THE "/phase" HALF OF THE COMMENT ABOVE WAS NEVER IMPLEMENTED. A unit
+                -- in another phase, layer or Chromie time can be UnitIsVisible TRUE and
+                -- still be unattributable, so the source-relative filter fails open with
+                -- the visibility probe perfectly happy. UnitPhaseReason returns nil for
+                -- same-phase and a reason otherwise (Features/Range.lua reads it the same
+                -- way).
+                -- ⚠ Only reliable within ~250yd (Frames/StatusIcons.lua). Past that it
+                -- returns nil, which reads as "same phase", which SHOWS — the
+                -- unreliability fails in the safe direction, so no distance guard.
+                if not hide and UnitPhaseReason then
+                    local okp, reason = pcall(UnitPhaseReason, unit)
+                    if okp and not (issecretvalue and issecretvalue(reason)) and reason then
+                        hide = true
+                    end
                 end
             end
         end
@@ -6205,7 +6237,13 @@ function SlotHandle:_applyIdentityGate()
         -- applied to the un-latched case — a vehicle — where it left the player's own
         -- slots rendering an unfiltered pool.
         if type(unit) == "string" and UnitExists(unit) then
-            local isOwn = (unit == "player")
+            -- ☠ UnitIsUnit, not a string compare: in raid layouts your own token is
+            -- `raidN`, so `unit == "player"` never matched your own frame there and the
+            -- exemption below silently did not apply to you. A no-op in practice today
+            -- (you are always visible and same-phase to yourself, so neither probe trips)
+            -- — but the compare is wrong, and the next probe added here may not be as kind.
+            local okOwn, ownSame = pcall(UnitIsUnit, unit, "player")
+            local isOwn = (okOwn and ownSame) and true or false
             if self._idGateVulnerable then
                 local ok, can = pcall(UnitCanAssist, "player", unit)
                 if ok then
@@ -6220,6 +6258,21 @@ function SlotHandle:_applyIdentityGate()
                 local okv, vis = pcall(UnitIsVisible, unit)
                 if okv and not (issecretvalue and issecretvalue(vis)) and not vis then
                     hide = true
+                end
+                -- ☠ THE "/phase" HALF OF THE COMMENT ABOVE WAS NEVER IMPLEMENTED. A unit
+                -- in another phase, layer or Chromie time can be UnitIsVisible TRUE and
+                -- still be unattributable, so the source-relative filter fails open with
+                -- the visibility probe perfectly happy. UnitPhaseReason returns nil for
+                -- same-phase and a reason otherwise (Features/Range.lua reads it the same
+                -- way).
+                -- ⚠ Only reliable within ~250yd (Frames/StatusIcons.lua). Past that it
+                -- returns nil, which reads as "same phase", which SHOWS — the
+                -- unreliability fails in the safe direction, so no distance guard.
+                if not hide and UnitPhaseReason then
+                    local okp, reason = pcall(UnitPhaseReason, unit)
+                    if okp and not (issecretvalue and issecretvalue(reason)) and reason then
+                        hide = true
+                    end
                 end
             end
         end

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -484,12 +484,18 @@ function DF:ResolveAbsorbBarLevel(frame, db)
     if mode == "FLOATING" then
         return frame:GetFrameLevel() + ((db and db.absorbBarFrameLevel) or 11)
     end
-    -- Bound to the health bar (OVERLAY / ATTACHED / ATTACHED_OVERFLOW): derived, and
-    -- deliberately clear of the dispel overlay band. healthBar is frame+3, so +15
-    -- lands ~frame+18 against the gradient's ~+17.
-    local hb = frame.healthBar and frame.healthBar:GetFrameLevel()
-        or (frame:GetFrameLevel() + 3)
-    return hb + 15
+    -- Bound to the health bar (OVERLAY / ATTACHED / ATTACHED_OVERFLOW): the ladder's
+    -- own slot, +11 (see the map in Features/Dispel.lua). NOT the slider -- that is
+    -- FLOATING-only, so reading it here would drag a bound bar to wherever a floating
+    -- bar was last placed.
+    --
+    -- ☠ This deliberately does NOT try to out-rank the dispel wash. An earlier cut did
+    -- (+15 off the health bar, landing above the gradient) and that was wrong: it made
+    -- the absorb poke through FULL FRAME too, which is the mode whose whole point is
+    -- covering the frame. Whether the wash hides the absorb is the WASH's business, and
+    -- it is now conditional on "Show On Current Health Only" -- see
+    -- DF:ResolveDispelGradientLevel in Features/Dispel.lua.
+    return frame:GetFrameLevel() + 11
 end
 
 function DF:UpdateAbsorb(frame, testIndex)

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -498,6 +498,33 @@ function DF:ResolveAbsorbBarLevel(frame, db)
     return frame:GetFrameLevel() + 11
 end
 
+-- ★ THE OTHER TWO BOUND BARS. Same contract as the absorb resolver above and for the
+-- same reason: the ladder is stated ONCE, here, and every mode branch asks for its slot
+-- rather than doing its own arithmetic off the health bar.
+--
+-- ☠ What these replace was not a near-miss, it was a different ladder. Each updater
+-- computed a level up top, applied it, then EVERY mode branch overwrote it with
+-- healthLevel + 1..3. The real band was health +3, prediction +4, heal-absorb +5,
+-- absorb +5, overflow +6 -- packed into four levels -- while the comments, the db keys
+-- and DF:ResolveDispelGradientLevel all reasoned about +8/+11/+12. The dispel wash's
+-- current-health slot of +4 was chosen to sit under that documented band and in fact
+-- TIED with heal prediction; it drew correctly on creation order alone
+-- (/df debug zorder on a live frame, 2026-08-13).
+-- ⚠ The old branch comments justified themselves with "below dispel overlay (+6) and
+-- aggro highlight (+9)". The overlay has been at +16 since 2026-08-07, and there is no
+-- aggro-highlight level anywhere in the addon -- both numbers were fiction, and fiction
+-- is what the arithmetic was protecting.
+function DF:ResolveHealAbsorbBarLevel(frame, db)
+    if not frame or not frame.GetFrameLevel then return nil end
+    return frame:GetFrameLevel() + 8
+end
+
+-- ⚠ The key is user-facing so it wins; 12 is the ladder's slot and the shipped default.
+function DF:ResolveHealPredictionBarLevel(frame, db)
+    if not frame or not frame.GetFrameLevel then return nil end
+    return frame:GetFrameLevel() + ((db and db.healPredictionFrameLevel) or 12)
+end
+
 function DF:UpdateAbsorb(frame, testIndex)
     if not frame then return end
     if not frame.healthBar then return end
@@ -847,9 +874,10 @@ function DF:UpdateAbsorb(frame, testIndex)
         customBar:ClearAllPoints()
         customBar:SetParent(frame.healthBar)
         customBar:SetFrameStrata(frame:GetFrameStrata())
-        -- ATTACHED mode should always be below dispel overlay (+6) and aggro highlight (+9)
-        -- Use healthLevel + 2 regardless of strata setting
-        customBar:SetFrameLevel(healthLevel + 2)
+        -- ☠ The ladder's absorb slot, resolved once at the top of this function.
+        -- Was healthLevel + 2 (frame+5), justified by a dispel overlay at +6 that has
+        -- been at +16 since 2026-08-07 -- see DF:ResolveHealAbsorbBarLevel.
+        customBar:SetFrameLevel(absorbLevel)
         
         -- Re-assert the texture's tiling mode. This block used to force tiling OFF
         -- unconditionally "to prevent dense repeating in narrow bars" — which is
@@ -1093,9 +1121,10 @@ function DF:UpdateAbsorb(frame, testIndex)
         customBar:ClearAllPoints()
         customBar:SetParent(frame.healthBar)
         customBar:SetFrameStrata(frame:GetFrameStrata())
-        -- ATTACHED_OVERFLOW mode should always be below dispel overlay (+6) and aggro highlight (+9)
-        -- Use healthLevel + 2 regardless of strata setting
-        customBar:SetFrameLevel(healthLevel + 2)
+        -- ☠ The ladder's absorb slot, resolved once at the top of this function.
+        -- Was healthLevel + 2 (frame+5), justified by a dispel overlay at +6 that has
+        -- been at +16 since 2026-08-07 -- see DF:ResolveHealAbsorbBarLevel.
+        customBar:SetFrameLevel(absorbLevel)
         
         -- Re-assert the texture's tiling mode. This block used to force tiling OFF
         -- unconditionally "to prevent dense repeating in narrow bars" — which is
@@ -1243,7 +1272,11 @@ function DF:UpdateAbsorb(frame, testIndex)
         -- ⚠ The comment here used to say "below dispel overlay (+6)". The overlay has
         -- been at +16 since the 2026-08-07 z-order review, so that number was fiction
         -- and it is what justified the hardcoded arithmetic.
-        overflowBar:SetFrameLevel(customBar:GetFrameLevel() + 1)
+        -- ☠ SHARES the attached bar's level rather than sitting one above it. At the
+        -- old squashed levels +1 was free; on the real ladder absorb is +11 and +12 is
+        -- heal prediction's slot. The two segments are adjacent and never overlap, so
+        -- one level is correct and needs no tie-break.
+        overflowBar:SetFrameLevel(customBar:GetFrameLevel())
         
         -- Apply same texture/color as main absorb bar
         local texture = db.absorbBarTexture or DF.STOCK_BAR_TEXTURE
@@ -1324,8 +1357,9 @@ function DF:UpdateAbsorb(frame, testIndex)
         -- Set parent to health bar for overlay mode
         customBar:SetParent(frame.healthBar)
         customBar:SetFrameStrata(frame:GetFrameStrata())
-        -- OVERLAY mode should be above health bar but below dispel overlay (+6) and highlights (+9)
-        customBar:SetFrameLevel(healthLevel + 2)
+        -- ☠ The ladder's absorb slot, resolved once at the top of this function.
+        -- Was healthLevel + 2 (frame+5) -- see DF:ResolveHealAbsorbBarLevel.
+        customBar:SetFrameLevel(absorbLevel)
         
         if customBar.bg then customBar.bg:Hide() end
         
@@ -1527,7 +1561,7 @@ function DF:UpdateHealAbsorb(frame, testIndex)
     
     local bar = frame.dfHealAbsorbBar
     local healthLevel = frame.healthBar:GetFrameLevel()
-    local healAbsorbLevel = healthLevel + 12
+    local healAbsorbLevel = DF:ResolveHealAbsorbBarLevel(frame, db) or (healthLevel + 5)
     
     bar:SetParent(frame)
     bar:SetFrameStrata(frame:GetFrameStrata())
@@ -1613,8 +1647,8 @@ function DF:UpdateHealAbsorb(frame, testIndex)
     elseif mode == "ATTACHED" then
         bar:ClearAllPoints()
         bar:SetParent(frame.healthBar)
-        -- ATTACHED mode should be below dispel overlay (+6) and aggro highlight (+9)
-        bar:SetFrameLevel(healthLevel + 3)
+        -- ☠ The resolved slot, not healthLevel + 3 -- see DF:ResolveHealAbsorbBarLevel.
+        bar:SetFrameLevel(healAbsorbLevel)
         
         -- Re-assert the texture's own tiling. This used to force it OFF outright
         -- "to prevent dense repeating in narrow bars", which is still the default
@@ -1720,8 +1754,8 @@ function DF:UpdateHealAbsorb(frame, testIndex)
     -- ============================================================
     else
         bar:SetParent(frame.healthBar)
-        -- OVERLAY mode should be above health bar but below dispel overlay (+6) and highlights (+9)
-        bar:SetFrameLevel(healthLevel + 2)
+        -- ☠ The resolved slot, not healthLevel + 2 -- see DF:ResolveHealAbsorbBarLevel.
+        bar:SetFrameLevel(healAbsorbLevel)
         
         if bar.bg then bar.bg:Hide() end
         
@@ -2041,7 +2075,10 @@ function DF:UpdateHealPrediction(frame, testIndex)
     -- stored value was always the "SANDWICH" default. Two of the three branches produced
     -- the SAME +1 anyway, and the third (+14) was unreachable. Collapsed; nothing moved.
     local healthLevel = frame.healthBar:GetFrameLevel()
-    local predictionLevel = healthLevel + 1
+    -- ☠ The ladder's slot (healPredictionFrameLevel, default 12), not healthLevel + 1.
+    -- The FLOATING branch below already read the key; every other branch used +1, so the
+    -- same bar sat eight levels apart depending only on mode.
+    local predictionLevel = DF:ResolveHealPredictionBarLevel(frame, db) or (healthLevel + 1)
 
     -- Texture and color
     local tex = ResolveBarTextureForFill(db, db.healPredictionTexture or DF.STOCK_BAR_TEXTURE,

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -1219,13 +1219,31 @@ function DF:UpdateAbsorb(frame, testIndex)
         end
         
         local overflowBar = frame.absorbOverflowBar
+
+        -- ☠ THE OVERFLOW BAR HAD NO LEVEL OF ITS OWN. Created as a healthBar child and
+        -- never levelled, it inherited frame+3 -- the health bar's own level -- while its
+        -- sibling (the attached bar) sits at +11. That was invisible for as long as the
+        -- dispel wash lived above the whole band, and surfaced the moment the wash
+        -- dropped under it for "Show On Current Health Only": the attached absorb came
+        -- through and the overflow stripe stayed washed (field-caught, Krathe).
+        -- Two halves of ONE readout must share a level; anything else is a coin-flip the
+        -- next z-order change re-tosses.
         local overflowVisHelper = overflowBar.visibilityHelper
         local attachedVisHelper = customBar.visibilityHelper
-        
+
         -- Configure the overflow bar (always, so it's ready when needed)
         overflowBar:ClearAllPoints()
-        -- Overflow bar should be just above attached bar but still below dispel overlay (+6)
-        overflowBar:SetFrameLevel(healthLevel + 3)
+        -- ☠ DERIVED FROM THE ATTACHED BAR, one above it. The two are halves of one
+        -- readout, and their ORDER is the contract -- the absolute number is not.
+        -- A DF:ResolveAbsorbBarLevel call used to sit ten lines above this one and was
+        -- overwritten right here on every pass: dead code that read as a fix, and it
+        -- survived an in-game confirmation because what actually fixed that report was
+        -- the dispel wash dropping to +4, not this bar moving. Proved by
+        -- /df debug zorder -- attached +5, overflow +6, resolver claims +11 (2026-08-13).
+        -- ⚠ The comment here used to say "below dispel overlay (+6)". The overlay has
+        -- been at +16 since the 2026-08-07 z-order review, so that number was fiction
+        -- and it is what justified the hardcoded arithmetic.
+        overflowBar:SetFrameLevel(customBar:GetFrameLevel() + 1)
         
         -- Apply same texture/color as main absorb bar
         local texture = db.absorbBarTexture or DF.STOCK_BAR_TEXTURE

--- a/DandersFrames/Frames/Create.lua
+++ b/DandersFrames/Frames/Create.lua
@@ -898,14 +898,19 @@ function DF:CreateFrameElementsExtended(frame, db)
     frame.dfPowerBar:SetMinMaxValues(0, 1)
     frame.dfPowerBar:SetValue(1)
     frame.dfPowerBar:SetAlpha(1)
-    -- ☠ SAME BAND AS ApplyResourceBarLayout (frame + resourceBarFrameLevel, default 20),
-    -- not healthBar+2 (frame+5). The layout normally supersedes this before the bar is
-    -- ever shown -- it is created hidden -- but the two values disagreed by fifteen
-    -- levels, which put the creation-time bar UNDER the dispel wash's full-frame band at
-    -- frame+17. Latent rather than live, and exactly the creation-vs-layout split that
-    -- hid the absorb overflow bar (see DF:ResolveAbsorbBarLevel). Any custom slider value
-    -- still arrives with the layout pass; this only fixes where it starts.
-    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel() + 20)
+    -- ☠ SAME BAND AS ApplyResourceBarLayout, and READ FROM THE SAME KEY -- not
+    -- healthBar+2 (frame+5), and not a hardcoded 20 either. The layout normally
+    -- supersedes this before the bar is ever shown (it is created hidden), but the two
+    -- values disagreed by fifteen levels, which started the bar UNDER the dispel wash's
+    -- full-frame band at frame+17. Same creation-vs-layout split that left
+    -- DF:ResolveAbsorbBarLevel as dead code.
+    -- ⚠ A hardcoded 20 is only correct on a default profile: the key is user-facing
+    -- and a lowered value is normal (Krathe's own runs 10 -- /df debug zorder). Reading
+    -- the key is what keeps the two writers agreeing for everyone; a constant that
+    -- happens to match the default just hides the split again.
+    local powerDB = DF.GetFrameDB and DF:GetFrameDB(frame)
+    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel()
+        + ((powerDB and powerDB.resourceBarFrameLevel) or 20))
     frame.dfPowerBar:Hide()
     
     local powerBg = frame.dfPowerBar:CreateTexture(nil, "BACKGROUND")
@@ -1288,14 +1293,19 @@ function DF:CreateUnitFrame(unit, index, isRaid)
     frame.dfPowerBar:SetMinMaxValues(0, 1)
     frame.dfPowerBar:SetValue(1)
     frame.dfPowerBar:SetAlpha(1)
-    -- ☠ SAME BAND AS ApplyResourceBarLayout (frame + resourceBarFrameLevel, default 20),
-    -- not healthBar+2 (frame+5). The layout normally supersedes this before the bar is
-    -- ever shown -- it is created hidden -- but the two values disagreed by fifteen
-    -- levels, which put the creation-time bar UNDER the dispel wash's full-frame band at
-    -- frame+17. Latent rather than live, and exactly the creation-vs-layout split that
-    -- hid the absorb overflow bar (see DF:ResolveAbsorbBarLevel). Any custom slider value
-    -- still arrives with the layout pass; this only fixes where it starts.
-    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel() + 20)
+    -- ☠ SAME BAND AS ApplyResourceBarLayout, and READ FROM THE SAME KEY -- not
+    -- healthBar+2 (frame+5), and not a hardcoded 20 either. The layout normally
+    -- supersedes this before the bar is ever shown (it is created hidden), but the two
+    -- values disagreed by fifteen levels, which started the bar UNDER the dispel wash's
+    -- full-frame band at frame+17. Same creation-vs-layout split that left
+    -- DF:ResolveAbsorbBarLevel as dead code.
+    -- ⚠ A hardcoded 20 is only correct on a default profile: the key is user-facing
+    -- and a lowered value is normal (Krathe's own runs 10 -- /df debug zorder). Reading
+    -- the key is what keeps the two writers agreeing for everyone; a constant that
+    -- happens to match the default just hides the split again.
+    local powerDB = DF.GetFrameDB and DF:GetFrameDB(frame)
+    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel()
+        + ((powerDB and powerDB.resourceBarFrameLevel) or 20))
     frame.dfPowerBar:Hide()
     
     local powerBg = frame.dfPowerBar:CreateTexture(nil, "BACKGROUND")

--- a/DandersFrames/Frames/Create.lua
+++ b/DandersFrames/Frames/Create.lua
@@ -898,7 +898,14 @@ function DF:CreateFrameElementsExtended(frame, db)
     frame.dfPowerBar:SetMinMaxValues(0, 1)
     frame.dfPowerBar:SetValue(1)
     frame.dfPowerBar:SetAlpha(1)
-    frame.dfPowerBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 2)
+    -- ☠ SAME BAND AS ApplyResourceBarLayout (frame + resourceBarFrameLevel, default 20),
+    -- not healthBar+2 (frame+5). The layout normally supersedes this before the bar is
+    -- ever shown -- it is created hidden -- but the two values disagreed by fifteen
+    -- levels, which put the creation-time bar UNDER the dispel wash's full-frame band at
+    -- frame+17. Latent rather than live, and exactly the creation-vs-layout split that
+    -- hid the absorb overflow bar (see DF:ResolveAbsorbBarLevel). Any custom slider value
+    -- still arrives with the layout pass; this only fixes where it starts.
+    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel() + 20)
     frame.dfPowerBar:Hide()
     
     local powerBg = frame.dfPowerBar:CreateTexture(nil, "BACKGROUND")
@@ -1281,7 +1288,14 @@ function DF:CreateUnitFrame(unit, index, isRaid)
     frame.dfPowerBar:SetMinMaxValues(0, 1)
     frame.dfPowerBar:SetValue(1)
     frame.dfPowerBar:SetAlpha(1)
-    frame.dfPowerBar:SetFrameLevel(frame.healthBar:GetFrameLevel() + 2)
+    -- ☠ SAME BAND AS ApplyResourceBarLayout (frame + resourceBarFrameLevel, default 20),
+    -- not healthBar+2 (frame+5). The layout normally supersedes this before the bar is
+    -- ever shown -- it is created hidden -- but the two values disagreed by fifteen
+    -- levels, which put the creation-time bar UNDER the dispel wash's full-frame band at
+    -- frame+17. Latent rather than live, and exactly the creation-vs-layout split that
+    -- hid the absorb overflow bar (see DF:ResolveAbsorbBarLevel). Any custom slider value
+    -- still arrives with the layout pass; this only fixes where it starts.
+    frame.dfPowerBar:SetFrameLevel(frame:GetFrameLevel() + 20)
     frame.dfPowerBar:Hide()
     
     local powerBg = frame.dfPowerBar:CreateTexture(nil, "BACKGROUND")

--- a/DandersFrames_Options/Core/ExportCategories.lua
+++ b/DandersFrames_Options/Core/ExportCategories.lua
@@ -580,6 +580,17 @@ DF.ExportCategories = {
         "defensiveIconShowBorder",
         "defensiveIconShowDuration",
         "defensiveIconSize",
+        -- ☠ This list is EXPLICIT, not prefix-matched — a new key that is not named here
+        -- silently fails to travel with an exported profile. No Font/Color entries: those
+        -- two keys deliberately have no defaults (see Core/Config.lua), but they are still
+        -- listed so a user who sets one keeps it.
+        "defensiveIconStackAnchor",
+        "defensiveIconStackColor",
+        "defensiveIconStackFont",
+        "defensiveIconStackOutline",
+        "defensiveIconStackScale",
+        "defensiveIconStackX",
+        "defensiveIconStackY",
         "defensiveIconX",
         "defensiveIconY",
         "defensiveSortOrder",

--- a/DandersFrames_Options/GUI/Pages/Auras.lua
+++ b/DandersFrames_Options/GUI/Pages/Auras.lua
@@ -1306,8 +1306,18 @@ function DF._SetupGUIPagesPart3(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         local bgClassAlpha = bgGroup:AddWidget(GUI:CreateSlider(self.child, L["Background Alpha"], 0, 1, 0.05, db, "backgroundClassAlpha", nil, function() DF:LightweightUpdateBackgroundColor() end, true), 55)
         bgClassAlpha.hideOn = function(d) return d.backgroundColorMode ~= "CLASS" end
         
-        AddToSection(bgGroup, nil, 1)
-        
+        -- ★ COLUMN 2, under Texture. Column 1 carries Color and then the Gradient editor,
+        -- which is ~280 lines of widgets and expands further as stops are added — so with
+        -- the gradient open, column 1 ran long while column 2 held Texture and nothing
+        -- else, leaving that box stranded beside a wall of controls (Krathe, 2026-08-13).
+        -- Background pairs naturally with Texture anyway: both are what the bar is drawn
+        -- ON, against Color/Gradient which are what it is drawn IN.
+        -- ⚠ When the gradient is hidden (healthColorMode ~= "PERCENT") this tips the other
+        -- way — column 2 then holds two groups against column 1's one. That is the lesser
+        -- imbalance, and the pending "gradient editor as a single-column box" rework
+        -- changes the same balance, so the two want checking together.
+        AddToSection(bgGroup, nil, 2)
+
         currentSection = nil
         AddSpace(GUI.Space.section, "both")
         

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -1816,18 +1816,25 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         -- the stack text was a hardcoded 14pt in Features/Auras.lua with no keys at all,
         -- which a user hit when 12.1 pushed some counts to three digits (report,
         -- 2026-08-13: "I can only change the duration text for it").
-        -- ⚠ NO colour control here, unlike the Buffs page. The render deliberately keeps
-        -- `defensiveIconStackColor` absent so the colour stays untouched exactly as the
-        -- old hardcoded table left it; seeding a default to feed a picker would restyle
-        -- every existing profile. Adding it is a follow-up that needs a decision on what
-        -- the current native colour actually is, not a guess.
+        -- ☠ FULL CONTROLS, INCLUDING COLOUR, WITH NO DEFAULT COLOUR KEY. Those are not in
+        -- tension: CreateColorPicker seeds {1,1,1,1} inside its own OnClick when the key
+        -- is absent, and UpdateSwatch skips a nil key entirely — so the control works and
+        -- writes NOTHING until a user actually picks a colour. Until then BuildSpec reads
+        -- nil and TextStyle leaves the colour alone, exactly as the old hardcoded table
+        -- did by omission.
+        -- ⚠ That is why `defensiveIconStackColor` has no Config default and must not gain
+        -- one. A seeded default would restyle every existing profile the moment they
+        -- update, and nobody has established what the untouched native colour actually is
+        -- — the picker's white is its own fallback, not a measurement.
         local defStackGroup = GUI:CreateSettingsGroup(self.child, 280)
         defStackGroup.hideOn = function(d) return not DF:FactoryOwnsDefensiveRow(d) end
         defStackGroup:AddWidget(GUI:CreateHeader(self.child, L["Stack Count"]), 40)
         GUI:CreateTextControls(defStackGroup, db, "defensiveIconStack", {
-            parent   = self.child,
-            onChange = function() if DF.UpdateAllDefensiveBars then DF:UpdateAllDefensiveBars() end end,
-            onDrag   = function() DF:LightweightUpdateDefensiveIcons() end,
+            parent     = self.child,
+            include    = { color = true },
+            colorLabel = L["Stack Text Color"],
+            onChange   = function() if DF.UpdateAllDefensiveBars then DF:UpdateAllDefensiveBars() end end,
+            onDrag     = function() DF:LightweightUpdateDefensiveIcons() end,
         })
         -- Grey with the feature, same as the Duration group above.
         defStackGroup.disableChildrenOn = HideDefensiveIconOptions

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -1809,6 +1809,30 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         -- renders Anchor + Offset X/Y on the same defensiveIconDurationX/Y keys — the
         -- separate group was a duplicate left behind by the TextStyle conversion.)
 
+        -- ===== STACK COUNT GROUP (Column 1) =====
+        -- Directly under Duration, matching the Buffs page and the Aura Designer cards:
+        -- the two text elements on an icon are tuned as a pair, so a user who finds one
+        -- expects the other adjacent. Until now this page had only the duration half —
+        -- the stack text was a hardcoded 14pt in Features/Auras.lua with no keys at all,
+        -- which a user hit when 12.1 pushed some counts to three digits (report,
+        -- 2026-08-13: "I can only change the duration text for it").
+        -- ⚠ NO colour control here, unlike the Buffs page. The render deliberately keeps
+        -- `defensiveIconStackColor` absent so the colour stays untouched exactly as the
+        -- old hardcoded table left it; seeding a default to feed a picker would restyle
+        -- every existing profile. Adding it is a follow-up that needs a decision on what
+        -- the current native colour actually is, not a guess.
+        local defStackGroup = GUI:CreateSettingsGroup(self.child, 280)
+        defStackGroup.hideOn = function(d) return not DF:FactoryOwnsDefensiveRow(d) end
+        defStackGroup:AddWidget(GUI:CreateHeader(self.child, L["Stack Count"]), 40)
+        GUI:CreateTextControls(defStackGroup, db, "defensiveIconStack", {
+            parent   = self.child,
+            onChange = function() if DF.UpdateAllDefensiveBars then DF:UpdateAllDefensiveBars() end end,
+            onDrag   = function() DF:LightweightUpdateDefensiveIcons() end,
+        })
+        -- Grey with the feature, same as the Duration group above.
+        defStackGroup.disableChildrenOn = HideDefensiveIconOptions
+        Add(defStackGroup, nil, 1)
+
         -- ===== DURATION BAR GROUP (Column 1) ===== (12.1 factory rows only —
         -- mirrors the Buffs page's block; UpdateAllDefensiveBars bumps the layout
         -- version, and the sig split routes Rebuild vs in-place restyle)

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -198,6 +198,20 @@ DF.TestData = {
         {icon = "Interface\\Icons\\spell_druid_ironbark", name = "Ironbark", duration = 12, stacks = 0, spellID = 102342},
         {icon = "Interface\\Icons\\Spell_Holy_SealOfSacrifice", name = "Blessing of Sacrifice", duration = 12, stacks = 0, spellID = 6940},
         {icon = "Interface\\Icons\\ability_monk_chicocoon", name = "Life Cocoon", duration = 12, stacks = 0, spellID = 116849},
+        -- ★ THE STACKED SAMPLE. Every other entry is stacks = 0, so the stack text never
+        -- drew and the Stack Count controls on the Defensive Icons page could only be
+        -- judged on a live aura in combat.
+        -- ☠ It has to be a spell that GENUINELY stacks. A first cut put a fake 12 on Pain
+        -- Suppression, which does not — a preview that shows something the game never
+        -- shows is the same class of lie as a test path that renders differently from
+        -- live. Sentinel is the right sample twice over: it is the exact spell in the
+        -- report behind these controls ("since the patch the number is quite huge"), and
+        -- SpellDB already carries it as a defensive (389539, cats.defensives).
+        -- ⚠ The value is for WIDTH, not accuracy — nobody has checked the real cap, and
+        -- the point is that two digits reveal the overflow a single digit hides.
+        -- No hand-maintained icon needed: _paintTestSlot prefers the GAME's texture for a
+        -- validated spellID and only falls back to this path.
+        {icon = "Interface\\Icons\\Spell_Holy_AuraOfLight", name = "Sentinel", duration = 15, stacks = 12, spellID = 389539},
     },
     animationTimer = nil,
     animationPhase = 0,


### PR DESCRIPTION
Three related rounds from a day of bug reports. All of the layering work was diagnosed by measuring live frames rather than reading source — a `/df debug zorder` section was added for exactly that and is what found most of these.

## Z-order: the health band

The documented ladder was not the one frames were using. Three updaters each resolved a level at the top, applied it, then had **every mode branch overwrite it** with `healthLevel + 1..3`. Measured on a live frame:

```
health +3 · prediction +4 · heal-absorb +5 · absorb +5 · overflow +6
```

against the +8/+11/+12 that the comments, two user-facing sliders and the dispel wash's own reasoning all assumed. `absorbBarFrameLevel` and `healPredictionFrameLevel` were read in the FLOATING branch and ignored everywhere else, so the same bar sat eight levels apart depending only on mode.

That is why the dispel wash kept burying things. Its current-health slot of +4 was chosen to sit under the *documented* band; on the real one it tied with heal prediction and sat below both absorbs, drawing correctly on creation order alone.

Resolvers now state the ladder once and the bound branches ask for their slot. Separately, the wash's level was measured from *whatever it happened to be parented to* — the health bar's pulse box when `frame.healthBar` existed at build time, `overlay` (thirteen levels higher) when it did not. Two frames with identical settings rendered differently by build order. It is measured from the frame now.

Branch comments justified the old arithmetic with "below dispel overlay (+6) and aggro highlight (+9)". The overlay has been +16 since the 2026-08-07 review, and there is no aggro-highlight level anywhere in the addon.

## Aura identity gate

A non-assistable unit makes the engine skip `includeSpellIDs` wholesale, so every helpful aura passes. The hide fallback that exists to mask this was skipping the player's own frame — correct for cinematics, where the latch already hides own frames and unlatches only after the recovery re-parse, and wrong everywhere else. Take control of an NPC and your own rows rendered an unfiltered pool for as long as you were in it.

Coverage added, each from a separate report: vehicle occupancy including the boarding transition (`UnitCanAssist` has not flipped yet while boarding, so a probe waiting on it is structurally late), phase (`UnitPhaseReason` — the branch comment had said "different instance/phase" while only testing visibility), and connection plus dead/ghost after unfiltered debuffs were reported on players carrying the ghost aura.

Vehicle edges sweep immediately rather than on the shared 0.05s debounce; that deferral was visible as a flash of unfiltered icons. Noisy events keep the debounce.

⚠️ **Behaviour change worth flagging:** filtered rows now go empty for dead units. They previously rendered unfiltered, so empty is the better failure, but it is visible in a wipe.

## Defensive icon stack count

Reported as no way to change the stack count size, only the duration text, with 12.1 pushing some counts to three digits. Accurate — the spec's own comment read "defensive stacks have no db keys, legacy fixed look", a hardcoded 14pt table while buff and debuff rows have had the full TextStyle block for a long time.

Now the same shared control block, with a Stack Count group under Duration to match the Buffs page. **Defaults render identically to the old table** — `baseSize 14 × Scale 1`, same anchor and offsets. `Font` and `Color` deliberately have no defaults: an absent key reads nil, which means "DF default font" and "don't touch the colour", exactly what the hardcoded table did by omission. The colour control still works — the picker seeds its own white on click — so nothing is written until a user picks one.

Keys are in `ExportCategories`; that list is explicit rather than prefix-matched, so an unlisted key silently fails to travel with a profile.

## Also

- `/df debug zorder` gained a Bars section that checks each row against the same resolvers the layout calls, printing a mismatch when they drift, rather than carrying its own copy of the ladder.
- Health bar Background moved to column 2 — column 1 carried Color, the gradient editor, and Background, while column 2 held Texture alone.
- One defensive preview entry given a stack so the new controls have something to show.