### PR TITLE
Aura identity gate rework, and a dozen field-reported fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,14 @@
 * (Bars) Fix solo-mode resource bars appearing on frames other than your own. (by Krathe)
 * (Aura Designer) Fix the enable toggle silently changing your Show Buffs setting when nothing needed to change. (by Krathe)
 * (Test Mode) The preview honours Smooth Bar Animation and labels which slot is you. (by Krathe)
+* (Auras) Fix buffs and debuffs sometimes staying hidden on group members after they died, released or disconnected — the frame only recovered when something else refreshed it, such as targeting that player. Most reported by healers missing HoTs on raid groups outside their own, and constant in battlegrounds. (by Krathe)
+* (Auras) Duration text now counts down cleanly to the end — 3, 2, 1, gone — instead of showing the final second twice. Applies to every duration format, the Aura Designer and the Defensive Icon. (by Krathe)
+* (Global Fonts) Apply to All now reaches the Aura Designer: the global text defaults, every placed indicator and all group text styles take the chosen font and outline. Previously it silently changed nothing there. (by Krathe)
 
 ### Improvements
 
 * (Aura Designer) The filter picker now has a scrollbar and a search box, matching the addon's other dropdowns.
+* (Debug) New IDGATE debug category traces every aura-visibility gate decision with its reason (dead, offline, cross-faction, in a vehicle, phased) — enable it when chasing a "my auras vanished" report, then check /df debug idgate. (by Krathe)
 
 ## [5.1.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* (Test Mode) The test panel's Absorbs and Heal Prediction toggles now apply fully when switched on mid-session — previously some frames were left without their shield or incoming heal until the toggle was flipped again. (by Krathe)
 * (Aura Designer) Fix indicators on shared slots fading twice as much as intended out of range, and staying faded after entering combat while someone was out of range.
 * (Debuff Bar) Fix the whole debuff row going empty on some group members — showing a dispel highlight with no debuff icon under it — when debuff categories were combined.
 * (Aura Designer) Every configured Health Bar Color and Background Color now shows. Previously only the highest-priority one ever did, so a lower-priority buff coloured nothing even when it was the only one on the unit. With several active at once the highest priority draws on top. (by Krathe)

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -5326,7 +5326,19 @@ function Factory:SyncFrame(frame)
     frame.dfADMemTestCleared = nil
 
     local adDB = DF.ResolveAuraDesigner and DF:ResolveAuraDesigner(frame)
-    if not adDB then return end
+    if not adDB then
+        -- ☠ TEAR DOWN, DO NOT JUST LEAVE. This was a bare `return`, sitting three lines
+        -- above the `not spec` exit that DOES call ClearFrame -- two "nothing to render"
+        -- paths, one of which released its containers and one of which abandoned them.
+        -- Skipping the sync does not stop anything rendering: the containers are declared
+        -- to the engine and Blizzard keeps drawing them until they are released, so an
+        -- unresolvable config left the previous config's indicators on screen, at their
+        -- old positions, until a reload. ClearFrame is cheap on a frame that owns nothing
+        -- (it returns immediately when there is no store), so this costs nothing in the
+        -- ordinary early-login case where the profile has simply not loaded yet.
+        self:ClearFrame(frame)
+        return
+    end
 
     -- The factory owns AD here (the legacy read-path engine is gone), so nothing maintains the
     -- buff-bar dedup set. Clear any set left populated by a prior legacy run so it can't

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -5333,12 +5333,23 @@ function Factory:SyncFrame(frame)
         -- Skipping the sync does not stop anything rendering: the containers are declared
         -- to the engine and Blizzard keeps drawing them until they are released, so an
         -- unresolvable config left the previous config's indicators on screen, at their
-        -- old positions, until a reload. ClearFrame is cheap on a frame that owns nothing
-        -- (it returns immediately when there is no store), so this costs nothing in the
-        -- ordinary early-login case where the profile has simply not loaded yet.
-        self:ClearFrame(frame)
+        -- old positions, until a reload.
+        -- ☠ LATCHED, exactly like the MemTest branch above and for its stated reason:
+        -- "ClearFrame ends in SyncSound, which is not free to re-run per update."
+        -- An earlier comment here claimed the repeated case costs nothing because
+        -- ClearFrame "returns immediately when there is no store" -- false for exactly
+        -- the frames this fix targets: dfADFactory is created once and never nil'd, so
+        -- a frame that ever rendered AD re-ran the full clear (teardown walks plus a
+        -- SyncSound reconcile) on EVERY sync pass while its config stayed unresolvable.
+        -- The flag resets the moment adDB resolves, so a config coming back re-syncs
+        -- normally. (PR #237 self-review finding 1.)
+        if not frame.dfADNoCfgCleared then
+            frame.dfADNoCfgCleared = true
+            self:ClearFrame(frame)
+        end
         return
     end
+    frame.dfADNoCfgCleared = nil
 
     -- The factory owns AD here (the legacy read-path engine is gone), so nothing maintains the
     -- buff-bar dedup set. Clear any set left populated by a prior legacy run so it can't

--- a/DandersFrames/Debug/DebugConsole.lua
+++ b/DandersFrames/Debug/DebugConsole.lua
@@ -79,6 +79,11 @@ local CATEGORY_GROUPS = {
             -- firehose. Replaces BLIZAURA, which was declared but never logged.
             { key = "AURAROW",       desc = "Aura row drivers: rebuild vs tuning vs style, retargets" },
             { key = "AURACONTAINER", desc = "12.1 AuraContainer factory (build, filters, capability gate)" },
+            -- The identity gate's own lane, split out of AURACONTAINER so a tester
+            -- chasing "auras vanished" can enable JUST the verdict trail: park/hide
+            -- flips with the probe that broke trust, latches, recovery re-parses.
+            -- Edge-triggered only, so it is quiet outside actual gate activity.
+            { key = "IDGATE",        desc = "Identity gate: park/hide verdicts with reasons, latches, recovery" },
             -- ⚠ Was EMITTED BUT NOT REGISTERED, which defeats the point of this table:
             -- both of its sites are DebugWarn -- custom-filter import skipping an
             -- entry, and a scrub that could not reach ParseADFilterRef -- i.e. exactly

--- a/DandersFrames/Debug/DebugConsole.lua
+++ b/DandersFrames/Debug/DebugConsole.lua
@@ -530,57 +530,100 @@ end
 -- DISPLAY RENDERING
 -- ============================================================
 
+-- ☠ THE RENDER WINDOW IS A HARD CAP, NOT A NICETY. The EditBox grows its height
+-- to numLines * lineHeight below, and past a few thousand lines that height
+-- exceeds what the renderer will draw — the box goes COMPLETELY blank, with the
+-- "no entries match" message nowhere in sight (field report: 10k entries, every
+-- large category blanked the window, tiny ones like SYSTEM rendered fine). The
+-- display code was built when maxLines defaulted to 500 (+500 overshoot), so
+-- ~1000 lines is the proven envelope; when the retention default was raised to
+-- 10000 the blank appeared. Retention and rendering are different budgets: keep
+-- all 10000 in the log, show the newest 1000, and SAY the rest are held back.
+local MAX_RENDER_LINES = 1000
+
+-- Shared per-entry sanitize + format. Legacy entries (logged before the
+-- write-time sanitizer existed) may hold nil or secret-tainted fields which
+-- would crash format(); `colored` picks the console form vs the export form.
+local function FormatLogEntry(entry, colored)
+    local timestamp = entry[1] or "??:??:??"
+    local level     = entry[2] or "INFO"
+    local category  = entry[3] or "GENERAL"
+    local message   = entry[4]
+    if message == nil then
+        message = "<nil>"
+    elseif type(message) ~= "string" then
+        message = tostring(message) or "<nonstring>"
+    end
+    if isSecretValue(message) then
+        message = "<SECRET — legacy tainted entry>"
+    end
+    if type(timestamp) ~= "string" or isSecretValue(timestamp) then
+        timestamp = "??:??:??"
+    end
+    if type(category) ~= "string" or isSecretValue(category) then
+        category = "GENERAL"
+    end
+    local sev = SEVERITY[level] or SEVERITY.INFO
+    local ok, formatted
+    if colored then
+        ok, formatted = pcall(format, "%s %s[%s]|r [%s] %s",
+            timestamp, sev.color or "|cffffffff", sev.label, category, message)
+    else
+        ok, formatted = pcall(format, "%s [%s] [%s] %s",
+            timestamp, type(level) == "string" and level or "INFO", category, message)
+    end
+    if ok and not isSecretValue(formatted) then
+        return formatted
+    end
+    return timestamp .. " [" .. (sev.label or "?") .. "] [" .. category .. "] <unrenderable entry>"
+end
+
+-- Walk the log NEWEST-FIRST, format only the newest `cap` matching entries, and
+-- keep counting the older matches without paying for their strings. Returns the
+-- lines in chronological order plus the total match count. Shared by the live
+-- display and the export so the two can never disagree about filtering again.
+local function CollectFilteredLines(cap, colored)
+    local minLevel = SEVERITY[(debugDb and debugDb.logLevel) or "INFO"]
+    if not minLevel then minLevel = SEVERITY.INFO end
+    local minLevelNum = minLevel.level
+    local filters = (debugDb and debugDb.filters) or {}
+    local lines, matched = {}, 0
+    for i = #debugLog, 1, -1 do
+        local entry = debugLog[i]
+        local sev = SEVERITY[entry[2]]
+        if sev and sev.level >= minLevelNum then
+            -- Category filter (absent = visible, explicit false = hidden); the
+            -- category is sanitized to GENERAL inside FormatLogEntry, so mirror
+            -- that here or a tainted category would dodge the filter check.
+            local category = entry[3]
+            if type(category) ~= "string" or isSecretValue(category) then
+                category = "GENERAL"
+            end
+            if filters[category] ~= false then
+                matched = matched + 1
+                if #lines < cap then
+                    lines[#lines + 1] = FormatLogEntry(entry, colored)
+                end
+            end
+        end
+    end
+    -- Collected newest-first: reverse into chronological order.
+    local n = #lines
+    for i = 1, math.floor(n / 2) do
+        lines[i], lines[n + 1 - i] = lines[n + 1 - i], lines[i]
+    end
+    return lines, matched
+end
+
 function DebugConsole:RefreshDisplay()
     needsRefresh = false
     if not liveEditBox or not debugLog then return end
 
-    local minLevel = SEVERITY[debugDb.logLevel or "INFO"]
-    if not minLevel then minLevel = SEVERITY.INFO end
-    local minLevelNum = minLevel.level
-
-    local filters = debugDb.filters or {}
-    local lines = {}
-
-    for _, entry in ipairs(debugLog) do
-        local timestamp = entry[1] or "??:??:??"
-        local level     = entry[2] or "INFO"
-        local category  = entry[3] or "GENERAL"
-        local message   = entry[4]
-
-        -- Sanitize every field BEFORE passing to format. Legacy entries
-        -- (logged before the write-time sanitizer existed) may have nil or
-        -- secret-tainted messages which would crash format().
-        if message == nil then
-            message = "<nil>"
-        elseif type(message) ~= "string" then
-            message = tostring(message) or "<nonstring>"
-        end
-        if isSecretValue(message) then
-            message = "<SECRET — legacy tainted entry>"
-        end
-        if type(timestamp) ~= "string" or isSecretValue(timestamp) then
-            timestamp = "??:??:??"
-        end
-        if type(category) ~= "string" or isSecretValue(category) then
-            category = "GENERAL"
-        end
-
-        -- Check severity filter
-        local sev = SEVERITY[level]
-        if sev and sev.level >= minLevelNum then
-            -- Check category filter (absent = visible, explicit false = hidden)
-            if filters[category] ~= false then
-                local colorCode = sev.color or "|cffffffff"
-                local ok, formatted = pcall(format, "%s %s[%s]|r [%s] %s",
-                    timestamp, colorCode, sev.label, category, message)
-                if ok and not isSecretValue(formatted) then
-                    tinsert(lines, formatted)
-                else
-                    tinsert(lines, timestamp .. " [" .. (sev.label or "?") ..
-                        "] [" .. category .. "] <unrenderable entry>")
-                end
-            end
-        end
+    local lines, matched = CollectFilteredLines(MAX_RENDER_LINES, true)
+    if matched > #lines then
+        tinsert(lines, 1, format(
+            "|cff666666… %d older matching lines held back (newest %d shown — narrow the filters to reach older lines; the full log is in the saved variables file)|r",
+            matched - #lines, #lines))
     end
 
     local text = #lines > 0 and table.concat(lines, "\n") or "|cff666666No log entries match current filters.|r"
@@ -664,56 +707,28 @@ end
 function DebugConsole:GetExportText()
     if not debugLog then return "No debug log available." end
 
-    -- Respect current severity and category filters so the export
-    -- matches what the user sees in the debug console
-    local minLevel = SEVERITY[(debugDb and debugDb.logLevel) or "INFO"]
-    if not minLevel then minLevel = SEVERITY.INFO end
-    local minLevelNum = minLevel.level
-    local filters = (debugDb and debugDb.filters) or {}
-
-    local entries = {}
-    for _, entry in ipairs(debugLog) do
-        local sev = SEVERITY[entry[2]]
-        if sev and sev.level >= minLevelNum and filters[entry[3]] ~= false then
-            -- Sanitize each field before format — legacy entries may have
-            -- nil or secret-tainted values which would crash format/concat.
-            local ts  = entry[1]
-            local lvl = entry[2]
-            local cat = entry[3]
-            local msg = entry[4]
-            if type(ts)  ~= "string" or isSecretValue(ts)  then ts  = "??:??:??" end
-            if type(lvl) ~= "string" or isSecretValue(lvl) then lvl = "INFO" end
-            if type(cat) ~= "string" or isSecretValue(cat) then cat = "GENERAL" end
-            if msg == nil then
-                msg = "<nil>"
-            elseif type(msg) ~= "string" then
-                msg = tostring(msg) or "<nonstring>"
-            end
-            if isSecretValue(msg) then msg = "<SECRET — legacy tainted entry>" end
-
-            local ok, formatted = pcall(format, "%s [%s] [%s] %s", ts, lvl, cat, msg)
-            if ok and not isSecretValue(formatted) then
-                tinsert(entries, formatted)
-            else
-                tinsert(entries, ts .. " [" .. lvl .. "] [" .. cat .. "] <unrenderable entry>")
-            end
-        end
-    end
+    -- Same filters, same formatter, same MAX_RENDER_LINES window as the live
+    -- display (CollectFilteredLines) — the export popup's text area is also a
+    -- content-sized EditBox, so an uncapped 10k-line export blanked exactly
+    -- like the live box did. The header names what was held back; the full
+    -- log always survives in the saved variables file.
+    local entries, matched = CollectFilteredLines(MAX_RENDER_LINES, false)
 
     local result = {}
     tinsert(result, "DandersFrames Debug Log")
     tinsert(result, "Version: " .. (DF.VERSION or "unknown"))
     tinsert(result, "Exported: " .. date("%Y-%m-%d %H:%M:%S"))
-    tinsert(result, "Entries: " .. #entries .. " (filtered from " .. #debugLog .. " total)")
+    if matched > #entries then
+        tinsert(result, ("Entries: newest %d of %d matched (%d total in log; older lines are in the saved variables file)")
+            :format(#entries, matched, #debugLog))
+    else
+        tinsert(result, "Entries: " .. #entries .. " (filtered from " .. #debugLog .. " total)")
+    end
     tinsert(result, "Min Level: " .. (debugDb and debugDb.logLevel or "INFO"))
     tinsert(result, "========================================")
     tinsert(result, "")
     for i = 1, #entries do
-        local entry = entries[i]
-        if isSecretValue(entry) then
-            entry = "<SECRET — export line was tainted>"
-        end
-        result[#result + 1] = entry
+        result[#result + 1] = entries[i]
     end
 
     return table.concat(result, "\n")

--- a/DandersFrames/Debug/DebugConsole.lua
+++ b/DandersFrames/Debug/DebugConsole.lua
@@ -535,10 +535,14 @@ end
 -- exceeds what the renderer will draw — the box goes COMPLETELY blank, with the
 -- "no entries match" message nowhere in sight (field report: 10k entries, every
 -- large category blanked the window, tiny ones like SYSTEM rendered fine). The
--- display code was built when maxLines defaulted to 500 (+500 overshoot), so
--- ~1000 lines is the proven envelope; when the retention default was raised to
--- 10000 the blank appeared. Retention and rendering are different budgets: keep
--- all 10000 in the log, show the newest 1000, and SAY the rest are held back.
+-- display code was built when maxLines defaulted to 500 (+500 overshoot); when
+-- the retention default was raised to 10000 the blank appeared. The ceiling is
+-- the region-size limit (~32,767px — roughly 2,700 lines at this font, but the
+-- font is user-scalable, which drags the true line count down). 1000 is the
+-- envelope the console demonstrably ran at for months, so it stays 1000
+-- (Krathe's call). Retention and rendering are different budgets: keep all
+-- 10000 in the log, show the newest window, and SAY the rest are held back.
+-- The export pages in chunks of this same size, losing nothing.
 local MAX_RENDER_LINES = 1000
 
 -- Shared per-entry sanitize + format. Legacy entries (logged before the
@@ -622,7 +626,7 @@ function DebugConsole:RefreshDisplay()
     local lines, matched = CollectFilteredLines(MAX_RENDER_LINES, true)
     if matched > #lines then
         tinsert(lines, 1, format(
-            "|cff666666… %d older matching lines held back (newest %d shown — narrow the filters to reach older lines; the full log is in the saved variables file)|r",
+            "|cff666666… %d older matching lines held back (newest %d shown — Copy to Clipboard exports every part, or narrow the filters)|r",
             matched - #lines, #lines))
     end
 
@@ -704,32 +708,40 @@ end
 -- EXPORT
 -- ============================================================
 
-function DebugConsole:GetExportText()
-    if not debugLog then return "No debug log available." end
+-- The export loses NOTHING: every matching line is formatted, then sliced into
+-- parts of MAX_RENDER_LINES — the popup's text area is a content-sized EditBox
+-- with the same region-size ceiling as the live box, so one giant string would
+-- blank it, but paged parts each render fine. One part = the common case (a
+-- filtered slice is almost always under the window); the caller shows a "next
+-- part" button only when there are more. Same filters, same formatter, same
+-- window as the display (CollectFilteredLines), so the views cannot disagree.
+function DebugConsole:GetExportChunks()
+    if not debugLog then return { "No debug log available." } end
 
-    -- Same filters, same formatter, same MAX_RENDER_LINES window as the live
-    -- display (CollectFilteredLines) — the export popup's text area is also a
-    -- content-sized EditBox, so an uncapped 10k-line export blanked exactly
-    -- like the live box did. The header names what was held back; the full
-    -- log always survives in the saved variables file.
-    local entries, matched = CollectFilteredLines(MAX_RENDER_LINES, false)
-
-    local result = {}
-    tinsert(result, "DandersFrames Debug Log")
-    tinsert(result, "Version: " .. (DF.VERSION or "unknown"))
-    tinsert(result, "Exported: " .. date("%Y-%m-%d %H:%M:%S"))
-    if matched > #entries then
-        tinsert(result, ("Entries: newest %d of %d matched (%d total in log; older lines are in the saved variables file)")
-            :format(#entries, matched, #debugLog))
-    else
-        tinsert(result, "Entries: " .. #entries .. " (filtered from " .. #debugLog .. " total)")
+    local entries = CollectFilteredLines(math.huge, false)
+    local total = #entries
+    local numChunks = math.max(1, math.ceil(total / MAX_RENDER_LINES))
+    local chunks = {}
+    for c = 1, numChunks do
+        local first = (c - 1) * MAX_RENDER_LINES + 1
+        local last  = math.min(total, c * MAX_RENDER_LINES)
+        local result = {}
+        tinsert(result, "DandersFrames Debug Log")
+        tinsert(result, "Version: " .. (DF.VERSION or "unknown"))
+        tinsert(result, "Exported: " .. date("%Y-%m-%d %H:%M:%S"))
+        if numChunks > 1 then
+            tinsert(result, ("Part %d of %d — lines %d-%d of %d matched (%d total in log)")
+                :format(c, numChunks, first, last, total, #debugLog))
+        else
+            tinsert(result, "Entries: " .. total .. " (filtered from " .. #debugLog .. " total)")
+        end
+        tinsert(result, "Min Level: " .. (debugDb and debugDb.logLevel or "INFO"))
+        tinsert(result, "========================================")
+        tinsert(result, "")
+        for i = first, last do
+            result[#result + 1] = entries[i]
+        end
+        chunks[#chunks + 1] = table.concat(result, "\n")
     end
-    tinsert(result, "Min Level: " .. (debugDb and debugDb.logLevel or "INFO"))
-    tinsert(result, "========================================")
-    tinsert(result, "")
-    for i = 1, #entries do
-        result[#result + 1] = entries[i]
-    end
-
-    return table.concat(result, "\n")
+    return chunks
 end

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -3046,10 +3046,24 @@ end
 -- Non-aura visibility for the missing-buff strip: the badge must never claim
 -- "missing" on a corpse / offline / out-of-range / unassistable unit. All
 -- non-secret reads; range mirrors the legacy issecretvalue guard. DELIBERATE
--- change vs legacy: no UnitIsPlayer — legacy excluded NPC group members because
--- its aura SCAN couldn't check them, but raid buffs are castable on
+-- change vs legacy: no UnitIsPlayer on GROUP frames — legacy excluded NPC group
+-- members because its aura SCAN couldn't check them, but raid buffs are castable on
 -- follower-dungeon NPCs (Krathe-verified) and the read-free widget works on any
 -- assistable unit. Pets stay excluded (pet frames don't run this feature).
+--
+-- ☠☠ THE PLAYERS-ONLY TERM IS SCOPED TO PINNED FRAMES, AND MUST STAY THAT WAY.
+-- It arrived unscoped and killed the feature outright in follower dungeons: every
+-- party member there is an NPC, so the strip hid on all of them and showed only on
+-- your own frame -- reported by Aur0r4 on 5.1.3 with a fresh profile, confirmed by
+-- Krathe in a follower dungeon. The bug it was fixing is real but NARROWER than the
+-- code it shipped as: a story-mode companion on a PINNED frame nagging about class
+-- raid buffs nobody can give it, which is exactly how the changelog scoped it
+-- ("(Pinned Frames) Story-mode NPC companions ..."). The paragraph above is the
+-- older claim and it was the correct one; the unscoped term was added beneath it
+-- without reconciling the two, so for a build the file argued with itself.
+-- ⚠ Residual, accepted: a story companion occupying a real PARTY slot rather than a
+-- pinned frame can still nag. A useless icon is cosmetic; a dead feature in every
+-- follower dungeon is not.
 --
 -- ☠ SPLIT OUT of DriveMissingBuffFactory on purpose. The drive only runs from
 -- RefreshFactoryRows, which fires on an aura-LAYOUT bump (a settings change) and
@@ -3074,12 +3088,14 @@ function DF:RefreshMissingBuffVisibility(frame)
         -- group is empty and every badge sits parked in its window.
         visible = true
     else
-        -- ☠ PLAYERS ONLY (#1046/S7): a missing CLASS raid buff is meaningless on
-        -- an NPC, but a story-mode companion passes every other term here
-        -- (assistable, alive — and UnitIsConnected can read secret-truthy on
-        -- such units, sailing through the `and` chain), so pinned NPCs nagged
-        -- about buffs nobody can give them.
-        visible = unit and UnitExists(unit) and UnitIsPlayer(unit)
+        -- ☠ PLAYERS ONLY ON PINNED FRAMES (#1046/S7) — see the header. A story-mode
+        -- companion passes every other term here (assistable, alive — and
+        -- UnitIsConnected can read secret-truthy on such units, sailing through the
+        -- `and` chain), so pinned NPCs nagged about buffs nobody can give them.
+        -- ☠ DO NOT DROP THE isPinnedFrame SCOPE. Unscoped, this term hides the strip
+        -- on every follower-dungeon party member, because they are all NPCs.
+        visible = unit and UnitExists(unit)
+            and (not frame.isPinnedFrame or UnitIsPlayer(unit))
             and not UnitIsDeadOrGhost(unit) and UnitIsConnected(unit)
             and not frame.isPetFrame and UnitCanAssist("player", unit)
         if visible then

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -796,9 +796,9 @@ local function BuildDurationFormatter(format, hideAboveT, colorByTime, alertMode
     -- know the total, so absolute-seconds bands are the 12.1 equivalent.)
     if hideAboveT or colorByTime or alertT then
         if not (C_StringUtil and C_StringUtil.CreateNumericRuleFormatter and Enum and Enum.NumericRuleFormatRounding) then return nil end
-        -- %d throughout, matching the plain path and Blizzard's Truncate: %.0f rounds to
-        -- NEAREST, so 152s rendered "3m" and 3599s rendered "60m" one tick before flipping
-        -- to "1h".
+        -- %d throughout, matching the plain path: %.0f rounds to NEAREST, so 152s
+        -- rendered "3m" and 3599s rendered "60m" one tick before flipping to "1h".
+        -- (Rounding itself rides the breakpoint/component fields, not the directive.)
         local secFmt = (format == "SHORT" and "%ds") or (format == "FULL" and "%d Seconds")
                         or (format == "TIMER" and "%d") or "%d"
         local minFmt = (format == "FULL") and "%d Minutes" or "%dm"
@@ -826,11 +826,18 @@ local function BuildDurationFormatter(format, hideAboveT, colorByTime, alertMode
                                -- can be composed out of order; the pre-alert code
                                -- always emitted ascending, so keep that guarantee)
             -- Highest threshold <= remaining seconds wins.
+            -- ☠ Seconds-shaped bands (no components) round UP — a countdown's digit
+            -- means "at most this many seconds remain", so ceil gives each digit
+            -- exactly one second and the text ends "3, 2, 1, gone". The old floor +
+            -- min=1 pair clamped the sub-1s floor of 0 back to 1, so "1" rendered
+            -- for TWO seconds (field report). Component bands keep floor at the
+            -- breakpoint: their quotient rounding lives on the component itself.
             local function add(threshold, fstr, hex, components)
                 if colorByTime and hex then fstr = "|cff" .. hex .. fstr .. "|r" end
                 if glyphPfx and threshold < alertT then fstr = glyphPfx .. fstr end
                 cuts[threshold] = true
-                bands[#bands + 1] = { threshold = threshold, step = 1, rounding = down,
+                bands[#bands + 1] = { threshold = threshold, step = 1,
+                                      rounding = components and down or up,
                                       min = 1, format = fstr, components = components }
             end
             if alertMode == "TEXT" then
@@ -911,8 +918,11 @@ local function BuildDurationFormatter(format, hideAboveT, colorByTime, alertMode
         if not (C_StringUtil and C_StringUtil.CreateNumericRuleFormatter and Enum and Enum.NumericRuleFormatRounding) then return nil end
         local ok, f = pcall(function()
             local down = Enum.NumericRuleFormatRounding.Down
+            local up   = Enum.NumericRuleFormatRounding.Up
             local fmt = C_StringUtil.CreateNumericRuleFormatter()
-            fmt:AddBreakpoint({ threshold = 0,    step = 1, rounding = down, min = 1, format = "%d" })
+            -- Seconds band CEILS (see the NUMBER branch): the countdown must end
+            -- "3, 2, 1, gone", and floor + min=1 held the "1" for two seconds.
+            fmt:AddBreakpoint({ threshold = 0,    step = 1, rounding = up, min = 1, format = "%d" })
             fmt:AddBreakpoint({ threshold = PROMOTE_MIN, step = 1, rounding = down, format = "%d:%02d",
                                 components = { { div = 60 }, { mod = 60 } } })
             fmt:AddBreakpoint({ threshold = PROMOTE_HOUR, step = 1, rounding = down, format = "%dh",
@@ -932,8 +942,13 @@ local function BuildDurationFormatter(format, hideAboveT, colorByTime, alertMode
             local down = Enum.NumericRuleFormatRounding.Down
             local up   = Enum.NumericRuleFormatRounding.Up
             local fmt = C_StringUtil.CreateNumericRuleFormatter()
-            -- Seconds band truncates: 45.6s remaining is "45", same as the game.
-            fmt:AddBreakpoint({ threshold = 0, step = 1, rounding = down, min = 1, format = "%d" })
+            -- ☠ Seconds band CEILS, deliberately (field report: "3, 2, 1, 1, gone").
+            -- A countdown digit means "at most this many seconds remain": ceil shows
+            -- each digit for exactly one second and the text vanishes AT expiry. The
+            -- old floor ("45.6 is 45, like the game") + min=1 clamp made the sub-1s
+            -- floor of 0 render as a SECOND "1" — the lingering last second. min=1
+            -- stays as a guard against an exact-0.0 sample flashing "0".
+            fmt:AddBreakpoint({ threshold = 0, step = 1, rounding = up, min = 1, format = "%d" })
             -- ☠ THE QUOTIENT ROUNDS UP, and that is Blizzard's behaviour, not a preference.
             -- Their formatter sets SetCanRoundUpLastUnit(true), so 2m32s reads "3m" and
             -- 1h03m reads "63m" -- odd-looking, but it is what the game's own frames show,
@@ -966,13 +981,16 @@ local function BuildDurationFormatter(format, hideAboveT, colorByTime, alertMode
         curve:AddPoint(1 + mult * SECONDS_PER_HOUR, Enum.SecondsFormatterInterval.Hours)
         curve:AddPoint(1 + mult * SECONDS_PER_DAY,  Enum.SecondsFormatterInterval.Days)
         fmt:SetDefaultAbbreviation(abbrev)
-        -- ☠ THE TWO CALLS THIS PATH USED TO OMIT. Blizzard's own aura formatter sets
-        -- both; without them a SecondsFormatter defaults to SecondsFormatterRounding
-        -- .RoundUp (enum 0 — and Blizzard setting Truncate explicitly is itself evidence
-        -- the default is not Truncate), so 44.6s remaining rendered "45s" here while the
-        -- game's frames rendered "44s". Guarded: the setters are newer than the type.
+        -- ☠ Rounding is RoundUp, a DELIBERATE break from Blizzard's aura formatter
+        -- (theirs sets Truncate; an earlier cut copied that for parity, so 44.6s read
+        -- "44s" like the game). Reversed with the countdown fix: every DF seconds
+        -- display now ceils — a digit means "at most this many seconds remain", each
+        -- digit holds exactly one second and the text ends "3s, 2s, 1s, gone" instead
+        -- of Truncate's lingering last digit. This also keeps SHORT/FULL agreeing
+        -- with NUMBER at every instant (mixed formats on one frame never differ by 1).
+        -- Guarded: the setters are newer than the type.
         if fmt.SetRounding and Enum.SecondsFormatterRounding then
-            fmt:SetRounding(Enum.SecondsFormatterRounding.Truncate)
+            fmt:SetRounding(Enum.SecondsFormatterRounding.RoundUp)
         end
         if fmt.SetCanRoundUpLastUnit then fmt:SetCanRoundUpLastUnit(true) end
         fmt:SetMinInterval(Enum.SecondsFormatterInterval.Seconds)

--- a/DandersFrames/Features/PinnedFrames.lua
+++ b/DandersFrames/Features/PinnedFrames.lua
@@ -2836,7 +2836,17 @@ function PinnedFrames:Reinitialize()
     end
     if not anyEnabled then
         self.currentMode = GetActualMode()
-        DF:Debug("PINNED", "Reinitialize: skipped - no set enabled (mode now %s)",
+        -- ☠ SKIP THE REBUILD, NEVER THE TEARDOWN. anyEnabled is answered from the NEW
+        -- mode's sets, so the one case it is false in a mode CHANGE is precisely the one
+        -- where old-mode frames are on screen with nothing left to hide them: a raid-only
+        -- set enabled, you leave the raid, the party side has nothing enabled, and this
+        -- returned before any cleanup -- leaving the raid container up until a reload
+        -- ("Raid - Pinned Frame still can get stuck on screen after exiting a raid",
+        -- Aphoex, 5.2.0-alpha.1). The bail exists to skip WORK (the 270ms-per-arena-entry
+        -- fix), and pruning is not that work: it walks MAX_SETS once, hides by name, and
+        -- defers its protected writes to regen on its own.
+        self:PruneOrphanedSets()
+        DF:Debug("PINNED", "Reinitialize: skipped - no set enabled (mode now %s), pruned",
             tostring(self.currentMode))
         return
     end

--- a/DandersFrames/Features/SecureSort.lua
+++ b/DandersFrames/Features/SecureSort.lua
@@ -3764,26 +3764,18 @@ function SecureSort:CalculateRaidGroupPosition(groupNum, posInGroup, playersInGr
 
     local retY = -yDown
 
-    -- Test-mode CENTER compensation (mirrors DF:ComputeRaidContainerCompensation, #867).
-    -- The secure snippet centres visible groups in the full-grid container via
-    -- (totalDim - populatedDim)/2; on LIVE the raid container is then shifted by the
-    -- same magnitude (relative to a single-populated-row reference) so the visible
-    -- content does not drift as the roster grows. That container shift lives in
-    -- DF:UpdateRaidContainerPosition and is applied to DF.raidContainer only — the
-    -- test container (DF.testRaidContainer) is intentionally left uncompensated. So in
-    -- test mode the frames carry the snippet's centring offset but nothing cancels the
-    -- drift, leaving test CENTER disagreeing with live whenever popRows > 1. Fold the
-    -- identical shift into the test frame offsets here (equivalent to shifting the
-    -- container, and keeping the test mover/centroid at the saved anchor exactly like
-    -- live). Gated on lp.testMode so the live sorting-disabled Lua path -- which uses the
-    -- already-compensated raidContainer -- is untouched.
-    if lp.testMode and groupAnchor == "CENTER" and popRows > 1 then
-        if horizontal then
-            retY = retY + (groupH - populatedHeight) / 2
-        else
-            x = x + (groupW - populatedWidth) / 2
-        end
-    end
+    -- ═══ RETIRED 2026-08-15: the lp.testMode CENTER compensation block (#867). ═══
+    -- It folded the container's CENTER shift into TEST FRAME offsets because the test
+    -- container was "intentionally left uncompensated" while live's container carried
+    -- the shift. That split accounting is what made the unlock overlay unfaithful:
+    -- the mover was sized/positioned from the container, and in test mode the frames
+    -- drifted half a group-row out of the box it drew (Aphoex, 2026-08-15,
+    -- groups-per-row < 8). The compensation now lives in exactly ONE place —
+    -- DF:UpdateRaidContainerPosition applies ComputeRaidContainerCompensation (now
+    -- test-aware) to the live container, the TEST container and the MOVER alike — so
+    -- this calculator returns raw grid offsets in every mode and the preview differs
+    -- from live in data only. ⚠ lp.testMode itself STAYS: PositionRaidFrameToGroupSlot
+    -- still reads it for the playerAnchor=END BOTTOMLEFT mirror (#875).
 
     return x, retY
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -730,98 +730,46 @@ end
 -- `_cf` is accepted and ignored ON PURPOSE — callers still hand over the
 -- candidateFilters, and the underscore is there so the next reader sees the omission
 -- as a decision rather than an oversight to fix.
--- ★ PER-RECORD identity dependence, for the PARK path -- distinct from
--- filterVulnerableToIdentityGate above, which answers "does this whole HELPFUL pool
--- fail open" and drives the HIDE path.
+-- ═══ RETIRED 2026-08-15: the four-boolean debuff park (RecordIdentityGated) ═══
 --
--- This one answers "is this record's CATEGORISATION only as good as the identity data",
--- and it covers HARMFUL rows, which the hide path deliberately does not.
--- ☠ Blizzard's two rules run in OPPOSITE directions
--- (Blizzard_AuraContainerUtil.CanApplyIdentityCandidateFilters):
---   helpful: spell-ID filters skipped when you CANNOT assist
---   harmful: spell-ID filters skipped when you CAN assist
--- which is why spell-ID filters are NOT what this keys on -- see GATED_CANDIDATE_KEYS.
--- ☠ The four category booleans count too. They sit outside Blizzard's identity block,
--- but IsRoleAura / IsPriorityDebuff read auraData.spellId to answer, so a record built on
--- them is only as trustworthy as the identity data behind it -- which is why a peer parks
--- exactly these four on their debuff rows and nothing else.
--- ☠ Token-only records (CROWD_CONTROL / RAID / dispel) are NOT gated: they are answered
--- by the filter string, need no identity, and parking them would empty the row. That
--- distinction is the whole reason this is per-record rather than per-container.
--- ☠ THE FOUR CATEGORY BOOLEANS ONLY. Spell-ID filters are deliberately NOT here,
--- for two independent reasons, either of which is disqualifying:
---   1. applyDebuffBlacklist stamps excludeSpellIDs onto EVERY debuff record as soon as
---      one Optional Debuff is configured. Including it would flag the whole row as
---      gated and park all of it -- exactly the wholesale blanking this design exists to
---      avoid, arriving through a back door.
---   2. It would be the wrong DIRECTION anyway. For a harmful aura Blizzard skips
---      spell-ID filters when you CAN assist, so they do not fail open when trust is
---      lost -- they start working. Parking on loss of trust would hide the record
---      precisely when its filtering became reliable.
--- The booleans are the real exposure: IsRoleAura / IsPriorityDebuff answer from
--- auraData.spellId, so their categorisation is only as good as the identity data behind
--- it, and a mis-categorised aura lands in the wrong record or none. That is why the peer
--- this mirrors parks exactly these four records on its debuff row and nothing else.
+-- It parked records asserting isBossAura / isBossOrRoleAura / isRoleAura / isPriorityAura
+-- whenever unit trust was lost. Removed because the engine never skips those filters, so
+-- there was no failure for it to prevent — only rows it could empty by mistake, which is
+-- what it did (dispel overlay lit with no debuff icon under it, two testers on 5.1.3).
 --
--- ☠☠☠ THE PARAGRAPH ABOVE DOES NOT MATCH THE ENGINE. Read from the shipped client
--- (Blizzard_AuraContainer/Blizzard_AuraContainerUtil.lua, DoesAuraPassCandidateFilters):
--- ONLY `excludeSpellIDs` and `includeSpellIDs` sit inside the
--- `if CanApplyIdentityCandidateFilters(...)` block. isBossAura, isBossOrRoleAura,
--- isRoleAura, isPriorityAura AND isFromPlayerOrPlayerPet are all evaluated AFTER it,
--- unconditionally. They are never skipped, so they never fail open, so there is nothing
--- for this park to protect against on those four keys.
--- ⚠ And the categorisation cannot be poisoned the way the paragraph claims: the engine
--- evaluates AuraUtil.IsRoleAura / IsPriorityDebuff itself, with the real auraData. It is
--- OUR Lua that cannot read spellId, not Blizzard's.
--- ⚠ There is also a THIRD exit we model nowhere: a spell whose
--- C_Secrets.GetSpellAuraSecrecy is Enum.SecrecyLevel.NeverSecret returns true from
--- CanApplyIdentityCandidateFilters regardless of assistability, so spell-ID filters keep
--- working on it in both directions. (DF already knows this set exists -- see
--- AuraBlacklist/Config.lua, ~62 IDs -- it just is not consulted here.)
--- ⇒ The park is guarding a mechanism that does not exist, which is one more reason it kept
--- emptying rows it should not. NOT removed here: that is a behaviour change on the debuff
--- row and wants Krathe's call plus an in-game check, not a quiet deletion inside an
--- unrelated fix. Do not "improve" this list until that decision is made.
+-- The three findings that settled it, all from the shipped client
+-- (Blizzard_AuraContainer/Blizzard_AuraContainerUtil.lua):
+--   1. In DoesAuraPassCandidateFilters, ONLY `includeSpellIDs` and `excludeSpellIDs` sit
+--      inside the `if CanApplyIdentityCandidateFilters(...)` block. All four booleans —
+--      and isFromPlayerOrPlayerPet — are evaluated after it, unconditionally.
+--   2. The categorisation cannot be poisoned by lost identity: the ENGINE evaluates
+--      AuraUtil.IsRoleAura (which reads auraData.isTank/isHealer/isDPSRoleAura, not
+--      spellId) and IsPriorityDebuff (a securecallfunction with the real ID). It is our
+--      Lua that cannot read spellId, not Blizzard's.
+--   3. Even under the one assumption source cannot settle — that those auraData fields
+--      might be unpopulated for an untrusted unit — each is applied as an EQUALITY test,
+--      so `nil ~= true` rejects and `nil ~= false` rejects. Both directions fail CLOSED.
+--      There is no direction in which they leak, therefore none in which parking helps.
 --
--- ☠☠ ASSERTED (`true`), NEVER MERELY MENTIONED. This tested `~= nil`, and `false ~= nil`
--- is true — so every record carrying a category boolean as a DEDUP SUBTRACTION counted as
--- identity-gated. BuildDirectDebuffFilters' notImportant() stamps isBossOrRoleAura=false
--- and isPriorityAura=false onto the CC, Raid, Dispellable and Non-Player records purely so
--- they do not re-render what the important records already claimed, so with Boss/Role or
--- Priority enabled -- the default -- EVERY record in the row was gated and a loss of trust
--- parked the lot to maxFrameCount 0. That is the wholesale blanking the note above says
--- this design exists to avoid, arriving through the dedup flags instead of the spell-ID
--- back door it was watching. Field symptom: the dispel OVERLAY fires (its own container
--- carries no category booleans, so it never parks) while the debuff row shows nothing,
--- intermittently, because trust follows unit assistability. Reported by two testers on
--- 5.1.3, the build the park shipped in.
+-- ⚠ We inherited the belief from a peer, which marks the identical four "identity-gated".
+-- VuhDo, which reached the same overall design independently, parks the opposite side:
+-- HELPFUL records carrying spell-ID filters, and never gates harmful at all. That is the
+-- keying the API supports, and it is what gatedGroupKeys carries now.
+-- ☠ HARMFUL must never take a TRANSIENT park: for a harmful aura the engine skips spell-ID
+-- filters when you CAN assist, so on a friendly they are permanently dead, not
+-- intermittently — parking on that would park forever.
 --
--- The distinction is membership vs subtraction. `= true` means "this record's CONTENTS are
--- defined by a categorisation that reads spellId" — untrustworthy identity makes the whole
--- record meaningless, so park it. `= false` only removes what a sibling claimed: with
--- identity lost, an aura may be wrongly subtracted, but the rest of the record is still
--- real, and showing most of a row beats showing none of it.
-local GATED_CANDIDATE_KEYS = {
-    "isBossAura", "isBossOrRoleAura", "isRoleAura", "isPriorityAura",
-}
-function AuraContainer.RecordIdentityGated(cf)
-    if type(cf) ~= "table" then return false end
-    for i = 1, #GATED_CANDIDATE_KEYS do
-        -- ☠ == true, NOT ~= nil. A record REQUIRING one of these categories depends on
-        -- identity data; a record carrying `= false` is the OPPOSITE — the important-first
-        -- subtraction that BuildDirectDebuffFilters stamps onto every token record (cc /
-        -- raid / dispel / nonplayer) whenever boss/role/priority categories are also on.
-        -- Counting those meant every record in the row was "gated" and the park emptied
-        -- the whole row on lost trust — the exact wholesale blanking the park's own header
-        -- calls a far worse failure than the leak. Field sign: dispel overlay lit (its
-        -- slots are separate and never parked) with no debuff icon under it, amplified by
-        -- the other records excluding dispellable types in favour of the parked dispel
-        -- record. Subtraction is also SAFE on lost trust: the equality test just rejects
-        -- flagged auras, and boss/priority flags are not caster-attribution data.
-        if cf[GATED_CANDIDATE_KEYS[i]] == true then return true end
-    end
-    return false
-end
+-- ═══════════════════════════════════════════════════════════════════════════════
+--
+-- ⚠ HISTORY, kept because it is the reason to distrust a "one-character fix". The park
+-- first tested `~= nil` rather than `== true`, and `false ~= nil` is true — so the dedup
+-- subtractions BuildDirectDebuffFilters stamps onto every token record (isBossOrRoleAura
+-- = false etc.) counted as gated, and losing trust emptied the ENTIRE debuff row. That was
+-- corrected to `== true` on 2026-08-14 and the row stopped blanking, which read as a fix
+-- and was really a mitigation: the predicate was still wrong, just less often. Both
+-- Danders and I wrote that one-liner independently the same day and neither of us went on
+-- to ask whether the four keys belonged there at all. A change that makes the symptom go
+-- away is the easiest place to stop looking.
 
 local function filterSourceRelative(filterString, _cf)
     if type(filterString) == "string" then
@@ -3084,11 +3032,19 @@ function NativeBackend:build()
                 if okGroup then
                     self.groupKeys[#self.groupKeys + 1] = key
                     self.groupStyles[key] = rec.style
-                    -- Remember which groups the identity park applies to (see
-                    -- AuraContainer.RecordIdentityGated). Per KEY, so token records stay
-                    -- live while the identity-dependent ones park.
+                    -- Remember which groups the identity park applies to. Per KEY, so
+                    -- token records stay live while the identity-dependent ones park.
+                    -- ☠ THE PREDICATE IS `filterVulnerableToIdentityGate`, i.e. exactly the
+                    -- records whose filters the ENGINE can skip: HELPFUL pools carrying
+                    -- include/excludeSpellIDs. It used to be RecordIdentityGated -- four
+                    -- category booleans on the DEBUFF row -- which the engine applies
+                    -- unconditionally (Blizzard_AuraContainerUtil: only the two spell-ID
+                    -- keys sit inside CanApplyIdentityCandidateFilters). Those booleans
+                    -- also fail CLOSED in both directions -- the test is an equality, so an
+                    -- unpopulated field rejects rather than passes -- so there was never a
+                    -- leak for that park to prevent, only rows it could empty by mistake.
                     self.gatedGroupKeys = self.gatedGroupKeys or {}
-                    self.gatedGroupKeys[key] = AuraContainer.RecordIdentityGated(cf) or nil
+                    self.gatedGroupKeys[key] = filterVulnerableToIdentityGate(f, cf) or nil
                 else
                     DF:DebugWarn(DBG, "AddAuraGroup failed: %s", tostring(err))
                 end
@@ -3385,6 +3341,10 @@ function NativeBackend:applyGroupTuning()
     local wasSourceRel  = self.handle._idGateSourceRelative
     self.handle._idGateVulnerable = nil
     self.handle._idGateSourceRelative = nil
+    -- ☠ REBUILT HERE TOO, or a string-only delta leaves the park set describing the
+    -- PREVIOUS filters. Same reason the vulnerability flag is recomputed on this path:
+    -- filter strings can now change without a rebuild, and the park keys off the string.
+    self.gatedGroupKeys = nil
     for i, rec in ipairs(normalizeFilters(config.filter)) do
         local key = rec.key or ("df" .. i)
         local cf = recordCandidateFilters(rec, config)
@@ -3396,6 +3356,12 @@ function NativeBackend:applyGroupTuning()
         -- always rebuilt, and build() recomputed the flag.)
         if filterVulnerableToIdentityGate(rec.f, cf) then
             self.handle._idGateVulnerable = true
+            -- ★ THE PARK SET IS THE SAME VERDICT, PER KEY. One record being vulnerable
+            -- used to mark the whole HANDLE and hide every row it owned; now only the
+            -- records the engine can actually skip go dark, and their token siblings
+            -- keep rendering.
+            self.gatedGroupKeys = self.gatedGroupKeys or {}
+            self.gatedGroupKeys[key] = true
         end
         if filterSourceRelative(rec.f, cf) then
             self.handle._idGateSourceRelative = true
@@ -3429,7 +3395,14 @@ function NativeBackend:applyGroupTuning()
         -- wins the one slot) are tunable. Same nil-CLEARS semantics as the group setter.
         for key in pairs(self.slotButtons) do
             if fsByKey[key] and c.SetAuraSlotFilterString then
-                if not pcall(c.SetAuraSlotFilterString, c, key, fsByKey[key]) then
+                -- ★ IDENTITY PARK, slot flavour. A slot has no maxFrameCount, so the park
+                -- is an EMPTY filter string — the same lever SlotHandle:_pushFilter uses,
+                -- and the one VuhDo uses for the same purpose. Without this the park
+                -- reached group-backed rows only, and a slot-backed row kept falling back
+                -- to the whole-handle hide it is meant to replace.
+                local parked = self.handle._idGateParked
+                    and self.gatedGroupKeys and self.gatedGroupKeys[key]
+                if not pcall(c.SetAuraSlotFilterString, c, key, parked and "" or fsByKey[key]) then
                     fsMissing = fsMissing or key
                 end
             end
@@ -5190,7 +5163,22 @@ function Handle:_applyIdentityGate()
                     self:_noteGateRecovery(can)
                     -- ☠ NOT `and not isOwn` — see the block above. Cinematics are the
                     -- latch's job; this branch is what covers a vehicle.
-                    if not can and self._idGateVulnerable then hide = true end
+                    --
+                    -- ★★ HIDE IS NOW THE FALLBACK, NOT THE RESPONSE. The park below empties
+                    -- exactly the records the engine can skip and leaves their siblings
+                    -- rendering; hiding empties the handle. Since ONE vulnerable record
+                    -- marks the whole handle (see the build loop), the old behaviour blanked
+                    -- a buff row's token groups because an unrelated spell-ID group sat
+                    -- beside them — over-hiding, and the opposite of what the gate is for.
+                    -- So hide only when the park cannot express it: no gated keys were
+                    -- registered at all, which means a build shape the park does not cover.
+                    -- ⚠ Deliberately NOT removed outright. If AddAuraGroup failed, or a
+                    -- consumer produced a handle with no keys, the vulnerable pool would
+                    -- otherwise render fully open with nothing suppressing it — the leak
+                    -- this whole mechanism exists to stop. Fallback, not dead code.
+                    if not can and self._idGateVulnerable and not self:_hasGatedGroups() then
+                        hide = true
+                    end
                 end
             end
             -- (2) Not in your visible world (different instance/phase): the

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -1271,6 +1271,14 @@ local function styleButton_regions(slot, config)
             -- what makes a holder around it safe.
             -- ☠ Hidden ONCE at creation, strictly before the bind — after that the engine
             -- owns Shown and we must never touch it.
+            -- ☠ STAMP WANTED-NESS, because the HOLDER OUTLIVES THE SETTING. The holder is
+            -- create-once and merely hidden when the cue is switched off, so its existence
+            -- says nothing about whether the user still wants it -- and armTestPandemicWindow
+            -- runs from a timer that fires long after this pass. Without this stamp the
+            -- pending re-arm re-Show()s a holder this pass just hid, once per fake cycle,
+            -- forever: "pandemic still loops in the frame even if it's disabled, only a
+            -- reload fixes it" (Aphoex, 5.2.0-alpha.1). Guard the EFFECT, not the shape.
+            slot._dfBorderPandemicWanted = (borderSpec.pandemicSpec and DF.Border) and true or false
             if borderSpec.pandemicSpec and DF.Border then
                 if not slot.dfBorderPandemicHolder then
                     slot.dfBorderPandemicHolder = makeHolder(host, LEVELS.PANDEMIC_BORDER)
@@ -1551,6 +1559,11 @@ local function styleButton_regions(slot, config)
     if isRow and not pdSpec and slot.dfPandemicHolder and not slot.AddPandemicRegion then
         slot.dfPandemicHolder:Hide()
     end
+    -- ☠ Companion to the hide above, and the half that survives a TIMER. Hiding here only
+    -- wins until armTestPandemicWindow's pending C_Timer fires and shows it again, which
+    -- is why switching the cue off in test mode looked like it did nothing until a reload.
+    -- See the matching stamp on the border twin.
+    slot._dfPandemicWanted = pdSpec and true or false
     -- ☠ THE SAME SWEEP, GENERALIZED — every other create-once region. The pandemic
     -- note above predicted this class ("every OTHER create-once region relies on
     -- 'off = never created'"), and the 5.1.1 self-contained test mode made it real:
@@ -3802,7 +3815,16 @@ local PANDEMIC_PREVIEW_OPEN_AT = 0.7
 -- feature on one duration and must open and close together, or the preview says the two
 -- behave differently when live drives them from the same engine window.
 local function armTestPandemicWindow(handle, slot, d, gen, elapsed)
-    local h1, h2 = slot.dfPandemicHolder, slot.dfBorderPandemicHolder
+    -- ☠ WANTED, not merely PRESENT. Both holders are create-once and only hidden when the
+    -- cue is switched off, so testing for the object asked "was this ever configured?"
+    -- when the question is "is it configured NOW". The style pass hid the holder and this
+    -- timer showed it straight back, once per fake cycle, until a reload.
+    local h1 = slot._dfPandemicWanted and slot.dfPandemicHolder or nil
+    local h2 = slot._dfBorderPandemicWanted and slot.dfBorderPandemicHolder or nil
+    -- Anything switched off since the last pass is hidden here rather than left wherever
+    -- the previous cycle happened to leave it.
+    if slot.dfPandemicHolder and not h1 then slot.dfPandemicHolder:Hide() end
+    if slot.dfBorderPandemicHolder and not h2 then slot.dfBorderPandemicHolder:Hide() end
     if not (h1 or h2) then return end
     local function setShown(shown)
         if h1 then h1:SetShown(shown) end
@@ -3821,16 +3843,29 @@ local function armTestPandemicWindow(handle, slot, d, gen, elapsed)
     end)
 end
 
--- One re-arm per aura cycle, scheduled exactly at expiry — no polling. Mutating the
--- shared duration restarts bar, swipe and text together (proven in the lab), so this
--- is the ONLY Lua the native preview costs. `gen` invalidates pending re-arms across
--- a repaint/teardown: every paint bumps slot._dfTestGen, and a stale closure returns.
+-- One re-arm per aura cycle, scheduled exactly at expiry — no polling. `gen` invalidates
+-- pending re-arms across a repaint/teardown: every paint bumps slot._dfTestGen, and a
+-- stale closure returns.
+--
+-- ☠ THE DURATION OBJECT DOES NOT CARRY THE SWIPE. This used to claim that mutating the
+-- shared duration "restarts bar, swipe and text together (proven in the lab)". The bar and
+-- text, yes -- they are bound to _dfTestDurObj. The swipe is NOT: slot.dfCD is a
+-- DF-created CooldownFrame driven by SetCooldown, and nothing here re-drove it, so it ran
+-- its first cycle and then sat empty while the bar kept looping ("cooldown swipe only
+-- shows once, doesn't loop" -- Aphoex, 5.2.0-alpha.1). The fallback lane had always called
+-- SetCooldown; only the native lane assumed the duration object covered it.
+-- ⚠ Whoever verified that claim watched the bar and read the swipe's first cycle as proof.
 local function scheduleTestRearm(handle, slot, d, gen, delay)
     C_Timer.After(delay, function()
         if handle._destroyed or slot._dfTestGen ~= gen then return end
         if not AuraContainer._testMode or not slot._dfTestDurObj then return end
         local ok = pcall(function() slot._dfTestDurObj:SetTimeFromStart(GetTime(), d) end)
         if ok then
+            -- Re-drive the swipe on the same edge as the duration, or it loops out of step
+            -- with the bar it is supposed to be showing the same countdown as.
+            if slot.dfCD and slot.dfCD.SetCooldown then
+                pcall(slot.dfCD.SetCooldown, slot.dfCD, GetTime(), d)
+            end
             -- The cycle restarted, so the refresh window closed with it.
             armTestPandemicWindow(handle, slot, d, gen, 0)
             scheduleTestRearm(handle, slot, d, gen, d)
@@ -3970,6 +4005,15 @@ function Handle:_paintTestSlot(slot, index)
                 slot._dfTestText, slot._dfTestTextAt = nil, nil
                 slot._dfTestTimed = true
                 nativeBar = slot.dfBar and true or false
+                -- ☠ SEED THE SWIPE HERE TOO. "The C side owns bar, swipe and text" is true
+                -- of the NATIVE regions armTestDuration bound; slot.dfCD is a DF-created
+                -- CooldownFrame and is not one of them. Only the fallback lane below ever
+                -- called SetCooldown, so on the native lane the swipe was driven by
+                -- whatever a previous pass left on it. Matches the re-drive in
+                -- scheduleTestRearm; both are needed or the first cycle and the rest differ.
+                if slot.dfCD and slot.dfCD.SetCooldown then
+                    pcall(slot.dfCD.SetCooldown, slot.dfCD, GetTime() - offset, d)
+                end
                 armTestPandemicWindow(self, slot, d, slot._dfTestGen, offset)
                 scheduleTestRearm(self, slot, d, slot._dfTestGen, d - offset)
             else

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -690,9 +690,48 @@ end
 -- buffs), so hiding them would hide truth, not garbage. HARMFUL pools are out
 -- of scope (their gate is UnitCanAttack — owned by the debuff-filtering work).
 local GATED_CATEGORY_TOKENS = { BIG_DEFENSIVE = true, EXTERNAL_DEFENSIVE = true }
+
+-- ★ THE NeverSecret EXEMPTION, and why it is EXCLUDE-ONLY. The engine's identity gate has
+-- a per-AURA escape hatch (Blizzard_AuraContainerUtil, checked FIRST and it wins outright):
+-- a spell whose C_Secrets.GetSpellAuraSecrecy is NeverSecret stays filterable on any unit —
+-- that is how Blizzard itself drops Exhaustion/Sated from friendly frames.
+--   * An excludeSpellIDs pool whose ENTIRE set is NeverSecret can never change behaviour
+--     on lost trust: the excluded auras keep hitting the exclude test (their exemption
+--     holds the gate open for THEM), and every other aura was never excluded anyway. Same
+--     output in both trust states ⇒ genuinely not vulnerable ⇒ parking it would hide
+--     correct data for nothing. This also honours the 2026-07-18 uniform-blackout call
+--     better than the blackout did: the buffs the user chose to hide STAY hidden.
+--   * ☠ An includeSpellIDs pool can NEVER take this exemption, whatever its map holds.
+--     The leak is not the mapped spells — it is every OTHER secret helpful aura on the
+--     unit skipping the include test and pouring in. The exemption is a property of the
+--     AURA being tested, not of our map. Do not "symmetrise" this.
+-- Secrecy is a static DB2 property, so one session cache; pcall + guards because the
+-- C_Secrets surface is 12.x-only and a probe failure must degrade to "vulnerable"
+-- (park too much, never leak).
+local auraSecrecyCache
+local function excludeSetAllNeverSecret(map)
+    local CS = C_Secrets
+    if not (CS and CS.GetSpellAuraSecrecy and Enum and Enum.SecrecyLevel) then return false end
+    local never = Enum.SecrecyLevel.NeverSecret
+    auraSecrecyCache = auraSecrecyCache or {}
+    for id in pairs(map) do
+        local v = auraSecrecyCache[id]
+        if v == nil then
+            local ok, s = pcall(CS.GetSpellAuraSecrecy, id)
+            v = (ok and s == never) or false
+            auraSecrecyCache[id] = v
+        end
+        if not v then return false end
+    end
+    return true
+end
+
 local function filterVulnerableToIdentityGate(filterString, cf)
     if type(filterString) ~= "string" or not filterString:find("HELPFUL") then return false end
-    if cf and (cf.includeSpellIDs or cf.excludeSpellIDs) then return true end
+    if cf and cf.includeSpellIDs then return true end
+    if cf and cf.excludeSpellIDs and not excludeSetAllNeverSecret(cf.excludeSpellIDs) then
+        return true
+    end
     for token in filterString:gmatch("[^|%s]+") do
         if GATED_CATEGORY_TOKENS[(token:gsub("^!", ""))] then return true end
     end
@@ -2992,6 +3031,16 @@ function NativeBackend:build()
                 if okSlot and btn then
                     pcall(btn.SetAllPoints, btn, handle.frame)
                     self.slotButtons[key] = btn
+                    -- ☠ PARK KEYS AT BIRTH, mirroring the group branch. The tuning path
+                    -- rebuilds this set, but tuning only runs after something changes — a
+                    -- slot-backed handle built while trusted would meet its FIRST trust
+                    -- loss with no gated keys, and the hide fallback (gated on
+                    -- _hasGatedGroups()==false) would blank the whole handle on exactly
+                    -- the transition the park exists to narrow.
+                    if filterVulnerableToIdentityGate(f, cf) then
+                        self.gatedGroupKeys = self.gatedGroupKeys or {}
+                        self.gatedGroupKeys[key] = true
+                    end
                 elseif not okSlot then DF:DebugWarn(DBG, "AddAuraSlot failed: %s", tostring(btn)) end
             elseif isSingleSlot then
                 -- Same declaration as the overlay branch, different GEOMETRY: an
@@ -3012,6 +3061,11 @@ function NativeBackend:build()
                     pcall(btn.ClearAllPoints, btn)
                     pcall(btn.SetPoint, btn, fa, c, fa, 0, handle._flowPadY or 0)
                     self.slotButtons[key] = btn
+                    -- Park keys at birth — see the overlay branch above for why.
+                    if filterVulnerableToIdentityGate(f, cf) then
+                        self.gatedGroupKeys = self.gatedGroupKeys or {}
+                        self.gatedGroupKeys[key] = true
+                    end
                 elseif not okSlot then
                     DF:DebugWarn(DBG, "AddAuraSlot (single-slot row) failed: %s", tostring(btn))
                 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5078,11 +5078,45 @@ function Handle:_setDeathLatch(on)
     end
 end
 
+-- ============================================================
+-- GATE EVENT LOG — always on, persistent, transitions only
+-- ============================================================
+-- Every gate flip lands in DandersFramesDB_v2.gateLog whether or not the debug
+-- console is enabled — a field report ("my HoTs vanished in the BG") arrives
+-- AFTER the fact, and the console is off for every user who isn't already
+-- chasing a bug. Transitions are rare (a handful per fight), so an always-on
+-- ring is cheap; the ring caps itself so an hour-long battleground cannot grow
+-- it unbounded. `/df debug idgate` prints the tail. When the console IS on the
+-- same line echoes there under the AURACONTAINER category, timestamped twice.
+-- ⚠ Only pass plain strings/numbers — a secret arg would taint the formatted
+-- line; the issecretvalue check below is the backstop, not a license.
+local GATE_LOG_CAP, GATE_LOG_KEEP = 300, 200
+local function GateLog(fmt, ...)
+    local ok, msg = pcall(string.format, fmt, ...)
+    if not ok then msg = tostring(fmt) end
+    if issecretvalue and issecretvalue(msg) then msg = "<secret log arg>" end
+    local db = _G.DandersFramesDB_v2
+    if type(db) == "table" then
+        local log = db.gateLog
+        if type(log) ~= "table" then log = {}; db.gateLog = log end
+        log[#log + 1] = date("%m-%d %H:%M:%S  ") .. msg
+        if #log > GATE_LOG_CAP then
+            -- One-pass compaction to the newest KEEP (DebugConsole's overshoot idea):
+            -- never a per-line table.remove shift.
+            local keep = {}
+            for i = #log - (GATE_LOG_KEEP - 1), #log do keep[#keep + 1] = log[i] end
+            db.gateLog = keep
+        end
+    end
+    DF:Debug(DBG, "%s", msg)
+end
+AuraContainer.GateLog = GateLog   -- shared with the death-latch/cine writers below
+
 function Handle:_noteGateRecovery(can)
     local was = self._idGateAssist
     self._idGateAssist = can and true or false
     if was == false and self._idGateAssist then
-        DF:Debug("AURACONTAINER", "gate recovered for unit=%s - re-parsing (pool was fail-open)",
+        GateLog("recovered unit=%s - re-parsing (pool was fail-open)",
             tostring(self.config and self.config.unit))
         self:Refresh()
         -- AFTER the bounce, deliberately: the whole point of the cinematic latch
@@ -5127,16 +5161,19 @@ end
 -- every corpse in a wipe. They currently render unfiltered, so empty is the better
 -- failure — but it is a visible change, not a silent one.
 -- Fail-open on a refused or secret read, like every other probe in this gate.
+-- Returns the REASON string when identity data is unavailable, nil otherwise —
+-- truthy exactly when the old boolean was true, and the string feeds GateLog so
+-- a field log says WHICH probe broke trust, not just that one did.
 local function IdentityUnavailable(unit)
     local okC, connected = pcall(UnitIsConnected, unit)
     if okC and not (issecretvalue and issecretvalue(connected)) and connected == false then
-        return true
+        return "offline"
     end
     local okD, dead = pcall(UnitIsDeadOrGhost, unit)
     if okD and not (issecretvalue and issecretvalue(dead)) and dead == true then
-        return true
+        return "dead/ghost"
     end
-    return false
+    return nil
 end
 local function SelfIsUsingVehicle(unit)
     if not unit then return false end
@@ -5159,6 +5196,7 @@ end
 
 function Handle:_applyIdentityGate()
     local hide = false
+    local why   -- the FIRST probe that broke trust this pass, for the gate log
     -- ★ `_hasGatedGroups` widens the probe to rows that are not HIDE-vulnerable but do
     -- carry identity-dependent GROUPS -- i.e. the debuff row. Without it the assist probe
     -- never ran for those handles and the park verdict could never flip.
@@ -5206,12 +5244,16 @@ function Handle:_applyIdentityGate()
                     -- records the false, so leaving the vehicle is a real false→true edge
                     -- and re-parses. Setting `hide` alone would hide correctly and never
                     -- rebuild the pool.
-                    if can and SelfIsUsingVehicle(unit) then can = false end
+                    if can and SelfIsUsingVehicle(unit) then can = false; why = "self-vehicle" end
                     -- ★ Disconnected / dead / ghost — see IdentityUnavailable. Folded
                     -- into `can` like the vehicle probe, so a rez or a reconnect is a
                     -- real false→true edge and re-parses the pool rather than just
                     -- un-hiding a stale one.
-                    if can and not isOwn and IdentityUnavailable(unit) then can = false end
+                    if can and not isOwn then
+                        local unavail = IdentityUnavailable(unit)
+                        if unavail then can = false; why = unavail end
+                    end
+                    if not can and not why then why = "cannot-assist" end
                     -- Trust verdict for the PARK path (see the park block below).
                     self._idGateUntrusted = (can == false) or nil
                     self:_noteGateRecovery(can)
@@ -5243,7 +5285,7 @@ function Handle:_applyIdentityGate()
             if not hide and not isOwn and self._idGateSourceRelative then
                 local okv, vis = pcall(UnitIsVisible, unit)
                 if okv and not (issecretvalue and issecretvalue(vis)) and not vis then
-                    hide = true
+                    hide = true; why = why or "not-visible"
                 end
                 -- ☠ THE "/phase" HALF OF THE COMMENT ABOVE WAS NEVER IMPLEMENTED. A unit
                 -- in another phase, layer or Chromie time can be UnitIsVisible TRUE and
@@ -5257,12 +5299,15 @@ function Handle:_applyIdentityGate()
                 if not hide and UnitPhaseReason then
                     local okp, reason = pcall(UnitPhaseReason, unit)
                     if okp and not (issecretvalue and issecretvalue(reason)) and reason then
-                        hide = true
+                        hide = true; why = why or "phased"
                     end
                 end
             end
         end
     end
+    -- Stash for /df debug idgate: the reason column answers "why is this row
+    -- parked/hidden RIGHT NOW" without waiting for the next transition line.
+    self._idGateWhy = (hide or self._idGateUntrusted) and why or nil
     -- Transition only. "My cross-realm friend's auras vanished" produced no log at
     -- all before this: the gate is two pcall'ed probes with deliberate fail-open /
     -- fail-safe asymmetry, and which one tripped is the whole answer. Fires on a
@@ -5285,9 +5330,9 @@ function Handle:_applyIdentityGate()
         -- each gated group's maxFrameCount, so it has to be set before the call — which is
         -- why this cannot simply latch on success.
         self._idGateParked = newParked
-        DF:Debug(DBG, "identity park %s for unit=%s",
-            newParked and "PARKING gated groups" or "restoring gated groups",
-            tostring(self.config and self.config.unit))
+        GateLog("park %s unit=%s why=%s",
+            newParked and "ON (gated groups -> 0)" or "OFF (gated groups restored)",
+            tostring(self.config and self.config.unit), tostring(why or "-"))
         -- ApplyTuning is the LIVE setter path and reads _idGateParked, so this is one
         -- call rather than a rebuild.
         local ok = true
@@ -5306,16 +5351,17 @@ function Handle:_applyIdentityGate()
             -- sweep recomputes the verdict from live conditions each time, so it converges
             -- on whatever is true then rather than on what was true when it broke.
             self._idGateParked = prevParked
-            DF:DebugWarn(DBG, "identity park apply FAILED for unit=%s — reverted, will retry",
-                tostring(self.config and self.config.unit))
+            GateLog("PARK APPLY FAILED unit=%s (combat=%s) — reverted, retries on next sweep",
+                tostring(self.config and self.config.unit),
+                tostring(InCombatLockdown and InCombatLockdown() or false))
         end
     end
 
     local newHidden = hide or nil
     if self._idGateHidden ~= newHidden then
-        DF:Debug("AURACONTAINER", "identity gate %s for unit=%s (vulnerable=%s sourceRelative=%s)",
-            newHidden and "HIDING" or "showing",
-            tostring(self.config and self.config.unit),
+        GateLog("hide %s unit=%s why=%s (vuln=%s srcRel=%s)",
+            newHidden and "ON" or "OFF",
+            tostring(self.config and self.config.unit), tostring(why or "-"),
             tostring(self._idGateVulnerable or false),
             tostring(self._idGateSourceRelative or false))
         self._idGateHidden = newHidden
@@ -6920,7 +6966,7 @@ function SlotHandle:_noteGateRecovery(can)
     end
     local c = self.owner and self.owner.container
     if not c or self._lastCandidateFilters == nil then return end
-    DF:Debug(DBG, "slot gate recovered for key=%s unit=%s - re-parsing (pool was fail-open)",
+    GateLog("slot recovered key=%s unit=%s - re-parsing (pool was fail-open)",
         tostring(self.key), tostring(self.owner and self.owner.unit))
     -- ☠ No native tuning setter runs in lockdown (see ApplyTuning). Queue the standard
     -- replay, which re-pushes candidates, verdict and filter together on the way out.
@@ -6940,6 +6986,7 @@ end
 
 function SlotHandle:_applyIdentityGate()
     local hide = false
+    local why   -- the FIRST probe that broke trust this pass, for the gate log
     if (self._idGateVulnerable or self._idGateSourceRelative) and not AuraContainer._testMode then
         local unit = self.owner and self.owner.unit
         -- ☠ See Handle:_applyIdentityGate — the `unit ~= "player"` exemption moved off
@@ -6961,12 +7008,16 @@ function SlotHandle:_applyIdentityGate()
                 if ok then
                     if issecretvalue and issecretvalue(can) then can = true end
                     -- ★ Boarding window — see SelfIsUsingVehicle and the Handle twin.
-                    if can and SelfIsUsingVehicle(unit) then can = false end
+                    if can and SelfIsUsingVehicle(unit) then can = false; why = "self-vehicle" end
                     -- ★ Disconnected / dead / ghost — see IdentityUnavailable. Folded
                     -- into `can` like the vehicle probe, so a rez or a reconnect is a
                     -- real false→true edge and re-parses the pool rather than just
                     -- un-hiding a stale one.
-                    if can and not isOwn and IdentityUnavailable(unit) then can = false end
+                    if can and not isOwn then
+                        local unavail = IdentityUnavailable(unit)
+                        if unavail then can = false; why = unavail end
+                    end
+                    if not can and not why then why = "cannot-assist" end
                     self:_noteGateRecovery(can)
                     if not can then hide = true end
                 end
@@ -6974,7 +7025,7 @@ function SlotHandle:_applyIdentityGate()
             if not hide and not isOwn and self._idGateSourceRelative then
                 local okv, vis = pcall(UnitIsVisible, unit)
                 if okv and not (issecretvalue and issecretvalue(vis)) and not vis then
-                    hide = true
+                    hide = true; why = why or "not-visible"
                 end
                 -- ☠ THE "/phase" HALF OF THE COMMENT ABOVE WAS NEVER IMPLEMENTED. A unit
                 -- in another phase, layer or Chromie time can be UnitIsVisible TRUE and
@@ -6988,18 +7039,20 @@ function SlotHandle:_applyIdentityGate()
                 if not hide and UnitPhaseReason then
                     local okp, reason = pcall(UnitPhaseReason, unit)
                     if okp and not (issecretvalue and issecretvalue(reason)) and reason then
-                        hide = true
+                        hide = true; why = why or "phased"
                     end
                 end
             end
         end
     end
+    -- Stash for /df debug idgate, mirroring the Handle.
+    self._idGateWhy = hide and why or nil
     local newHidden = hide or nil
     if self._gateHidden ~= newHidden then
         self._gateHidden = newHidden
-        DF:Debug(DBG, "slot identity gate %s for key=%s unit=%s",
-            newHidden and "HIDING" or "showing", tostring(self.key),
-            tostring(self.owner and self.owner.unit))
+        GateLog("slot %s key=%s unit=%s why=%s",
+            newHidden and "hide ON" or "hide OFF", tostring(self.key),
+            tostring(self.owner and self.owner.unit), tostring(why or "-"))
         self:_pushFilter()
     end
 end
@@ -7436,6 +7489,13 @@ idGateWatch:RegisterEvent("UNIT_EXITED_VEHICLE")
 -- relies on both for pet death detection (Frames/Pets.lua).
 idGateWatch:RegisterEvent("UNIT_FLAGS")
 idGateWatch:RegisterEvent("UNIT_CONNECTION")
+-- ★ Combat exit re-verifies the gate. A park/restore whose ApplyTuning failed IN combat
+-- reverts its flag and retries on the next sweep (see _applyIdentityGate) — but that
+-- retry needs a sweep to ride, and a post-fight lull can go minutes without one. Regen
+-- is the natural edge: it is exactly when every deferred container op flushes, and in
+-- a battleground (where trust flips constantly — deaths, releases, rezzes) combat
+-- drops often enough to make this the reliable repair lane.
+idGateWatch:RegisterEvent("PLAYER_REGEN_ENABLED")
 local gateSweepQueued
 
 -- ☠ THIS FILTER MUST MATCH _applyIdentityGate's OWN CONDITION, TERM FOR TERM. It did not:
@@ -7463,6 +7523,10 @@ end
 function AuraContainer.SetUnitDeathLatched(unit, on)
     if type(unit) ~= "string" then return end
     if AuraContainer._testMode then return end
+    -- Transition-driven (dfLastKnownDead edges in Frames/Update.lua), so one line
+    -- per real death/rez — the gate log's densest writer in a battleground, and
+    -- exactly the edge the missing-HoTs class turned on.
+    GateLog("death latch %s unit=%s", on and "ON" or "OFF", unit)
     for h in pairs(AuraContainer._handles or {}) do
         if not h._destroyed and h.config and h.config.unit == unit
             and not h.config.parentDrivenVisibility then
@@ -7607,7 +7671,7 @@ cineWatch:SetScript("OnEvent", function(_, event)
         -- the clear and the fallback timer while the gate guard suppresses the
         -- recovery edge — a latch stuck until reload.
         if AuraContainer._testMode then return end
-        DF:Debug(DBG, "cinematic start (%s): latching vulnerable pools", event)
+        GateLog("cinematic start (%s): latching vulnerable pools", event)
         CineLatchAll(true)
         return
     end
@@ -7631,7 +7695,7 @@ cineWatch:SetScript("OnEvent", function(_, event)
     local gen = cineGen
     C_Timer.After(3, function()
         if gen == cineGen then
-            DF:Debug(DBG, "cinematic latch fallback: showing whatever is still held")
+            GateLog("cinematic latch fallback: showing whatever is still held")
             CineLatchAll(false)
         end
     end)
@@ -7694,14 +7758,14 @@ function AuraContainer.DebugDumpIdentityGate()
             if h._idGateUntrusted then parkedTxt = parkedTxt .. "(untrusted)" end
             local gatedN = 0
             for _ in pairs((h.backend and h.backend.gatedGroupKeys) or {}) do gatedN = gatedN + 1 end
-            print(("    " .. DF.OUT.SECTION .. "%d|r mode=%s unit=%s filter=%s inc=%s exc=%s vuln=%s srcRel=%s exists=%s canAssist=%s vis=%s gateHidden=%s parked=%s gatedGroups=%d cine=%s death=%s assist=%s intent=%s shown=%s retry=%s"):format(
+            print(("    " .. DF.OUT.SECTION .. "%d|r mode=%s unit=%s filter=%s inc=%s exc=%s vuln=%s srcRel=%s exists=%s canAssist=%s vis=%s gateHidden=%s parked=%s why=%s gatedGroups=%d cine=%s death=%s assist=%s intent=%s shown=%s retry=%s"):format(
                 n, tostring(cfg.mode or "row"), tostring(unit),
                 table.concat(fParts, "&"), tostring(inc), tostring(exc),
                 tostring(h._idGateVulnerable or false),
                 tostring(h._idGateSourceRelative or false),
                 tostring(type(unit) == "string" and UnitExists(unit) or false), canTxt, visTxt,
                 tostring(h._idGateHidden or false),
-                parkedTxt, gatedN,
+                parkedTxt, tostring(h._idGateWhy or "-"), gatedN,
                 tostring(h._cineLatched or false),
                 tostring(h._deathLatched or false),
                 tostring(h._idGateAssist),
@@ -7734,13 +7798,14 @@ function AuraContainer.DebugDumpIdentityGate()
                 elseif issecretvalue and issecretvalue(can) then canTxt = "SECRET"
                 else canTxt = tostring(can) end
             end
-            print(("    " .. DF.OUT.SECTION .. "S%d|r key=%s unit=%s vuln=%s srcRel=%s canAssist=%s gateHidden=%s parked=%s cine=%s death=%s assist=%s filter=%s"):format(
+            print(("    " .. DF.OUT.SECTION .. "S%d|r key=%s unit=%s vuln=%s srcRel=%s canAssist=%s gateHidden=%s parked=%s why=%s cine=%s death=%s assist=%s filter=%s"):format(
                 sn, tostring(s.key), tostring(unit),
                 tostring(s._idGateVulnerable or false),
                 tostring(s._idGateSourceRelative or false),
                 canTxt,
                 tostring(s._gateHidden or false),
                 tostring(s.parked or false),
+                tostring(s._idGateWhy or "-"),
                 tostring(s._cineLatched or false),
                 tostring(s._deathLatched or false),
                 tostring(s._idGateAssist),
@@ -7767,6 +7832,19 @@ function AuraContainer.DebugDumpIdentityGate()
         o:Field("auras secret", okS and tostring(secret) or "ERR", "NEUTRAL")
     end
     o:Field("test mode", AuraContainer._testMode or false, "NEUTRAL")
+    -- ★ The persistent gate log's tail — every transition, timestamped, whether or
+    -- not the debug console was on when it happened. This is the half a field report
+    -- needs: the dump above is NOW, the tail is WHAT LED HERE.
+    local glog = type(_G.DandersFramesDB_v2) == "table" and _G.DandersFramesDB_v2.gateLog
+    if type(glog) == "table" and #glog > 0 then
+        o:Section(("Gate log — last %d of %d (persists across sessions)"):format(
+            math.min(15, #glog), #glog))
+        for i = math.max(1, #glog - 14), #glog do
+            print("    " .. tostring(glog[i]))
+        end
+    else
+        o:Section("Gate log — empty (no transitions recorded yet)")
+    end
     o:Siblings("idgate")
 end
 

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -763,6 +763,26 @@ end
 -- it, and a mis-categorised aura lands in the wrong record or none. That is why the peer
 -- this mirrors parks exactly these four records on its debuff row and nothing else.
 --
+-- ☠☠☠ THE PARAGRAPH ABOVE DOES NOT MATCH THE ENGINE. Read from the shipped client
+-- (Blizzard_AuraContainer/Blizzard_AuraContainerUtil.lua, DoesAuraPassCandidateFilters):
+-- ONLY `excludeSpellIDs` and `includeSpellIDs` sit inside the
+-- `if CanApplyIdentityCandidateFilters(...)` block. isBossAura, isBossOrRoleAura,
+-- isRoleAura, isPriorityAura AND isFromPlayerOrPlayerPet are all evaluated AFTER it,
+-- unconditionally. They are never skipped, so they never fail open, so there is nothing
+-- for this park to protect against on those four keys.
+-- ⚠ And the categorisation cannot be poisoned the way the paragraph claims: the engine
+-- evaluates AuraUtil.IsRoleAura / IsPriorityDebuff itself, with the real auraData. It is
+-- OUR Lua that cannot read spellId, not Blizzard's.
+-- ⚠ There is also a THIRD exit we model nowhere: a spell whose
+-- C_Secrets.GetSpellAuraSecrecy is Enum.SecrecyLevel.NeverSecret returns true from
+-- CanApplyIdentityCandidateFilters regardless of assistability, so spell-ID filters keep
+-- working on it in both directions. (DF already knows this set exists -- see
+-- AuraBlacklist/Config.lua, ~62 IDs -- it just is not consulted here.)
+-- ⇒ The park is guarding a mechanism that does not exist, which is one more reason it kept
+-- emptying rows it should not. NOT removed here: that is a behaviour change on the debuff
+-- row and wants Krathe's call plus an in-game check, not a quiet deletion inside an
+-- unrelated fix. Do not "improve" this list until that decision is made.
+--
 -- ☠☠ ASSERTED (`true`), NEVER MERELY MENTIONED. This tested `~= nil`, and `false ~= nil`
 -- is true — so every record carrying a category boolean as a DEDUP SUBTRACTION counted as
 -- identity-gated. BuildDirectDebuffFilters' notImportant() stamps isBossOrRoleAura=false
@@ -7359,6 +7379,21 @@ idGateWatch:RegisterEvent("PLAYER_FOCUS_CHANGED")
 idGateWatch:RegisterEvent("UNIT_ENTERING_VEHICLE")
 idGateWatch:RegisterEvent("UNIT_ENTERED_VEHICLE")
 idGateWatch:RegisterEvent("UNIT_EXITED_VEHICLE")
+-- ☠☠ THE GATE READS DEAD AND DISCONNECTED, SO IT MUST HEAR THEM. IdentityUnavailable
+-- folds UnitIsDeadOrGhost and UnitIsConnected into the assist verdict, and until these two
+-- lines the watcher had no event for either. The consequence was one-way: a unit that died
+-- or dropped took the false on whatever unrelated event happened to sweep, and coming back
+-- produced NO sweep at all, so _noteGateRecovery never saw the false->true edge and a
+-- filtered helpful row stayed empty. Healers reported HoTs missing on some members with the
+-- auras verifiably still applied (5.1.3).
+-- ☠ PARTY_MEMBER_ENABLE / DISABLE above do NOT cover this. They are party-scoped and do not
+-- fire for raid members, which is why the clearest field report was a 40-player raid ("cannot
+-- see my riptides on group 5/6/7/8") -- past party size there was no connection signal at all.
+-- UNIT_CONNECTION is the group-wide equivalent and UNIT_FLAGS carries the death edge;
+-- Blizzard's own CompactUnitFrame registers exactly this pair per unit, and DF already
+-- relies on both for pet death detection (Frames/Pets.lua).
+idGateWatch:RegisterEvent("UNIT_FLAGS")
+idGateWatch:RegisterEvent("UNIT_CONNECTION")
 local gateSweepQueued
 
 -- ☠ THIS FILTER MUST MATCH _applyIdentityGate's OWN CONDITION, TERM FOR TERM. It did not:

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -7639,13 +7639,30 @@ function AuraContainer.DebugDumpIdentityGate()
                 if cf and cf.includeSpellIDs then inc = true end
                 if cf and cf.excludeSpellIDs then exc = true end
             end
-            print(("    " .. DF.OUT.SECTION .. "%d|r mode=%s unit=%s filter=%s inc=%s exc=%s vuln=%s srcRel=%s exists=%s canAssist=%s vis=%s gateHidden=%s intent=%s shown=%s retry=%s"):format(
+            -- ☠ PARK, LATCHES AND THE RECOVERY EDGE BELONG HERE TOO. This line reported the
+            -- HIDE path only, and hide is one of FOUR writers that can blank a row --
+            -- _applyVisibility composes gateHidden with the cinematic and death latches, and
+            -- the debuff row does not hide at all, it PARKS its gated groups to
+            -- maxFrameCount 0. So the "dispel overlay lit with no debuff icon under it" bug
+            -- was invisible in the dump built to see exactly that class of fault: the row was
+            -- parked, and there was no column for parked. `assist` is the recovery-edge
+            -- tracker _noteGateRecovery compares against — it answers the question every one
+            -- of these reports turns on, "will this ever un-hide on its own".
+            local parkedTxt = tostring(h._idGateParked or false)
+            if h._idGateUntrusted then parkedTxt = parkedTxt .. "(untrusted)" end
+            local gatedN = 0
+            for _ in pairs((h.backend and h.backend.gatedGroupKeys) or {}) do gatedN = gatedN + 1 end
+            print(("    " .. DF.OUT.SECTION .. "%d|r mode=%s unit=%s filter=%s inc=%s exc=%s vuln=%s srcRel=%s exists=%s canAssist=%s vis=%s gateHidden=%s parked=%s gatedGroups=%d cine=%s death=%s assist=%s intent=%s shown=%s retry=%s"):format(
                 n, tostring(cfg.mode or "row"), tostring(unit),
                 table.concat(fParts, "&"), tostring(inc), tostring(exc),
                 tostring(h._idGateVulnerable or false),
                 tostring(h._idGateSourceRelative or false),
                 tostring(type(unit) == "string" and UnitExists(unit) or false), canTxt, visTxt,
                 tostring(h._idGateHidden or false),
+                parkedTxt, gatedN,
+                tostring(h._cineLatched or false),
+                tostring(h._deathLatched or false),
+                tostring(h._idGateAssist),
                 tostring(h._intendedShown ~= false),
                 tostring(h.config and h.config.parentDrivenVisibility and "(nested)"
                     or (h.frame and h.frame:IsShown()) or false),
@@ -7655,11 +7672,58 @@ function AuraContainer.DebugDumpIdentityGate()
     if n > CAP then
         o:Line(("… capped at %d lines"):format(CAP), "NEUTRAL")
     end
+    -- ☠ SLOTS SWEEP TOO, AND THIS DUMP DID NOT WALK THEM. They live in their own
+    -- registry (see AcquireSlot) because the loop above is Handle-shaped -- the exact
+    -- omission that left the collapsed AD path with no gate at all, repeated here in the
+    -- tool meant to catch it. Every Aura Designer PLACED indicator is a SlotHandle with
+    -- its own _applyIdentityGate and its own _gateHidden, so a dump that reports only
+    -- Handles is blind to the half the AD uses -- and the AD is where the stuck-indicator
+    -- reports came from.
+    local sn, svuln = 0, 0
+    for s in pairs(AuraContainer._slotHandles or {}) do
+        sn = sn + 1
+        if s._idGateVulnerable then svuln = svuln + 1 end
+        if sn <= CAP then
+            local unit = s.owner and s.owner.unit
+            local canTxt = "-"
+            if type(unit) == "string" and UnitExists(unit) then
+                local ok, can = pcall(UnitCanAssist, "player", unit)
+                if not ok then canTxt = "ERR"
+                elseif issecretvalue and issecretvalue(can) then canTxt = "SECRET"
+                else canTxt = tostring(can) end
+            end
+            print(("    " .. DF.OUT.SECTION .. "S%d|r key=%s unit=%s vuln=%s srcRel=%s canAssist=%s gateHidden=%s parked=%s cine=%s death=%s assist=%s filter=%s"):format(
+                sn, tostring(s.key), tostring(unit),
+                tostring(s._idGateVulnerable or false),
+                tostring(s._idGateSourceRelative or false),
+                canTxt,
+                tostring(s._gateHidden or false),
+                tostring(s.parked or false),
+                tostring(s._cineLatched or false),
+                tostring(s._deathLatched or false),
+                tostring(s._idGateAssist),
+                -- The pushed string IS the actuation: "" means parked/hidden by one of
+                -- the four writers above, whichever won in _pushFilter.
+                tostring(s.liveFilter)))
+        end
+    end
+    if sn > CAP then
+        o:Line(("… slots capped at %d lines"):format(CAP), "NEUTRAL")
+    end
     o:Section("Summary")
     o:Field("handles", n, n > 0 and "GOOD" or "NEUTRAL")
     -- A vulnerable handle is the whole point of this dump, so it is the one
     -- number that must not sit uncoloured in a wall of numbers.
     o:Field("gate-vulnerable", vuln, vuln > 0 and "WARN" or "GOOD")
+    o:Field("slots", sn, sn > 0 and "GOOD" or "NEUTRAL")
+    o:Field("slots gate-vulnerable", svuln, svuln > 0 and "WARN" or "GOOD")
+    -- ★ Global aura secrecy, printed because it frames every line above: it does NOT
+    -- switch the identity gate off (CanApplyIdentityCandidateFilters has no such bypass),
+    -- but it is the first thing you want to know when a filter behaves unexpectedly.
+    if C_Secrets and C_Secrets.ShouldAurasBeSecret then
+        local okS, secret = pcall(C_Secrets.ShouldAurasBeSecret)
+        o:Field("auras secret", okS and tostring(secret) or "ERR", "NEUTRAL")
+    end
     o:Field("test mode", AuraContainer._testMode or false, "NEUTRAL")
     o:Siblings("idgate")
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -791,9 +791,9 @@ end
 --      There is no direction in which they leak, therefore none in which parking helps.
 --
 -- ⚠ We inherited the belief from a peer, which marks the identical four "identity-gated".
--- VuhDo, which reached the same overall design independently, parks the opposite side:
--- HELPFUL records carrying spell-ID filters, and never gates harmful at all. That is the
--- keying the API supports, and it is what gatedGroupKeys carries now.
+-- Another 12.1 raid-frame implementation, arrived at independently, parks the opposite
+-- side: HELPFUL records carrying spell-ID filters, and never gates harmful at all. That is
+-- the keying the API supports, and it is what gatedGroupKeys carries now.
 -- ☠ HARMFUL must never take a TRANSIENT park: for a harmful aura the engine skips spell-ID
 -- filters when you CAN assist, so on a friendly they are permanently dead, not
 -- intermittently — parking on that would park forever.
@@ -3451,7 +3451,7 @@ function NativeBackend:applyGroupTuning()
             if fsByKey[key] and c.SetAuraSlotFilterString then
                 -- ★ IDENTITY PARK, slot flavour. A slot has no maxFrameCount, so the park
                 -- is an EMPTY filter string — the same lever SlotHandle:_pushFilter uses,
-                -- and the one VuhDo uses for the same purpose. Without this the park
+                -- and the one other 12.1 implementations use for it. Without this the park
                 -- reached group-backed rows only, and a slot-backed row kept falling back
                 -- to the whole-handle hide it is meant to replace.
                 local parked = self.handle._idGateParked

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5079,38 +5079,18 @@ function Handle:_setDeathLatch(on)
 end
 
 -- ============================================================
--- GATE EVENT LOG — always on, persistent, transitions only
+-- GATE EVENT LOG — the IDGATE debug category, transitions only
 -- ============================================================
--- Every gate flip lands in DandersFramesDB_v2.gateLog whether or not the debug
--- console is enabled — a field report ("my HoTs vanished in the BG") arrives
--- AFTER the fact, and the console is off for every user who isn't already
--- chasing a bug. Transitions are rare (a handful per fight), so an always-on
--- ring is cheap; the ring caps itself so an hour-long battleground cannot grow
--- it unbounded. `/df debug idgate` prints the tail. When the console IS on the
--- same line echoes there under the AURACONTAINER category, timestamped twice.
--- ⚠ Only pass plain strings/numbers — a secret arg would taint the formatted
--- line; the issecretvalue check below is the backstop, not a license.
-local GATE_LOG_CAP, GATE_LOG_KEEP = 300, 200
+-- Every gate flip (park/hide/recovery, slot twins, death and cinematic latches)
+-- logs under its OWN console category, IDGATE, so a tester chasing "auras
+-- vanished" can enable just the verdict trail without the rest of the
+-- AURACONTAINER firehose. Opt-in like every other category — nothing is written
+-- unless the user turns it on. Each verdict line carries the probe that broke
+-- trust (see IdentityUnavailable and the `why` locals). One shared helper so
+-- every writer lands in the same lane; DF:Debug already sanitises secret args.
 local function GateLog(fmt, ...)
-    local ok, msg = pcall(string.format, fmt, ...)
-    if not ok then msg = tostring(fmt) end
-    if issecretvalue and issecretvalue(msg) then msg = "<secret log arg>" end
-    local db = _G.DandersFramesDB_v2
-    if type(db) == "table" then
-        local log = db.gateLog
-        if type(log) ~= "table" then log = {}; db.gateLog = log end
-        log[#log + 1] = date("%m-%d %H:%M:%S  ") .. msg
-        if #log > GATE_LOG_CAP then
-            -- One-pass compaction to the newest KEEP (DebugConsole's overshoot idea):
-            -- never a per-line table.remove shift.
-            local keep = {}
-            for i = #log - (GATE_LOG_KEEP - 1), #log do keep[#keep + 1] = log[i] end
-            db.gateLog = keep
-        end
-    end
-    DF:Debug(DBG, "%s", msg)
+    DF:Debug("IDGATE", fmt, ...)
 end
-AuraContainer.GateLog = GateLog   -- shared with the death-latch/cine writers below
 
 function Handle:_noteGateRecovery(can)
     local was = self._idGateAssist
@@ -7605,6 +7585,11 @@ idGateWatch:SetScript("OnEvent", function(_, event)
         C_Timer.After(0.05, IdentityGateSweep)
     end
     if event == "PLAYER_ENTERING_WORLD" then
+        -- One-time scrub: a same-day reverted design (90fc296f) briefly wrote an
+        -- always-on gateLog ring into the SV before gate logging moved to the
+        -- IDGATE console category. Remove once shipped builds can't have it.
+        local sv = _G.DandersFramesDB_v2
+        if type(sv) == "table" and sv.gateLog ~= nil then sv.gateLog = nil end
         C_Timer.After(2, IdentityGateSweep)
         C_Timer.After(6, IdentityGateSweep)
     end
@@ -7832,18 +7817,26 @@ function AuraContainer.DebugDumpIdentityGate()
         o:Field("auras secret", okS and tostring(secret) or "ERR", "NEUTRAL")
     end
     o:Field("test mode", AuraContainer._testMode or false, "NEUTRAL")
-    -- ★ The persistent gate log's tail — every transition, timestamped, whether or
-    -- not the debug console was on when it happened. This is the half a field report
-    -- needs: the dump above is NOW, the tail is WHAT LED HERE.
-    local glog = type(_G.DandersFramesDB_v2) == "table" and _G.DandersFramesDB_v2.gateLog
-    if type(glog) == "table" and #glog > 0 then
-        o:Section(("Gate log — last %d of %d (persists across sessions)"):format(
-            math.min(15, #glog), #glog))
-        for i = math.max(1, #glog - 14), #glog do
-            print("    " .. tostring(glog[i]))
+    -- ★ The IDGATE trail's tail, pulled from the console log — the dump above is
+    -- NOW, the tail is WHAT LED HERE. Only populated while the IDGATE debug
+    -- category is enabled (opt-in like every category), so say so when empty
+    -- rather than reading as "no transitions happened".
+    local dlog = type(_G.DandersFramesDB_v2) == "table" and _G.DandersFramesDB_v2.debugLog
+    local tail = {}
+    if type(dlog) == "table" then
+        for i = #dlog, 1, -1 do
+            local e = dlog[i]
+            if type(e) == "table" and e[3] == "IDGATE" then
+                tail[#tail + 1] = tostring(e[1]) .. "  " .. tostring(e[4])
+                if #tail >= 15 then break end
+            end
         end
+    end
+    if #tail > 0 then
+        o:Section(("Gate log — last %d IDGATE lines"):format(#tail))
+        for i = #tail, 1, -1 do print("    " .. tail[i]) end
     else
-        o:Section("Gate log — empty (no transitions recorded yet)")
+        o:Section("Gate log — empty (enable the IDGATE debug category to record transitions)")
     end
     o:Siblings("idgate")
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -7360,6 +7360,21 @@ idGateWatch:RegisterEvent("UNIT_ENTERING_VEHICLE")
 idGateWatch:RegisterEvent("UNIT_ENTERED_VEHICLE")
 idGateWatch:RegisterEvent("UNIT_EXITED_VEHICLE")
 local gateSweepQueued
+
+-- ☠ THIS FILTER MUST MATCH _applyIdentityGate's OWN CONDITION, TERM FOR TERM. It did not:
+-- the gate widened to `or self:_hasGatedGroups()` so the debuff row's park verdict could
+-- flip, and the sweep that DRIVES the gate was left on the old two-term test. A row that
+-- carries gated groups without being hide-vulnerable was therefore never swept, so its
+-- park could be set at build and never re-evaluated by any watcher event -- the same
+-- "fixed the class in one place, not its sibling" shape the park bug itself had.
+-- ⚠ Declared HERE, above SetUnitDeathLatched, because that is its first caller. Below it
+-- this reads as a nil GLOBAL: it parses clean, and every call site is inside a pcall, so
+-- the failure would have been completely silent. Caught by diffing _ENV reads, not by luac.
+local function GateAppliesTo(h)
+    return h._idGateVulnerable or h._idGateSourceRelative
+        or (h._hasGatedGroups and h:_hasGatedGroups())
+end
+
 -- ============================================================
 -- DEATH LATCH — unit-keyed sweep (#1043)
 -- ============================================================
@@ -7382,12 +7397,42 @@ function AuraContainer.SetUnitDeathLatched(unit, on)
             pcall(function() s:_setDeathLatch(on) end)
         end
     end
+    -- ☠☠ DEATH IS AN IDENTITY EDGE TOO, AND NOTHING ELSE DELIVERS IT. IdentityUnavailable
+    -- folds UnitIsDeadOrGhost / UnitIsConnected into the assist verdict, so a dead unit
+    -- makes _applyIdentityGate decide `can = false` -- which PARKS its gated groups and,
+    -- for a hide-vulnerable HELPFUL pool, hides the row outright. But idGateWatch registers
+    -- only faction / phase / name / roster / target / focus / vehicle events: there is no
+    -- death or resurrection event anywhere in that list.
+    --
+    -- So the gate could take the false while a unit was dead (any roster event during the
+    -- death is enough, and in a raid those never stop), and then never re-run on the alive
+    -- edge -- _noteGateRecovery never saw the false->true transition, so no re-parse and no
+    -- un-hide. The HoTs stayed gone until some unrelated watcher event happened to sweep.
+    -- Field shape: "sometimes my hots don't appear on some of my teammates", healer able to
+    -- target the player and confirm the HoTs are really there (targeting fires
+    -- PLAYER_TARGET_CHANGED, which sweeps -- so the act of checking could fix it and hide
+    -- the cause). Reported by several healers on 5.1.3.
+    --
+    -- The death latch is already driven off the real dead/alive transitions in
+    -- Frames/Update.lua and is unit-keyed, so it is exactly the edge the gate was missing.
+    -- Re-running the gate for this unit's handles is cheap: two pcall'ed unit probes each,
+    -- and only for handles the gate applies to at all.
+    for h in pairs(AuraContainer._handles or {}) do
+        if not h._destroyed and h.config and h.config.unit == unit and GateAppliesTo(h) then
+            pcall(function() h:_applyIdentityGate() end)
+        end
+    end
+    for s in pairs(AuraContainer._slotHandles or {}) do
+        if s.owner and s.owner.unit == unit and GateAppliesTo(s) then
+            pcall(function() s:_applyIdentityGate() end)
+        end
+    end
 end
 
 local function IdentityGateSweep()
     gateSweepQueued = nil
     for h in pairs(AuraContainer._handles or {}) do
-        if h._idGateVulnerable or h._idGateSourceRelative then
+        if GateAppliesTo(h) then
             pcall(function() h:_applyIdentityGate() end)
         end
     end
@@ -7395,7 +7440,7 @@ local function IdentityGateSweep()
     -- one is Handle-shaped; forgetting them is exactly how the collapsed AD path ended up
     -- with no gate at all despite every placed config being vulnerable.
     for h in pairs(AuraContainer._slotHandles or {}) do
-        if h._idGateVulnerable or h._idGateSourceRelative then
+        if GateAppliesTo(h) then
             pcall(function() h:_applyIdentityGate() end)
         end
     end

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -2278,6 +2278,14 @@ function DF:UpdateHealPrediction(frame, testIndex)
     -- ★ Nothing in live's path is secret-bound here, so there is no reason to fork:
     -- test values are plain numbers, and a StatusBar fed a plain value behaves the
     -- same as one fed a secret. Standing rule -- test follows live wherever it can.
+    --
+    -- ★ ONE ceiling for live's calculator AND the test mirror, or they drift -- the
+    -- exact fast-path-copy trap this file has sprung twice. 1.05 is the field
+    -- consensus for the overheal tail: Blizzard's own compact party/raid frames cap
+    -- at 5% past the bar, and every surveyed implementation either matches that
+    -- sliver or shows no overhang at all. A first cut used 2.0 ("never the binding
+    -- constraint") -- functionally correct and visually an outlier nobody ships.
+    local OVERHEAL_CEILING = 1.05
     local function applyTestHeals(testData)
         maxHealth = (testData and testData.maxHealth) or 100000
         local healthPct = (testData and testData.healthPercent) or 0.75
@@ -2293,12 +2301,16 @@ function DF:UpdateHealPrediction(frame, testIndex)
         -- not it is displayed; only the preview's fiction follows its toggles.
         local haPct = (db.testShowAbsorbs and testData and testData.healAbsorbPercent) or 0
         local total = math.max(0, healPct - haPct) * maxHealth   -- safe: nothing is secret in test
-        -- Mirrors SetIncomingHealClampMode. With overheal off the calculator would
-        -- never report more than the missing health, so neither may the preview;
-        -- with it on the overhang is the point and the bar is parented to the frame
-        -- rather than the health bar so it can spill.
+        -- Mirrors SetIncomingHealClampMode + the overflow ceiling. With overheal off
+        -- the calculator never reports more than the missing health, so neither may
+        -- the preview; with it on the overhang spills past the bar (it is parented to
+        -- the frame, not the health bar, for exactly that) but is capped at the SAME
+        -- ceiling live's calculator enforces -- an uncapped preview promised a tail
+        -- live never draws.
         if not db.healPredictionShowOverheal then
             total = math.min(total, math.max(0, maxHealth - healthPct * maxHealth))
+        else
+            total = math.min(total, math.max(0, maxHealth * OVERHEAL_CEILING - healthPct * maxHealth))
         end
         -- The breakdown live gets from the calculator. An even split is the only
         -- honest preview: there is no real healer to attribute to.
@@ -2359,13 +2371,13 @@ function DF:UpdateHealPrediction(frame, testIndex)
             -- unconditional 1.0 here (commented "Always 100%", read backwards) is why
             -- Show Overheal never showed overheals: the clamp-mode line above did
             -- everything right and this line capped the sum anyway.
-            -- ON  -> 2.0: never the binding constraint (clamp mode 1 already caps the
-            --        VALUE at maxHealth, so the sum tops out at health + max <= 2x max).
-            --        The render is built for the spill — the bar is parented to the
-            --        frame, not the health bar, precisely so it can overhang — and the
-            --        test-mode mirror above previews the overhang uncapped.
+            -- ON  -> OVERHEAL_CEILING (1.05, declared above applyTestHeals so the test
+            --        mirror caps at the same number): a bounded 5% tail past the bar,
+            --        matching Blizzard's own compact frames. The render is built for
+            --        the spill — the bar is parented to the frame, not the health bar,
+            --        precisely so it can overhang.
             -- OFF -> 1.0: belt for mode 0, which already caps at missing health.
-            calc:SetIncomingHealOverflowPercent(db.healPredictionShowOverheal and 2.0 or 1.0)
+            calc:SetIncomingHealOverflowPercent(db.healPredictionShowOverheal and OVERHEAL_CEILING or 1.0)
             -- Heals NET of consuming heal absorbs (mode 0, ReducedByIncomingHeals).
             -- This IS the engine default the bar has ridden all along — pinned
             -- explicitly so it can never drift, and so the heal-absorb bar (now also

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -2356,14 +2356,20 @@ function DF:UpdateHealPrediction(frame, testIndex)
             
             local calc = frame.healPredictionCalculator
             
-            -- Configure the calculator based on settings. Enum, straight from the API
-            -- docs (the comment here used to state it BACKWARDS — the code was right):
-            --   UnitIncomingHealClampMode 0 = MissingHealth, 1 = MaximumHealth.
-            -- Show Overheal ON  -> 1 (MaximumHealth: the heal may exceed missing health)
-            -- Show Overheal OFF -> 0 (MissingHealth: capped at what fits)
-            local clampMode = db.healPredictionShowOverheal and 1 or 0
-
-            calc:SetIncomingHealClampMode(clampMode)
+            -- ☠ CLAMP MODE 0 IN BOTH STATES — the overheal toggle drives the OVERFLOW
+            -- PERCENT, never the mode. Per the enum docs the overflow belongs to mode 0
+            -- ("clamp to the amount of missing health WITH OVERFLOW APPLIED"), while
+            -- mode 1 (MaximumHealth) is a VALUE cap of the whole health pool with no
+            -- overflow term at all — so under mode 1 the ceiling never binds, the value
+            -- may reach maxHealth on its own, and a near-full unit renders health+heal
+            -- at close to DOUBLE the bar. That was field-caught as a full-bar blue
+            -- overhang (Kesara screenshot, 2026-08-15) the first time overheal actually
+            -- rendered: an earlier cut set mode 1 for ON on the assumption the ceiling
+            -- capped the sum in every mode. It caps only mode 0's.
+            -- Mode 0 + ceiling is also literally Blizzard's compact-frame formula
+            -- (trim when health + heals > max * 1.05): sum <= ceiling * max, i.e. a
+            -- bounded tail with overheal on, flush at the bar edge with it off.
+            calc:SetIncomingHealClampMode(0)
             -- ☠ THE OVERFLOW PERCENT IS A CEILING ON THE SUM, NOT A "SHOW THIS MUCH".
             -- Per the API doc: "Increasing this to a value OVER 1.0 will mean that
             -- incoming heals can extend beyond maximum health." So 1.0 pins
@@ -2372,11 +2378,12 @@ function DF:UpdateHealPrediction(frame, testIndex)
             -- Show Overheal never showed overheals: the clamp-mode line above did
             -- everything right and this line capped the sum anyway.
             -- ON  -> OVERHEAL_CEILING (1.05, declared above applyTestHeals so the test
-            --        mirror caps at the same number): a bounded 5% tail past the bar,
-            --        matching Blizzard's own compact frames. The render is built for
-            --        the spill — the bar is parented to the frame, not the health bar,
-            --        precisely so it can overhang.
-            -- OFF -> 1.0: belt for mode 0, which already caps at missing health.
+            --        mirror caps at the same number): mode 0's cap becomes
+            --        missing + 5% of max — a bounded tail past the bar, matching
+            --        Blizzard's own compact frames. The render is built for the spill —
+            --        the bar is parented to the frame, not the health bar, precisely so
+            --        it can overhang.
+            -- OFF -> 1.0: mode 0's cap is exactly the missing health — flush at the bar.
             calc:SetIncomingHealOverflowPercent(db.healPredictionShowOverheal and OVERHEAL_CEILING or 1.0)
             -- Heals NET of consuming heal absorbs (mode 0, ReducedByIncomingHeals).
             -- This IS the engine default the bar has ridden all along — pinned

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -2352,7 +2352,20 @@ function DF:UpdateHealPrediction(frame, testIndex)
             local clampMode = db.healPredictionShowOverheal and 1 or 0
 
             calc:SetIncomingHealClampMode(clampMode)
-            calc:SetIncomingHealOverflowPercent(1.0)  -- Always 100%
+            -- ☠ THE OVERFLOW PERCENT IS A CEILING ON THE SUM, NOT A "SHOW THIS MUCH".
+            -- Per the API doc: "Increasing this to a value OVER 1.0 will mean that
+            -- incoming heals can extend beyond maximum health." So 1.0 pins
+            -- health + heal at exactly the bar edge — zero overhang — and the old
+            -- unconditional 1.0 here (commented "Always 100%", read backwards) is why
+            -- Show Overheal never showed overheals: the clamp-mode line above did
+            -- everything right and this line capped the sum anyway.
+            -- ON  -> 2.0: never the binding constraint (clamp mode 1 already caps the
+            --        VALUE at maxHealth, so the sum tops out at health + max <= 2x max).
+            --        The render is built for the spill — the bar is parented to the
+            --        frame, not the health bar, precisely so it can overhang — and the
+            --        test-mode mirror above previews the overhang uncapped.
+            -- OFF -> 1.0: belt for mode 0, which already caps at missing health.
+            calc:SetIncomingHealOverflowPercent(db.healPredictionShowOverheal and 2.0 or 1.0)
             -- Heals NET of consuming heal absorbs (mode 0, ReducedByIncomingHeals).
             -- This IS the engine default the bar has ridden all along — pinned
             -- explicitly so it can never drift, and so the heal-absorb bar (now also

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -1851,22 +1851,38 @@ end
 --   * Single populated row (no drift)
 --   * Required handler / headers not yet created
 function DF:ComputeRaidContainerCompensation()
-    if not DF.raidPositionHandler then return 0, 0 end
-    if not DF.raidSeparatedHeaders then return 0, 0 end
-
     local db = DF:GetRaidDB()
     if not db then return 0, 0 end
     if not db.raidUseGroups then return 0, 0 end
     if (db.raidGroupAnchor or "START") ~= "CENTER" then return 0, 0 end
 
-    -- Mirror the snippet: a group is "populated" when its child count > 0.
-    -- Read counts from the same handler attributes the snippet reads, so the
-    -- compensation always agrees with the snippet's view of the world.
-    local handler = DF.raidPositionHandler
+    -- ★ ONE compensation, MODE-AWARE — this function is now the single source of the
+    -- CENTER shift. The live container, the TEST container and the MOVER all take it
+    -- in UpdateRaidContainerPosition; the test frame calculator carries NONE of it
+    -- (its old lp.testMode comp block is retired — see CalculateRaidGroupPosition).
+    -- The unlock overlay is only faithful if all three read the SAME number, which is
+    -- why there is exactly one ("overlay is not faithful when groups-per-row < 8",
+    -- Aphoex 2026-08-15: content sat half a group-row below the box because the
+    -- container carried the shift and the mover never did).
+    -- In test mode the populated count comes from the TEST roster (5 per group,
+    -- mirroring LightweightPositionRaidTestFrames): the handler attributes describe
+    -- the LIVE roster, which solo is ZERO populated groups — the comp would read 0
+    -- while the preview simulates eight.
     local numPopulated = 0
-    for i = 1, 8 do
-        local count = handler:GetAttribute("group" .. i .. "count") or 0
-        if count > 0 then numPopulated = numPopulated + 1 end
+    if DF.raidTestMode then
+        local testCount = db.raidTestFrameCount or 10
+        numPopulated = math.min(8, math.ceil(testCount / 5))
+    else
+        if not DF.raidPositionHandler then return 0, 0 end
+        if not DF.raidSeparatedHeaders then return 0, 0 end
+        -- Mirror the snippet: a group is "populated" when its child count > 0.
+        -- Read counts from the same handler attributes the snippet reads, so the
+        -- compensation always agrees with the snippet's view of the world.
+        local handler = DF.raidPositionHandler
+        for i = 1, 8 do
+            local count = handler:GetAttribute("group" .. i .. "count") or 0
+            if count > 0 then numPopulated = numPopulated + 1 end
+        end
     end
     if numPopulated == 0 then return 0, 0 end
 

--- a/DandersFrames/Frames/Init.lua
+++ b/DandersFrames/Frames/Init.lua
@@ -981,7 +981,16 @@ function DF:UnlockRaidFrames()
             DF.testRaidContainer:SetSize(DF.raidContainer:GetSize())
         end
     end
-    
+
+    -- ★ CONVERGE THROUGH THE ONE POSITIONER. The hand-positioning above sets raw
+    -- anchors; UpdateRaidContainerPosition is the single owner of the CENTER
+    -- compensation (container + test container + mover, one number), so run it last
+    -- or the unlock path shows the box at the uncompensated anchor until the next
+    -- reposition happens by — the exact overlay drift this block otherwise
+    -- reintroduces. (Core.lua already routes its callers through it for the same
+    -- reason.) Safe here: unlock is OOC by construction (combat guard at the top).
+    if DF.UpdateRaidContainerPosition then DF:UpdateRaidContainerPosition() end
+
     -- Debug info
     if DF:DebugActive("HEADERS") then
         headerDebug("Raid unlock - container size:", DF.raidContainer:GetWidth(), "x", DF.raidContainer:GetHeight())

--- a/DandersFrames/Frames/Pets.lua
+++ b/DandersFrames/Frames/Pets.lua
@@ -517,6 +517,26 @@ function DF:SetPetFrameVisible(frame, visible)
         frame.dfPetHidden = false
         -- Set to 1 so range system can take over (don't compare current alpha - it may be secret)
         frame:SetAlpha(1)
+        -- ☠ RE-DERIVE THE Z-ORDER AT SHOW TIME, from the owner's CURRENT level. The
+        -- #1047 elevation (owner level + 15, clearing neighbours' bound fills) is
+        -- applied in ApplyPetFrameStyle -- but on the FIRST test entry of a session the
+        -- pet is styled in the same tick its owner frame is being built, so the style
+        -- pass captures a pre-layout owner level and the pet sits under neighbouring
+        -- health fills until something re-styles it. Second entry and any settings
+        -- change re-ran the style from the final level, which is exactly the field
+        -- report ("will fix the second time test mode is enabled or a frame is updated
+        -- by changing a setting"; toggles inside test mode showed/hid without
+        -- re-styling, so they never updated it either -- this covers them too, because
+        -- they route through here). Deriving at every SHOW makes the ordering
+        -- irrelevant: the level is read from what the owner IS, not what it was when
+        -- the pet was styled. Idempotent for live pets -- same formula
+        -- ApplyPetFrameStyle applies.
+        if frame.ownerFrame then
+            pcall(function()
+                frame:SetFrameStrata(frame.ownerFrame:GetFrameStrata())
+                frame:SetFrameLevel(frame.ownerFrame:GetFrameLevel() + 15)
+            end)
+        end
         -- Also try to show if not in combat (for proper click targeting)
         if not InCombatLockdown() then
             frame:Show()

--- a/DandersFrames/Frames/Position.lua
+++ b/DandersFrames/Frames/Position.lua
@@ -2351,19 +2351,29 @@ function DF:UpdateRaidContainerPosition()
     DF.raidContainer:ClearAllPoints()
     DF.raidContainer:SetPoint("CENTER", UIParent, "CENTER", cx / scale, cy / scale)
 
-    -- Mover/test container do NOT get the compensation: the mover represents
-    -- the user's saved position (centroid), and the test container has no
-    -- secure snippet running so populated-row drift never happens there.
+    -- ☠ MOVER AND TEST CONTAINER TAKE THE COMPENSATION TOO — all three read the one
+    -- number ComputeRaidContainerCompensation returns. The previous rule ("the mover
+    -- represents the user's saved position") kept the mover at the raw anchor while
+    -- the content sat at anchor + comp, so with Center alignment and groups-per-row
+    -- below 8 the unlock overlay drew half a group-row away from the frames it claims
+    -- to bound (Aphoex, 2026-08-15). The saved anchor is invisible to users; the
+    -- overlay's entire job is to be WHERE THE FRAMES ARE. Drag stays coherent: the
+    -- drag OnUpdate moves mover + both containers rigidly by the same raw offset, and
+    -- DragStop re-runs this function, so box and content keep one shared baseline
+    -- throughout.
+    -- ⚠ The test container now carries the comp ON THE CONTAINER, mirroring live —
+    -- the test frame calculator no longer folds it into frame offsets. One accounting
+    -- model in both modes; the calculator's testMode comp fork is retired.
     if DF.raidMoverFrame and DF.raidMoverFrame:IsShown() then
         DF.raidMoverFrame:SetScale(scale)
         DF.raidMoverFrame:ClearAllPoints()
-        DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", x / scale, y / scale)
+        DF.raidMoverFrame:SetPoint("CENTER", UIParent, "CENTER", cx / scale, cy / scale)
     end
 
     if DF.testRaidContainer then
         DF.testRaidContainer:SetScale(scale)
         DF.testRaidContainer:ClearAllPoints()
-        DF.testRaidContainer:SetPoint("CENTER", UIParent, "CENTER", x / scale, y / scale)
+        DF.testRaidContainer:SetPoint("CENTER", UIParent, "CENTER", cx / scale, cy / scale)
     end
 end
 

--- a/DandersFrames/Locales/enUS.lua
+++ b/DandersFrames/Locales/enUS.lua
@@ -40,6 +40,7 @@ L["Auto-create profiles enabled."] = true
 -- rest of the chat line. The caller wraps the substituted name instead.
 L["Auto-created profile: %s"] = true
 L["Auto-profile evaluation and runtime overlay"] = true
+L["Identity gate: park/hide verdicts with reasons, latches, recovery"] = true
 L["Cannot delete the default profile"] = true
 L["Cannot rename the default profile"] = true
 L["Click-casting binding apply, hover, PreClick state"] = true

--- a/DandersFrames/Locales/enUS.lua
+++ b/DandersFrames/Locales/enUS.lua
@@ -770,6 +770,8 @@ L["Debuffs that can be dispelled. Use the dropdown below to choose which dispels
 L["Debuffs that can be dispelled. Which dispels count is set just below."] = true
 L["Debug"] = true
 L["Debug Log Export (Filtered)"] = true
+L["Debug Log Export (part %d of %d)"] = true
+L["Next Part"] = true
 L["Debug console module not loaded."] = true
 L["Debug logging %s"] = true
 L["Decimal Places"] = true

--- a/DandersFrames_Options/GUI/Pages/Frames.lua
+++ b/DandersFrames_Options/GUI/Pages/Frames.lua
@@ -401,8 +401,30 @@ function DF._SetupGUIPagesPart2(GUI, CreateCategory, CreateSubTab, BuildPage, L,
             })
         end
 
+        -- ☠ RE-CLAMP ON EVERY CALL, not just at page build. The build-time clamp above
+        -- (see `persistedTab`) already knew the index could address a set that is gone
+        -- "or in the other mode" -- but it runs ONCE, when the page is constructed, and
+        -- a mode switch does not rebuild the page: it drives the REFRESH path. Joining a
+        -- raid while the party side had more pinned sets than the raid side therefore
+        -- left `activeHighlightTab` pointing past the end of the live list, and the ~27
+        -- call sites that index this directly threw "attempt to index a nil value" --
+        -- nine at once, one per refreshed control (Aphoex, 5.2.0-alpha.1, on entering a
+        -- raid; stack came in through the roster widget's getter).
+        -- ⚠ The clamp is the FIX; the nil return is only the last resort. RemoveSet
+        -- refuses to drop below one set, so an empty list is unreachable by design and a
+        -- nil here means something else is wrong -- callers that write must NOT silently
+        -- swallow that, which is why this does not hand back a scratch table.
         local function GetCurrentSet()
-            return db.pinnedFrames.sets[activeHighlightTab]
+            local sets = db.pinnedFrames and db.pinnedFrames.sets
+            if type(sets) ~= "table" then return nil end
+            local n = #sets
+            if n == 0 then return nil end
+            if activeHighlightTab > n then activeHighlightTab = n end
+            if activeHighlightTab < 1 then activeHighlightTab = 1 end
+            -- Keep the persisted value honest too, or the next page build re-reads the
+            -- stale index and the clamp has to happen all over again.
+            pagePinnedFrames.persistedTab = activeHighlightTab
+            return sets[activeHighlightTab]
         end
 
         local function IsCurrentBossMode()
@@ -1511,7 +1533,10 @@ function DF._SetupGUIPagesPart2(GUI, CreateCategory, CreateSubTab, BuildPage, L,
                 DF.PinnedFrames:UpdatePreviewSet(activeHighlightTab)
             end
         end)
-        nameInputContainer.Refresh = function() nameInput:SetText(GetCurrentSet().name or "") end
+        nameInputContainer.Refresh = function()
+            local s = GetCurrentSet()
+            nameInput:SetText((s and s.name) or "")
+        end
         -- SetEnabled shim: grey the label + editbox in place when the set is disabled.
         nameInputContainer.SetEnabled = function(_, enabled)
             nameInput:EnableMouse(enabled)
@@ -1813,7 +1838,9 @@ function DF._SetupGUIPagesPart2(GUI, CreateCategory, CreateSubTab, BuildPage, L,
 
         rosterWidget = GUI:CreateHighlightRosterWidget(
             self.child,
-            function() return GetCurrentSet().players end,
+            -- Guarded as well as clamped: this is the getter the raid-join crash came
+            -- through, and a roster with no set to read is an empty roster, not an error.
+            function() local s = GetCurrentSet() return s and s.players or {} end,
             function(players)
                 local set = GetCurrentSet()
                 set.players = players

--- a/DandersFrames_Options/GUI/Pages/Frames.lua
+++ b/DandersFrames_Options/GUI/Pages/Frames.lua
@@ -66,25 +66,81 @@ function DF._SetupGUIPagesPart2(GUI, CreateCategory, CreateSubTab, BuildPage, L,
             -- BASE resolver: "apply font globally" edits the user's base
             -- preset — with a runtime auto-layout active, the ACTIVE resolver
             -- would mutate the layout's preset instead (editor model is BASE).
+            -- ☠ Field report (5.1.3): this block silently did nothing. Three holes:
+            --   1. `if defaults then` skipped the whole write when the table was absent.
+            --   2. adDB.auras is SPEC-KEYED (auras[spec][auraName]) since the spec-scope
+            --      migration, and the old loop iterated one level short — the instance
+            --      clearing never matched anything, while EnsureTypeConfig stamps fonts
+            --      on every placed indicator at creation, so instances shadowed the
+            --      defaults write forever.
+            --   3. Layout / Other / debuff-category GROUPS carry their text style on
+            --      group.style with NO adDB.defaults fallback — untouched entirely.
             local _adMode = (db == DF.db.raid) and "raid" or "party"
             local _adCfg = (DF.GetModeBaseAuraDesigner and DF:GetModeBaseAuraDesigner(_adMode))
                 or (DF.GetModeAuraDesigner and DF:GetModeAuraDesigner(_adMode))
             if _adCfg then
-                if _adCfg.defaults then
-                    local adDefaults = _adCfg.defaults
-                    adDefaults.durationFont = font; adDefaults.durationOutline = outline
-                    adDefaults.stackFont = font; adDefaults.stackOutline = outline
-                end
-                -- Clear per-instance font overrides so all indicators inherit global
-                if _adCfg.auras then
-                    for _, auraCfg in pairs(_adCfg.auras) do
-                        if auraCfg.indicators then
-                            for _, inst in ipairs(auraCfg.indicators) do
+                if not _adCfg.defaults then _adCfg.defaults = {} end
+                local adDefaults = _adCfg.defaults
+                adDefaults.durationFont = font; adDefaults.durationOutline = outline
+                adDefaults.stackFont = font; adDefaults.stackOutline = outline
+                -- Clear per-instance font overrides so indicators inherit the
+                -- defaults written above. Covers the post-migration indicators
+                -- array AND the legacy per-type sub-tables ("icon"/"square"/"bar")
+                -- of a record the lazy instances migration hasn't touched yet.
+                local function _clearAuraRecord(rec)
+                    if type(rec) ~= "table" then return end
+                    if type(rec.indicators) == "table" then
+                        for _, inst in ipairs(rec.indicators) do
+                            if type(inst) == "table" then
                                 inst.durationFont = nil; inst.durationOutline = nil
                                 inst.stackFont = nil; inst.stackOutline = nil
                             end
                         end
                     end
+                    -- ☠ Not ipairs over {rec.icon, rec.square, rec.bar}: a nil hole
+                    -- (record with a bar but no icon) would end the walk early.
+                    for _, tk in pairs({ "icon", "square", "bar" }) do
+                        local t = rec[tk]
+                        if type(t) == "table" then
+                            t.durationFont = nil; t.durationOutline = nil
+                            t.stackFont = nil; t.stackOutline = nil
+                        end
+                    end
+                end
+                if type(_adCfg.auras) == "table" then
+                    for _, specAuras in pairs(_adCfg.auras) do
+                        if type(specAuras) == "table" then
+                            for _, rec in pairs(specAuras) do _clearAuraRecord(rec) end
+                        end
+                    end
+                end
+                if type(_adCfg.otherAuras) == "table" then
+                    for _, rec in pairs(_adCfg.otherAuras) do _clearAuraRecord(rec) end
+                end
+                -- Group buttons: SET the style explicitly (the opposite move from the
+                -- indicator clearing) — group.style has no defaults chain to inherit
+                -- from, so nil here would just mean the hardcoded factory default.
+                local function _styleGroup(g)
+                    if type(g) ~= "table" then return end
+                    local s = g.style
+                    if type(s) ~= "table" then s = {}; g.style = s end
+                    s.durationFont = font; s.durationOutline = outline
+                    s.stackFont = font; s.stackOutline = outline
+                end
+                if type(_adCfg.layoutGroups) == "table" then
+                    for _, v in pairs(_adCfg.layoutGroups) do
+                        if type(v) == "table" and v.id ~= nil then
+                            _styleGroup(v)   -- pre-spec-scope flat array entry
+                        elseif type(v) == "table" then
+                            for _, g in pairs(v) do _styleGroup(g) end
+                        end
+                    end
+                end
+                if type(_adCfg.otherLayoutGroups) == "table" then
+                    for _, g in pairs(_adCfg.otherLayoutGroups) do _styleGroup(g) end
+                end
+                if type(_adCfg.debuffGroups) == "table" then
+                    for _, g in pairs(_adCfg.debuffGroups) do _styleGroup(g) end
                 end
             end
 
@@ -102,10 +158,10 @@ function DF._SetupGUIPagesPart2(GUI, CreateCategory, CreateSubTab, BuildPage, L,
                         el.font = font; el.outline = outline
                     end
                 end
-                if _tdCfg.globalDefaults then
-                    _tdCfg.globalDefaults.font = font
-                    _tdCfg.globalDefaults.outline = outline
-                end
+                -- Create-if-missing, same silent-skip hole the AD defaults had.
+                if not _tdCfg.globalDefaults then _tdCfg.globalDefaults = {} end
+                _tdCfg.globalDefaults.font = font
+                _tdCfg.globalDefaults.outline = outline
             end
 
             DF:UpdateAllFrames()

--- a/DandersFrames_Options/GUI/Pages/Modules.lua
+++ b/DandersFrames_Options/GUI/Pages/Modules.lua
@@ -2103,22 +2103,42 @@ function DF._SetupGUIPagesPart5(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         AddToSection(entryCountLabel, 20, "both")
 
         -- Action buttons row (Refresh / Clear Log / Copy to Clipboard)
-        local function CopyLogToClipboard()
-            if not DF.DebugConsole then return end
-            -- Was a hand-rolled dialog: ~35 lines building its own frame, backdrop,
-            -- title, drag handlers and close button. ☠ It also called CreateFrame
-            -- with the FIXED global name "DFDebugExportPopup" on every click, so a
-            -- second export built a second frame over the same global and orphaned
-            -- the first — a leak per click. The shared input popup is a singleton
-            -- and is the same control the click-cast profile export already uses.
+        -- Was a hand-rolled dialog: ~35 lines building its own frame, backdrop,
+        -- title, drag handlers and close button. ☠ It also called CreateFrame
+        -- with the FIXED global name "DFDebugExportPopup" on every click, so a
+        -- second export built a second frame over the same global and orphaned
+        -- the first — a leak per click. The shared input popup is a singleton
+        -- and is the same control the click-cast profile export already uses.
+        --
+        -- PAGED: one giant export string blanks the popup's content-sized text
+        -- area exactly like the live box (region-size ceiling), so the console
+        -- slices the export into parts and this pages through them. One part =
+        -- the old single dialog; more parts add a "Next Part" button. The parts
+        -- with a Next button are not readOnly (the popup only offers an accept
+        -- button on editable inputs) — stray edits in a copy box are harmless.
+        local function ShowExportChunk(chunks, i)
+            local isLast = i >= #chunks
             DF:ShowPopupInput({
-                title       = L["Debug Log Export (Filtered)"],
+                title       = (#chunks > 1)
+                    and format(L["Debug Log Export (part %d of %d)"], i, #chunks)
+                    or L["Debug Log Export (Filtered)"],
                 message     = L["Press Ctrl+A to select all, then Ctrl+C to copy"],
-                text        = DF.DebugConsole:GetExportText(),
+                text        = chunks[i],
                 multiline   = true,
-                readOnly    = true,
+                readOnly    = isLast,
+                acceptLabel = (not isLast) and L["Next Part"] or nil,
+                onAccept    = (not isLast) and function()
+                    -- The popup hides itself right AFTER this callback runs
+                    -- (button onClick -> callback -> Hide), so reopening in the
+                    -- same tick would be hidden immediately. Next tick.
+                    C_Timer.After(0, function() ShowExportChunk(chunks, i + 1) end)
+                end or nil,
                 cancelLabel = L["Close"],
             })
+        end
+        local function CopyLogToClipboard()
+            if not DF.DebugConsole then return end
+            ShowExportChunk(DF.DebugConsole:GetExportChunks(), 1)
         end
 
         local actionRow = GUI:CreateButtonRow(self.child, {

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -3922,9 +3922,33 @@ function DF:CreateTestPanel()
             if callback then callback(container.checked, isRaidMode) end
             if isRaidMode and DF.raidTestMode then
                 DF:UpdateRaidTestFrames()
+                -- ☠ SECOND PASS NEXT TICK — the same one ENTRY runs, for the same
+                -- reason. A toggle flipped on for the first time this session CREATES
+                -- its bars during this pass, and an anchor-derived rect is 0 for the
+                -- whole creation tick — so anything anchored to a new bar's own
+                -- texture (the absorb chained to the brand-new prediction fill)
+                -- painted at width 0 and stayed invisible until another toggle pass
+                -- happened by. That is exactly the trap entry's After(0) repaint
+                -- exists for; its comment even says "goes through the SAME
+                -- UpdateTestFrame pathway — no second painter". Field-caught twice on
+                -- the interplay unit (Aphoex + Krathe, 2026-08-15): the first fix
+                -- reordered the painters to live's order — necessary, but it fixed
+                -- the within-pass dependency, not the rects. Hide-then-reshow
+                -- "correcting" it was the tell: a second pass over settled rects.
+                C_Timer.After(0, function()
+                    if DF.raidTestMode and DF.UpdateRaidTestFrames then
+                        DF:UpdateRaidTestFrames()
+                    end
+                end)
             elseif not isRaidMode and DF.testMode then
                 DF:UpdateAllFrames()
                 if DF.RefreshTestFrames then DF:RefreshTestFrames() end
+                -- Same second pass as the raid branch above — see that comment.
+                C_Timer.After(0, function()
+                    if DF.testMode and DF.RefreshTestFrames then
+                        DF:RefreshTestFrames()
+                    end
+                end)
             end
             -- Update badge on parent section
             if container.section and container.section.UpdateBadge then

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -805,15 +805,20 @@ function DF:UpdateTestFrameHealthOnly(frame, index)
     -- (Audit, 2026-08-07.)
     if DF.UpdateReducedMaxHealth then DF:UpdateReducedMaxHealth(frame) end
 
-    -- Update absorb bars if enabled
+    -- ☠ LIVE'S ORDER — heal absorb, prediction, absorb LAST. The absorb chains to the
+    -- prediction's tail and reads its stamps, so it must run after it; see the same
+    -- note at the UpdateTestFrame drive, which is where the one-pass version of this
+    -- ordering bug was field-caught. The ticker repeats every tick, so it self-healed
+    -- one tick late here — but a painter that is only accidentally correct is the
+    -- second-pathway class, and the two drive sites must stay identical.
     if db.testShowAbsorbs then
-        DF:UpdateAbsorb(frame, animatedTestData)
         DF:UpdateHealAbsorb(frame, animatedTestData)
     end
-    
-    -- Update heal prediction if enabled
     if db.testShowHealPrediction ~= false then
         DF:UpdateHealPrediction(frame, animatedTestData)
+    end
+    if db.testShowAbsorbs then
+        DF:UpdateAbsorb(frame, animatedTestData)
     end
     
     -- Update dispel gradient if it's tracking health
@@ -995,24 +1000,28 @@ function DF:UpdateTestFrame(frame, index, applyLayout)
     -- Health text colour + alpha: DF:UpdateHealthTextAppearance owns both, same as the
     -- name text. Applied by the shared pass below.
     
-    -- Update absorb bars
+    -- ☠ LIVE'S ORDER — heal absorb, PREDICTION, absorb LAST — because the absorb DEPENDS
+    -- on the prediction: it chains to the prediction's tail (ResolveAbsorbChainAnchor)
+    -- and its clamp reads the netted-heal stamps UpdateHealPrediction writes
+    -- (dfTotalHeals). This ran absorb FIRST, so a single pass over frames with no
+    -- previous state computed the shield against a prediction that did not exist yet.
+    -- ENTRY hid that: its After(0) geometry repaint runs a second full pass that
+    -- converges everything. The panel-toggle path (RefreshTestFrames) runs ONE pass —
+    -- so flipping the toggles on after a reload that started with them off left the
+    -- cross-dependent frames wrong until the next repaint happened by: the interplay
+    -- unit lost its heal and shield, the reduced-max unit its heal, while a unit whose
+    -- bars barely depend on each other looked fine (Aphoex's video, 2026-08-15 — the
+    -- patchiness IS the dependency graph). ApplyFrameLayout has carried this exact
+    -- ordering note since the band rework; the preview painter just never matched it.
     if db.testShowAbsorbs then
-        DF:UpdateAbsorb(frame, testData)
         DF:UpdateHealAbsorb(frame, testData)
     else
-        if frame.dfAbsorbBar then frame.dfAbsorbBar:Hide() end
         if frame.dfHealAbsorbBar then frame.dfHealAbsorbBar:Hide() end
-        if frame.absorbOvershieldGlow then frame.absorbOvershieldGlow:Hide() end
-        if frame.absorbOverflowBar then frame.absorbOverflowBar:Hide() end
         if frame.healAbsorbOvershieldGlow then frame.healAbsorbOvershieldGlow:Hide() end
-        -- Hide attached textures used for ATTACHED mode test display
-        if frame.absorbAttachedTexture then frame.absorbAttachedTexture:Hide() end
         if frame.healAbsorbAttachedTexture then frame.healAbsorbAttachedTexture:Hide() end
-        -- Hide overflow bar
-        if frame.absorbOverflowBar then frame.absorbOverflowBar:Hide() end
     end
-    
-    -- Update heal prediction (check test mode setting)
+
+    -- Heal prediction (check test mode setting) — BEFORE the absorb, which chains to it.
     if db.testShowHealPrediction ~= false then
         DF:UpdateHealPrediction(frame, testData)
     else
@@ -1023,6 +1032,17 @@ function DF:UpdateTestFrame(frame, index, applyLayout)
         -- pathway would, or the chain reads a bar nobody can see.
         if frame.dfHealPredictionBar then frame.dfHealPredictionBar:Hide() end
         if frame.dfHealPredictionBar2 then frame.dfHealPredictionBar2:Hide() end
+    end
+
+    -- Damage absorb LAST — reads the prediction's chain tail and stamps.
+    if db.testShowAbsorbs then
+        DF:UpdateAbsorb(frame, testData)
+    else
+        if frame.dfAbsorbBar then frame.dfAbsorbBar:Hide() end
+        if frame.absorbOvershieldGlow then frame.absorbOvershieldGlow:Hide() end
+        if frame.absorbOverflowBar then frame.absorbOverflowBar:Hide() end
+        -- Hide attached texture used for ATTACHED mode test display
+        if frame.absorbAttachedTexture then frame.absorbAttachedTexture:Hide() end
     end
 
     -- Update power/resource bar


### PR DESCRIPTION
Eleven commits: five field-reported bugs, then a rework of the aura identity gate after that gate turned out to be the cause of one of them and wrong in two further ways.

**Nothing here is confirmed in game yet**, so there are no changelog entries. Several items change what renders on live aura rows and want a pass before merge — the verification notes are at the bottom.

---

## Field-reported fixes

**Missing-buff icons only appeared on your own frame** — `RefreshMissingBuffVisibility` tested `UnitIsPlayer` on every frame, so in a follower dungeon, where every party member is an NPC, the strip hid on all of them. The term was added to stop a story-mode companion nagging about raid buffs nobody can give it; that bug is real but narrower than the code it shipped as — the companion sat on a pinned frame, which is how the changelog scoped it. The function header already said not to do this, in a paragraph recording that raid buffs *are* castable on follower-dungeon NPCs. The header was right; the term is now scoped to pinned frames. *Reported by Aur0r4 on 5.1.3 against a fresh profile.*

**Nine Lua errors on joining a raid** — `GetCurrentSet()` addressed `sets[activeHighlightTab]` and the index is clamped into the live set list exactly once, when the page is built. A mode switch does not rebuild the page, it drives the refresh path, so a tab index valid for the party side survived into a raid side with fewer sets. The clamp now runs inside the accessor, covering all ~27 call sites rather than the one in the stack trace — ten of those are writes and would have thrown identically. *Reported by Aphoex.*

**Raid pinned frame stuck on screen after leaving a raid** — `Reinitialize` bails early when no set is enabled, to skip rebuilding nothing. But that question is answered from the *new* mode's sets, and the one case it is false during a mode change is exactly the case where old-mode frames are still up with nothing left to hide them. It returned before any teardown. `PruneOrphanedSets` now runs first. *Reported by Aphoex.*

**Test mode: pandemic cue kept flashing after being switched off, and the cooldown swipe ran once** — the holders are create-once and only hidden when the cue is disabled, so testing "is there a holder" answered "was this ever configured", not "is it configured now": the style pass hid it and the pending timer showed it straight back, once per cycle, until a reload. Each gate now stamps whether its cue is wanted. Separately, the re-arm claimed that mutating the shared duration restarts bar, swipe and text together — true of the bar and text, which are bound to the duration object, but the swipe is a separate cooldown frame that nothing re-drove. Both lanes now drive it. *Reported by Aphoex.*

**Aura Designer indicators kept rendering after their config stopped resolving** — `SyncFrame` had two "nothing to render" exits three lines apart; one released its containers and one abandoned them. Skipping the sync does not stop anything rendering, so the previous config's indicators stayed on screen at their old positions until a reload. Not claimed as the proven cause of the profile-reset report, since the full reset does reseed the designer template library — it is a real leak on its own merits and closes one of the two ways that symptom can arise.

---

## The identity gate

Several healers reported HoTs missing on some group members, intermittently, with the auras verifiably still applied. That turned out to be this gate, and reviewing it against the shipped client turned up two further faults.

**Background.** `candidateFilters.includeSpellIDs` / `excludeSpellIDs` are applied only inside `AuraContainerUtil.CanApplyIdentityCandidateFilters`, which rejects a harmful aura when you can assist the unit and a helpful one when you cannot. When it rejects, the filters are silently skipped and every aura passes — a whitelisted buff row becomes every buff on the unit. Nothing reports it, and the engine only re-parses on aura events, so a parse made during that window persists after trust returns.

**1. The verdict was one-way.** `IdentityUnavailable` folds dead/ghost and disconnected into the assist verdict, but the watcher registered no event for either. A unit that died or dropped took the false on whatever unrelated event happened to sweep, and coming back produced no sweep at all — so no re-parse and no un-hide, and the row stayed empty until something unrelated swept it. `UNIT_FLAGS` and `UNIT_CONNECTION` now drive it, plus the death latch's own dead/alive edge.

`PARTY_MEMBER_ENABLE`/`DISABLE` did not cover this: they are party-scoped and do not fire for raid members, which is why the clearest report was a 40-player raid ("cannot see my riptides on group 5/6/7/8"). Blizzard's own `CompactUnitFrame` registers exactly this pair per unit and DF already relied on both for pet death detection, so this was an inconsistency within our own codebase rather than unknown API.

**2. The sweep was narrower than the gate.** `IdentityGateSweep` filtered on two terms while the gate itself had widened to three, so a row carrying gated groups without being hide-vulnerable was never swept and its park verdict could be set at build and never re-evaluated. Both now share one predicate so they cannot drift again.

**3. The park was keyed on filters the engine never skips.** It parked records asserting `isBossAura` / `isBossOrRoleAura` / `isRoleAura` / `isPriorityAura`. Per `DoesAuraPassCandidateFilters`, only the two spell-ID keys sit inside the identity block; those four are evaluated after it, unconditionally. Nor can their categorisation be poisoned by lost identity — the engine evaluates `IsRoleAura` (which reads aura role flags, not spell ID) and `IsPriorityDebuff` (a secure call with the real ID) itself. And even granting the one thing source cannot settle, that those fields might be unpopulated on an untrusted unit, each is applied as an equality test, so `nil` rejects against both `true` and `false`. They fail closed in both directions. There was no leak to prevent, only rows the park could empty by mistake — which is what produced the dispel highlight lit with no debuff icon under it.

**What the park keys on now:** helpful records carrying spell-ID filters, which is what the engine actually skips. That single re-key retired the old park and created the buff-side one, because it is the same key set. Previously one vulnerable record marked the whole handle and the hide emptied the handle, so a buff row lost its token groups because an unrelated spell-ID group sat beside them. Now only the affected records go dark. Slot-backed rows park by empty filter string, since a slot has no frame count. Hide is kept as a fallback for a handle that is vulnerable but registered no gated keys, or that pool would render fully open with nothing suppressing it.

**4. `NeverSecret` is now modelled, asymmetrically.** The engine checks spell secrecy first and it wins outright, so an exclude-only pool whose entire set is `NeverSecret` cannot change behaviour on lost trust and is exempt from the park. An include pool can never take that exemption, whatever its map holds — the leak is every *other* secret aura skipping the include test, which is a property of the aura being tested, not of our map.

**5. Slot park keys are seeded at birth.** Both slot build branches registered the button without populating the park set, and the tuning rebuild only runs when something changes — so a slot-backed handle built while trusted met its first trust loss with an empty set and fell through to the whole-handle hide.

---

## Diagnostics

`/df debug idgate` reported the hide path and was silent on everything else, which is why none of the above was visible in the tool built to see it. It now also walks slot handles (every placed Aura Designer indicator is one, and they were never dumped), and reports the park state and the untrusted verdict behind it, the cinematic and death latches, the gated-group count, the recovery-edge tracker that answers "will this un-hide on its own", and global aura secrecy. Diagnostic only.

---

## Verification notes

Every changed file parses and its global reads are unchanged from the base. All reasoning is derived from the shipped client source, and the park change was cross-checked against how other 12.1 implementations split the same problem. None of it is verified in game.

Worth a pass before merge, in rough order of blast radius:

- **Buff and debuff rows on a cross-faction or phased unit** — the row should lose only its spell-ID-filtered records, not its token records. This is the behaviour change with the widest reach.
- **HoTs on a group member who dies and is resurrected** — they should return without needing to target the unit. Targeting is itself a sweep trigger, so checking that way can mask the fault.
- **The debuff row generally**, since the old park no longer fires: dispel highlight and debuff icons should agree.
- Follower dungeon: missing-buff icons on NPC party members.
- Joining a raid with the options window open on the Pinned Frames page.
- Leaving a raid with a raid-only pinned set enabled and nothing enabled on the party side.
- Test mode: toggle pandemic off, and watch the cooldown swipe loop.

`/df debug idgate` will show the park, latch and recovery state for each of these directly.


---

# Round 2 — nine further commits

**One item in this round is confirmed in game** (the test-panel toggle fix, changelogged accordingly); the rest follow the same rule as round 1 — no changelog entry until confirmed.

## Show Overheal never worked, in three acts

The heal prediction never rendered past full health with Show Overheal on. Three commits, because the first two fixes were each one layer short and the field caught both:

1. The overflow percent is a **ceiling on the sum**, not a share to display — the API doc is explicit that only values *over* 1.0 permit extending past maximum health, and the code set 1.0 unconditionally with a comment reading it backwards. The toggle has been cosmetic since the calculator port.
2. The first working value (2.0) was an outlier — surveyed against the field, the reference implementations cap the tail at 1.05 or show none, so the ceiling is now one shared 1.05 constant used by both live and the test mirror, which had been previewing the overhang uncapped.
3. The ceiling only binds in **clamp mode 0** — mode 1 is a plain value cap with no overflow term, so a near-full unit drew the prediction across the entire frame (field screenshot). Both toggle states now use mode 0 and the toggle drives only the ceiling: missing-health cap when off, missing + 5% when on. That is also literally the stock compact-frame formula.

## Raid unlock overlay unfaithful below 8 groups per row

With Center alignment the CENTER-shift was accounted three different ways: the live container carried it, the *test frames* carried it (a testMode fork inside the position calculator), and the mover never carried it — so the overlay drew half a group-row away from the content it claims to bound. The compensation now lives in exactly one place: `ComputeRaidContainerCompensation` is mode-aware (test derives its populated count from the test roster, since the handler attributes describe the live roster), and the one positioner applies it to the live container, the test container and the mover alike. The calculator's testMode fork is retired, so the preview differs from live in data only. The unlock path converges through the positioner instead of leaving raw anchors on screen.

## Pet frames under neighbouring health fills on first test entry

The owner-level+15 elevation is applied at style time, and on the first entry of a session the pet is styled in the same tick its owner frame is being built — capturing a pre-layout level. `SetPetFrameVisible` now re-derives strata and level from the owner's *current* level on every show, which covers first entry, the in-test toggles (which showed/hid without re-styling), and live pets whose owner's level moved while hidden.

## Test-panel bar toggles left cross-dependent frames wrong — ✅ confirmed in game

Two commits, and the second matters: reordering the test painters to live's order (heal absorb → prediction → absorb last, since the absorb chains to the prediction's tail and reads its stamps) was necessary but not sufficient. The remaining fault was the creation-tick rect rule one level down: a toggle flipped on for the first time in a session *creates* its bars that pass, and the absorb then anchors to the brand-new prediction fill's zero-width rect. Entry has always cured this with its next-tick second pass; the toggle path never had one. Both checkbox branches now queue the identical second pass. Verified against the exact field repro (reload with toggles off → enter test → flip on → matches a fresh entry).

## Review follow-up

The self-review's finding 1 is fixed: the unresolvable-config teardown in `Factory:SyncFrame` now latches like the MemTest branch beside it, instead of re-running the teardown walks and a SyncSound reconcile on every sync pass — and the comment that wrongly called that repetition free is corrected.

## Verification notes (round 2)

Confirmed in game: the test-panel toggle fix. Still to check:
- Overheal on → a bounded ~5% tail past the bar on a near-full target; off → flush at the edge; test mode shows the same tail as live.
- Raid unlock overlay with Center alignment and Groups Per Row 7 — the box bounds all eight groups, dragging included.
- Pet frames above neighbouring fills on the first test entry of a session.


---

# Round 3 — five further commits (field reports, 2026-08-15)

## Duration text showed the final second twice ("3, 2, 1, 1, gone")

The seconds bands used floor rounding with a `min = 1` clamp: at 1.9s remaining the floor is 1, at 0.9s it is 0 and the clamp pushes it back to "1" — so the last digit held for two seconds and the countdown never reached its end cleanly. All seconds-shaped bands now **ceil** (a countdown digit means "at most this many seconds remain"), so each digit holds exactly one second and the text vanishes at expiry. Applied consistently across every path: the plain NUMBER and TIMER builders, the banded builder (colour-by-time / hide-above / alerts), and SHORT/FULL via the native formatter's RoundUp mode — the Defensive Icon and Aura Designer ride the same resolver. The old truncation was a deliberate parity choice with the stock frames' mid-range display; the end-of-countdown behaviour is the case users actually watch, and ceiling keeps every DF format agreeing with every other at every instant.

## Global Font "Apply to All" never reached the Aura Designer

The AD block existed but silently did nothing, for three independent reasons: the defaults write was skipped when the defaults table was absent; the per-instance override clearing iterated `auras` one level short of its spec-keyed shape (`auras[spec][auraName]`) — and since every placed indicator stamps its fonts at creation, instance values shadowed the defaults forever; and group text styles (filter groups, Other groups, debuff category groups) were never touched at all — they carry their style on the group record with no defaults fallback. The handler now creates the defaults table, clears indicator font/outline overrides across both aura pools (including pre-migration per-type sub-tables), and writes group styles explicitly. The Text Designer branch got the same create-if-missing hardening.

## Identity gate: battleground hardening + its own debug lane

Field reports of missing auras in PvP (mostly raid groups 5–8, on the live release) match the missing-events class already fixed in round 1 — beyond the player's own subgroup there was no death/connection signal at all, and battlegrounds are a constant death/release/resurrect cycle, so the one-way verdict struck continuously. Two additions harden and instrument it:

1. **Combat-exit sweep**: `PLAYER_REGEN_ENABLED` joins the gate watcher. A park apply that fails in combat reverts its flag and retries on the next sweep — regen is now the guaranteed retry edge instead of hoping an unrelated event arrives.
2. **IDGATE debug category**: every gate transition (park/hide, recovery re-parses, slot twins, death and cinematic latches) logs under its own opt-in console category, each line carrying the probe that broke trust (cannot-assist / dead-ghost / offline / self-vehicle / not-visible / phased). `/df debug idgate` gains a `why=` column per handle and prints the last 15 logged lines. Off by default like every category; the first cut wrote an always-on saved-variable ring and was reworked the same day to opt-in on request, with a one-shot scrub for the ring key.

## Changelog

Entries added for the gate recovery fix, the countdown ending, the Apply-to-All reach, and the IDGATE category.

## Verification notes (round 3)

- Any short buff's countdown ends 3 → 2 → 1 → gone, one second per digit, in the rows, the Aura Designer and the Defensive Icon (all formats, colour-by-time on and off).
- Global Fonts → Apply to All changes the font shown on AD indicator cards, group cards and the rendered buttons immediately.
- In a battleground: HoTs/buffs on members of other groups reappear on their own after the member dies and is resurrected, without targeting them. With the IDGATE category enabled, `/df debug idgate` shows the park/restore trail with reasons.

## Round 3 addendum — the debug console itself was unusable at scale

Field-caught while using the console for the work above: with the log at 10k entries, the Live Log box went **completely blank** for any broad category selection (and the export popup with it), while tiny categories rendered fine. Two commits:

1. **Render cap.** The box grows its EditBox height by line count, and past a region-size ceiling (~32k px, roughly 2,700 lines at this font) the renderer draws nothing at all — not even the "no entries match" message. The display code predates the retention default being raised from 500 to 10000 lines, which is what exposed it. Retention and rendering are now separate budgets: the log still keeps 10000 entries, the box renders the newest 1000 matching lines, and a banner line states how many older matches are held back. One shared collector now feeds both the live view and the export (the export previously filtered on the unsanitised category, so the two could disagree).
2. **Paged export.** Capping the export would lose the thing it exists for, so it formats every matching line and slices into 1000-line parts: one part behaves exactly like the old dialog; more parts add a "Next Part" button, each part's header naming its line range so multi-part pastes reassemble unambiguously.

## Verification notes (round 3 addendum)

- With 10k+ log entries and every category ticked: the Live Log renders (newest 1000, banner on top), and Copy to Clipboard offers "part 1 of N" with working paging.
- A narrow selection (one quiet category) behaves exactly as before: full list, single export dialog.
