### PR TITLE
Debuff row dedup, important-debuff marker preview, and the per-character macro import fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * (Bars) Fix solo-mode resource bars appearing on frames other than your own. (by Krathe)
 * (Aura Designer) Fix the enable toggle silently changing your Show Buffs setting when nothing needed to change. (by Krathe)
 * (Test Mode) The preview honours Smooth Bar Animation and labels which slot is you. (by Krathe)
+* (Click Casting) Fix importing per-character macros erroring out and showing nothing — the game moved the account-macro limit this build, and the import read the old name. (by Krathe)
 * (Debuff Bar) Fix debuffs appearing twice when Non-Player Debuffs was enabled alongside another category. Any mob-cast debuff that was also dispellable, crowd control or raid-flagged was counted by both categories, so trash packs applying poison and disease filled the row with pairs of identical icons and pushed past the icon limit. (by Krathe)
 * (Auras) Fix buffs and debuffs sometimes staying hidden on group members after they died, released or disconnected — the frame only recovered when something else refreshed it, such as targeting that player. Most reported by healers missing HoTs on raid groups outside their own, and constant in battlegrounds. (by Krathe)
 * (Auras) Duration text now counts down cleanly to the end — 3, 2, 1, gone — instead of showing the final second twice. Applies to every duration format, the Aura Designer and the Defensive Icon. (by Krathe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * (Bars) Fix solo-mode resource bars appearing on frames other than your own. (by Krathe)
 * (Aura Designer) Fix the enable toggle silently changing your Show Buffs setting when nothing needed to change. (by Krathe)
 * (Test Mode) The preview honours Smooth Bar Animation and labels which slot is you. (by Krathe)
+* (Debuff Bar) Fix debuffs appearing twice when Non-Player Debuffs was enabled alongside another category. Any mob-cast debuff that was also dispellable, crowd control or raid-flagged was counted by both categories, so trash packs applying poison and disease filled the row with pairs of identical icons and pushed past the icon limit. (by Krathe)
 * (Auras) Fix buffs and debuffs sometimes staying hidden on group members after they died, released or disconnected — the frame only recovered when something else refreshed it, such as targeting that player. Most reported by healers missing HoTs on raid groups outside their own, and constant in battlegrounds. (by Krathe)
 * (Auras) Duration text now counts down cleanly to the end — 3, 2, 1, gone — instead of showing the final second twice. Applies to every duration format, the Aura Designer and the Defensive Icon. (by Krathe)
 * (Global Fonts) Apply to All now reaches the Aura Designer: the global text defaults, every placed indicator and all group text styles take the chosen font and outline. Previously it silently changed nothing there. (by Krathe)
@@ -43,6 +44,7 @@
 ### Improvements
 
 * (Aura Designer) The filter picker now has a scrollbar and a search box, matching the addon's other dropdowns.
+* (Debuff Bar) The Important Debuffs settings box now previews the corner marker beside its title, in the colours you picked, and greys it out while the marker is switched off. (by Krathe)
 * (Debug) New IDGATE debug category traces every aura-visibility gate decision with its reason (dead, offline, cross-faction, in a vehicle, phased) — enable it when chasing a "my auras vanished" report, then check /df debug idgate. (by Krathe)
 
 ## [5.1.3]

--- a/DandersFrames/ClickCasting/Bindings.lua
+++ b/DandersFrames/ClickCasting/Bindings.lua
@@ -3205,9 +3205,18 @@ end
 function CC:GetWoWCharacterMacros()
     local macros = {}
     local numGlobal, numPerChar = GetNumMacros()
-    
-    -- Character macros start after global ones (index 121+)
-    local startIndex = MAX_ACCOUNT_MACROS + 1
+
+    -- Character macros start after the account block.
+    -- ☠ THE COUNT IS `Constants.MacroConsts.MAX_ACCOUNT_MACROS`, NOT A GLOBAL. The bare
+    -- global was removed; reading it here threw "attempt to perform arithmetic on global
+    -- 'MAX_ACCOUNT_MACROS' (a nil value)" and broke per-character macro import outright
+    -- (field-reported). Blizzard's own MacroUI reads the same constant table.
+    -- The literal is the LAST resort only: a hardcoded 120 silently reads the wrong slots
+    -- the day Blizzard changes the account allowance, so prefer the live constant and let
+    -- the fallback cover a client that lacks the table entirely.
+    local MC = _G.Constants and _G.Constants.MacroConsts
+    local accountMax = (MC and tonumber(MC.MAX_ACCOUNT_MACROS)) or 120
+    local startIndex = accountMax + 1
     for i = startIndex, startIndex + numPerChar - 1 do
         local name, icon, body = GetMacroInfo(i)
         if name then

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -284,18 +284,25 @@ local function BuildDirectDebuffFilters(db, claimed)
 
     -- Negation suffix for a group, given which higher-priority token filters
     -- apply to it. ALL-mode dispel dedups via excludeDispelTypes (see cfFor).
-    -- Token precedence among the NON-important records is dispel > CC > raid, so only
-    -- those two exclusions are ever needed. There is deliberately no raid exclusion:
-    -- raid is the last token record, and the important records above no longer negate
-    -- anything (they subtract via candidateFilters instead — see IMPORTANT-FIRST
-    -- PRECEDENCE below), so nothing is left that would need to exclude it.
-    local function neg(excludeDispel, excludeCC)
+    -- Token precedence among the NON-important records is dispel > CC > raid >
+    -- non-player, so each record excludes the ones above it.
+    -- ☠ THE RAID EXCLUSION IS NOT OPTIONAL ANY MORE, and the comment that used to sit
+    -- here said it was ("raid is the last token record, so nothing needs to exclude
+    -- it"). That was true when it was written and stopped being true the moment the
+    -- NON-PLAYER record was added below it — see that record's own note. Every
+    -- exclusion is keyed on the CONFIG flag, not on the record existing: a category
+    -- claimed by an Aura Designer group is shown there instead, so subtracting it
+    -- here is the dedup working, not a leak.
+    local function neg(excludeDispel, excludeCC, excludeRaid)
         local s = ""
         if excludeDispel then
             if playerMode then s = s .. "|!" .. dispelToken
             elseif anyToken then s = s .. "|!" .. anyToken end
         end
         if excludeCC and ccToken then s = s .. "|!" .. ccToken end
+        -- "RAID" is negatable (only INCLUDE_NAME_PLATE_ONLY and MAW are not —
+        -- AuraUtil.AuraFilters / IsValidFilterString).
+        if excludeRaid and raidOn then s = s .. "|!RAID" end
         return s
     end
     -- candidateFilters for one record. Hands each record its OWN table (extra
@@ -391,8 +398,21 @@ local function BuildDirectDebuffFilters(db, claimed)
     -- ⚠ No claim key yet: an Aura Designer group cannot claim this category, so the
     -- record always builds when the option is on. Add one beside the others if a group
     -- ever needs to take it over.
+    -- ☠☠ IT MUST NEGATE THE TOKEN RECORDS ABOVE IT, and for its first months it did not.
+    -- Every other record in this function subtracts its higher-precedence siblings;
+    -- this one shipped as a bare "HARMFUL" plus one candidate boolean, so ANY mob-cast
+    -- debuff that was also dispellable / crowd-control / raid-flagged rendered TWICE —
+    -- once here and once in that record. There is NO cross-group dedup in the engine
+    -- (each AddAuraGroup parses the whole pool independently), so overlapping filters
+    -- are the only thing standing between a config and double-rendered icons.
+    -- Field shape: trash packs applying poison and disease (both dispellable, both
+    -- mob-cast) filled the row with pairs of identical icons and blew past the row's
+    -- Max Debuffs, because that cap is PER GROUP — 4 categories x 3 = up to 12
+    -- (Beans, 5.2.0-alpha.1, Vaults of Atal'Ulek and delves).
+    -- ⚠ In ALL-mode dispel the exclusion rides cfFor's excludeDispelTypes instead, so
+    -- neg's dispel half is correctly inert there — the two paths must not double up.
     if db.debuffFilterNonPlayer then
-        filters[#filters + 1] = { filter = "HARMFUL", key = "nonplayer",
+        filters[#filters + 1] = { filter = "HARMFUL" .. neg(true, true, true), key = "nonplayer",
                                   candidateFilters = cfFor(false,
                                       notImportant({ isFromPlayerOrPlayerPet = false })) }
     end

--- a/DandersFrames/FilterRegistry/SpellDB.lua
+++ b/DandersFrames/FilterRegistry/SpellDB.lua
@@ -47,8 +47,10 @@ R.Excluded = {
     [59752]   = "Will to Survive — 100ms stun-immunity blip; nothing to display",
     [422382]  = "Wild Growth log-side id — no client-side spell data (audit INVALID)",
     [1308649] = "Vampiric Insight — no client-side spell data (audit INVALID); re-add with the corrected id from the harvest",
-    [443113]  = "Strength of the Black Ox (ally absorb) — spec-variable rider, not worth tracking (maintainer curation)",
-    [443112]  = "Strength of the Black Ox (self cast-time buff) — same call as 443113",
+    -- (Removed 2026-08-15) 443113/443112 Strength of the Black Ox — un-excluded on
+    -- Krathe's ruling after user demand (lab thread dfc19c2f): "add it, default off".
+    -- Both ids already live upstream, so the next regen lands the record; the lab
+    -- side flags it as an off-by-default candidate so the flag arrives with it.
 }
 
 -- Maintainer category overrides — the FINAL category set for these ids, replacing

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -999,14 +999,42 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         -- placement. Every change is STRUCTURAL (region presence / group layout cell /
         -- the group's init closure), so each callback must invalidate rather than
         -- lightweight-reposition — same pair the Hide Duplicate Debuffs toggle uses.
+        local UpdateImportantSwatch   -- assigned below, once the header exists
         local function ImportantChanged()
             if DF.RebuildDirectFilterStrings then DF:RebuildDirectFilterStrings() end
             if DF.InvalidateAuraLayout then DF:InvalidateAuraLayout() end
+            -- The marker's own colour pickers change nothing structural on this page,
+            -- so nothing else would repaint the swatch.
+            if UpdateImportantSwatch then UpdateImportantSwatch() end
         end
         local function ImportantOff(d) return not d.showDebuffs or not d.debuffImportantHighlight end
 
         local impGroup = GUI:CreateSettingsGroup(self.child, 280)
-        impGroup:AddWidget(GUI:CreateHeader(self.child, L["Important Debuffs"]), 40)
+        -- Header carries a live preview of the corner marker itself (asked for in the
+        -- field: the section names a feature whose art you otherwise cannot see without
+        -- pulling a mob). Greys out — like the icon sections' previews — whenever the
+        -- marker is not actually rendering: debuffs off, highlight off, or marker off.
+        local impHeader = GUI:CreateHeader(self.child, L["Important Debuffs"])
+        impGroup:AddWidget(impHeader, 40)
+        -- 13px: the marker art is a filled disc, so it reads heavier than the padded
+        -- icon atlases the section previews use — matched to the header text rather
+        -- than to the other swatches' 16.
+        local impSwatch = GUI:AttachHeaderSwatch(impHeader, 13, 2)
+        UpdateImportantSwatch = function(d)
+            if not impSwatch then return end
+            d = d or DF.db[GUI.SelectedMode]
+            if not d then return end
+            impSwatch:SetSwatch({
+                { texture = "Interface\\AddOns\\DandersFrames\\Media\\DF_AlertBadge",
+                  color = d.debuffImportantBadgeColor },
+                { texture = "Interface\\AddOns\\DandersFrames\\Media\\DF_AlertMark",
+                  color = d.debuffImportantMarkColor },
+            }, not d.showDebuffs or not d.debuffImportantHighlight or d.debuffImportantBadge == false)
+        end
+        -- RefreshChildStates calls refreshContent(db) on every shown child, so the
+        -- swatch follows a mode switch / profile load without its own event.
+        impHeader.refreshContent = function(_, d) UpdateImportantSwatch(d) end
+        UpdateImportantSwatch(db)
         impGroup:AddWidget(GUI:CreateLabel(self.child,
             L["Makes boss, role and priority debuffs stand out in the normal debuff row."], 250), 30)
         local impOn = impGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Highlight Important Debuffs"],

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -204,8 +204,64 @@ function GUI:CreateHeader(parent, text)
     if DF.Search then
         DF.Search:SetCurrentSection(text)
     end
-    
+
     return container
+end
+
+--- Attach a small live preview swatch to a header built by GUI:CreateHeader —
+--- the plain-header counterpart of a collapsible section's SetPreviewIcons, for
+--- sections whose setting produces ONE small piece of art (the important-debuff
+--- corner marker). It sits immediately right of the title rather than at the
+--- group's right edge: a lone swatch only reads as "this is the thing this
+--- section makes" when it sits with the words.
+---
+--- `layers` draws 1..N textures in order with their own colours, because the real
+--- art is often layered (the marker is a tinted disc plus a tinted glyph) — a
+--- one-texture swatch would preview a white blob and lie about the colours, which
+--- is the exact fault the section-preview swatches were corrected for.
+---
+--- Greying: pass dimmed=true and every layer desaturates and drops alpha, matching
+--- the icon sections' `desaturate` convention. Drive it from the owning header's
+--- `refreshContent` so RefreshChildStates keeps it live (see CreateSettingsGroup).
+function GUI:AttachHeaderSwatch(header, size, layerCount)
+    if not header or not header.text then return nil end
+    if header.swatch then return header.swatch end
+    local SZ = size or 16
+    local sw = CreateFrame("Frame", nil, header)
+    sw:SetSize(SZ, SZ)
+    sw:SetPoint("LEFT", header.text, "RIGHT", 6, 0)
+    sw.layers = {}
+    for i = 1, (layerCount or 2) do
+        -- Ascending sublevel so layer 2 draws over layer 1 (disc, then glyph).
+        local t = sw:CreateTexture(nil, "OVERLAY", nil, i)
+        t:SetAllPoints()
+        t:Hide()
+        sw.layers[i] = t
+    end
+    --- layers: { { texture = path, color = {r,g,b,a}? }, ... }
+    sw.SetSwatch = function(self, layers, dimmed)
+        for i, t in ipairs(self.layers) do
+            local d = layers and layers[i]
+            if d and d.texture then
+                t:SetTexture(d.texture)
+                t:SetDesaturated(dimmed and true or false)
+                -- ⚠ AFTER the texture call — SetTexture/SetAtlas reset vertex colour.
+                -- Same trap documented on the section preview swatches.
+                if dimmed then
+                    t:SetVertexColor(0.5, 0.5, 0.5, 0.55)
+                elseif d.color then
+                    t:SetVertexColor(d.color.r or 1, d.color.g or 1, d.color.b or 1, d.color.a or 1)
+                else
+                    t:SetVertexColor(1, 1, 1, 1)
+                end
+                t:Show()
+            else
+                t:Hide()
+            end
+        end
+    end
+    header.swatch = sw
+    return sw
 end
 
 -- Collapsible section for grouping related settings.


### PR DESCRIPTION
Three field-reported items on top of `v5.2.0-alpha.2`.

## Non-player debuffs double-rendered, and blew past Max Debuffs

The debuff row declares one aura group per selected category, and **the engine does no cross-group dedup** — each `AddAuraGroup` parses the whole pool independently — so every record has to subtract the higher-precedence ones. Order is important (boss/role, priority) → dispel → crowd control → raid → non-player; the important pair subtract via `candidateFilters`, the token records via filter-string negations.

The **Non-Player Debuffs** record shipped as a bare `HARMFUL` plus one candidate boolean, with no negations at all. So any mob-cast debuff that was *also* dispellable, crowd control or raid-flagged rendered **twice** — once in its own category and once here. Reported on trash packs applying poison and disease: both dispellable, both mob-cast, so the row filled with pairs of identical icons.

It also explains the second half of the report — "more than the 3 debuffs I set" — because `maxFrameCount` is **per group** and Blizzard exposes no container-level cap: four categories at three each is up to twelve icons, and the doubling used that headroom up fast. The dedup fix removes the doubling; the per-category arithmetic itself is an engine limit (counts are secret, and filter-string tokens AND rather than OR, so the categories cannot be collapsed into one group). Worth a separate decision if "Max Debuffs" should be re-presented as per-category.

`neg()` grows a raid arm to express this. `RAID` is negatable — only `INCLUDE_NAME_PLATE_ONLY` and `MAW` are not (`AuraUtil.IsValidFilterString`). Every exclusion stays keyed on the config flag rather than on the record existing, so a category claimed by an Aura Designer group is still subtracted here, which is the dedup working rather than a leak.

## Important Debuffs: preview the marker on its header

Asked for in the field — the section names a feature whose art you otherwise cannot see without pulling a mob. `GUI:AttachHeaderSwatch` is the plain-header counterpart of a collapsible section's `SetPreviewIcons`:

- **Layered**, so the swatch shows the real tinted disc plus glyph in the user's own colours. A single-texture swatch would preview a white blob and misstate the colours — the same fault the section previews were corrected for.
- **Greys out** via the icon sections' `desaturate` convention whenever the marker is not actually rendering: debuffs off, highlight off, or marker off.
- Repaints from the header's `refreshContent` (so it follows mode switches and profile loads) and from the section's own change callback (so both colour pickers update it live).

## Strength of the Black Ox is no longer excluded

Both ids leave `R.Excluded` so the next SpellDB regeneration carries the record, per the curation decision — it was excluded to solve a noise problem, which is what the off-by-default flag is for.

## Verification notes

- Trash pack applying poison/disease with Non-Player plus Dispellable (or Crowd Control / Raid) enabled: one icon per debuff, not two.
- A category claimed by an Aura Designer debuff group still disappears from the row.
- Important Debuffs header shows the marker in its configured colours; it greys when the highlight or the marker is switched off, and follows a party/raid mode switch.


## Per-character macro import threw on a removed global

`MAX_ACCOUNT_MACROS` is no longer a bare global — it moved into `Constants.MacroConsts` (still 120, with `MAX_CHARACTER_MACROS` at 30 beside it), which is where Blizzard's own macro UI reads it. `CC:GetWoWCharacterMacros` still read the global, so computing the first character-macro slot threw *"attempt to perform arithmetic on global 'MAX_ACCOUNT_MACROS' (a nil value)"* and the import dialog came up empty. Field-reported with a stack through `ClickCasting/UI/Dialogs.lua`.

Now read from the constant table, with the literal kept only as a last-resort fallback — hardcoding it outright would silently read the wrong slots the day the account allowance changes.

Swept the rest of the addon for the same class (removed global read as a constant): no other `MAX_*` reads anywhere, and of the constant-style globals we do read, only `STANDARD_TEXT_FONT` and `GAME_LOCALE` are absent from the 12.1 source — both already nil-guarded at their call sites (`SafeSetFont` coerces a nil font to its fallback; the locale read is `GAME_LOCALE or gameLocale`).

Verification: Click Casting → import macros → the per-character tab lists this character's macros with no error.
