### PR TITLE
Pinned frames under the 12.1 containers, aura row geometry, and Indicator Info for test mode

### DIFF
--- a/DandersFrames/AuraDesigner/Engine.lua
+++ b/DandersFrames/AuraDesigner/Engine.lua
@@ -90,16 +90,11 @@ function Engine:ForceRefreshAllFrames()
     if DF.IterateRaidFrames then
         DF:IterateRaidFrames(TryUpdate)
     end
-    if DF.PinnedFrames and DF.PinnedFrames.initialized and DF.PinnedFrames.headers then
-        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
-            local header = DF.PinnedFrames.headers[setIndex]
-            if header and header:IsShown() then
-                for i = 1, 40 do
-                    local child = header:GetAttribute("child" .. i)
-                    if child then TryUpdate(child) end
-                end
-            end
-        end
+    -- ☠ THROUGH THE SHARED WALKER, NOT A HAND-ROLLED HEADER LOOP — this walked
+    -- PinnedFrames.headers only, so an Aura Designer edit never reached a pinned BOSS
+    -- frame, and neither did the AD-off teardown. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(TryUpdate)
     end
 
     -- The native factory buff row derives its Aura-Designer dedup set from the AD

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -1425,25 +1425,38 @@ function DF:LightweightUpdateFontShadows()
     end
 end
 
--- Update only power/resource bar height
-function DF:LightweightUpdatePowerBarSize()
+-- ☠☠ THE RESOURCE-BAR DRAG PREVIEW RUNS THE LIVE LAYOUT. Both of these were hand-rolled
+-- forks of DF:LayoutResourceBar, and both were wrong in ways only visible mid-drag —
+-- which is exactly where a "lightweight" copy is least likely to be checked.
+--
+--   * POSITION forked `ClearAllPoints()` + ONE `SetPoint`. With "Match Health Bar
+--     Width/Height" on — the DEFAULT — the real layout sizes the matched axis purely by
+--     TWO anchor points and never calls SetWidth, so the bar carries no explicit width for
+--     its whole life. Dropping to a single point collapsed it to width 0: the bar VANISHED
+--     for the duration of the drag and returned on release, when the full update
+--     re-applied both points. (Aphoex 3.1, party and raid alike.)
+--   * SIZE forked the axis mapping and never read `resourceBarOrientation`, while the real
+--     layout swaps the axes for a vertical bar — so on a vertical bar the two sliders drove
+--     the wrong dimensions mid-drag and snapped back on release.
+--
+-- Routing both at the live function retires the fork rather than patching each symptom,
+-- and it is the standing rule for every preview surface: differ in DATA, never in
+-- RENDERING.
+-- ⚠ It costs more per tick than the old copies. That is the point — they were cheap
+-- because they were not doing the job. The callbacks are already throttled, and the full
+-- update on release ran this very function anyway.
+local function RelayoutResourceBars()
     local mode = DF.GUI and DF.GUI.SelectedMode or "party"
     local db = DF.db[mode]
-    if not db then return end
-    
-    local height = db.resourceBarHeight or 4
-    local width = db.resourceBarWidth or 50
-    
-    local function UpdateBar(frame)
-        if frame and frame.dfPowerBar then
-            frame.dfPowerBar:SetHeight(height)
-            if not db.resourceBarMatchWidth then
-                frame.dfPowerBar:SetWidth(width)
-            end
-        end
-    end
-    
-    IterateFramesInMode(mode, UpdateBar)
+    if not db or not DF.LayoutResourceBar then return end
+    IterateFramesInMode(mode, function(frame)
+        if frame and frame.dfPowerBar then DF:LayoutResourceBar(frame, db) end
+    end)
+end
+
+-- Drag callback for Width / Length and Height / Thickness
+function DF:LightweightUpdatePowerBarSize()
+    RelayoutResourceBars()
 end
 
 -- Update only border thickness
@@ -1729,24 +1742,11 @@ function DF:LightweightUpdateHighlight(highlightType)
     IterateFramesInMode(mode, UpdateHighlight)
 end
 
--- Update power bar position
+-- Drag callback for Anchor / Offset X / Offset Y. See RelayoutResourceBars above for why
+-- this no longer places the bar itself — the single-SetPoint fork is what made the bar
+-- disappear for the whole drag.
 function DF:LightweightUpdatePowerBarPosition()
-    local mode = DF.GUI and DF.GUI.SelectedMode or "party"
-    local db = DF.db[mode]
-    if not db then return end
-    
-    local anchor = db.resourceBarAnchor or "BOTTOM"
-    local x = db.resourceBarX or 0
-    local y = db.resourceBarY or 0
-    
-    local function UpdateBar(frame)
-        if frame and frame.dfPowerBar then
-            frame.dfPowerBar:ClearAllPoints()
-            frame.dfPowerBar:SetPoint(anchor, frame, anchor, x, y)
-        end
-    end
-    
-    IterateFramesInMode(mode, UpdateBar)
+    RelayoutResourceBars()
 end
 
 -- Update absorb bar size/position

--- a/DandersFrames/Core/Config.lua
+++ b/DandersFrames/Core/Config.lua
@@ -2689,6 +2689,11 @@ DF.PartyDefaults = {
     testShowPersonalTargeted = true,
     testShowAuraDesigner = false,
     testShowTextDesigner = true,
+    -- Test-mode section identification: highlights whichever element the cursor is
+    -- over and names it. OFF by default -- test mode is also how people pixel-tune
+    -- spacing. (A separate testShowLabelTips key existed for one build; the two were
+    -- merged into this one, since nobody wants half the answer.)
+    testShowLabels = false,
 
     -- Tooltip settings
     tooltipBuffAnchor = "FRAME",

--- a/DandersFrames/Core/Config.lua
+++ b/DandersFrames/Core/Config.lua
@@ -2663,13 +2663,22 @@ DF.PartyDefaults = {
     -- ☠ 0 = the defensive row does not preview, and that is DELIBERATE: this key
     -- replaced the `testShowExternalDef` checkbox, which shipped OFF, and these defaults
     -- must mirror TEST_PRESETS.DEFAULT (see the note further down) or a fresh profile
-    -- matches no preset and the panel highlights nothing. Default does not include the
-    -- defensive icon; HEALER and Full do.
-    -- Raise it and the row previews that many icons - 1 is the natural working value,
-    -- since the defensive icon is a single-slot cue in the common case and this row only
-    -- previews on TANK/HEALER frames. Before the key existed the preview borrowed
-    -- testBuffCount and drew 2 whatever the row's own Max Icons said.
-    testDefensiveCount = 0,
+    -- matches no preset and the panel highlights nothing.
+    -- The row previews this many icons - 1 is the natural working value, since the
+    -- defensive icon is a single-slot cue in the common case and this row only previews on
+    -- TANK/HEALER frames. Before the key existed the preview borrowed testBuffCount and
+    -- drew 2 whatever the row's own Max Icons said.
+    --
+    -- ☠ 1, NOT 0 — AND TEST_PRESETS.DEFAULT LISTS IT TO MATCH. It shipped at 0, inherited
+    -- from the `testShowExternalDef` checkbox it replaced, which also shipped off. A COUNT
+    -- reads differently from a checkbox though: 0 is indistinguishable from a broken
+    -- feature, and three of the five presets (Default, Auras, Combat) re-zero it on click
+    -- because the preset tables are exhaustive. Net effect was "Defensive Icons don't show
+    -- up in test mode frames — ever" (Aphoex 6), which is what a whole feature looks like
+    -- when its only control is off and nothing says so.
+    -- ⚠ This is a DEFAULT CHANGE, not a bug fix, and it is Krathe's to reverse: set this to
+    -- 0 and drop the key from TEST_PRESETS.DEFAULT to restore the old behaviour exactly.
+    testDefensiveCount = 1,
     testFrameCount = 5,
     testPreset = "DEFAULT",
     testShowAbsorbs = false,

--- a/DandersFrames/Designer/Presets.lua
+++ b/DandersFrames/Designer/Presets.lua
@@ -362,9 +362,28 @@ local function MigrateDesigner(profile, libKey, refKey, inlineKey, factory)
             local modeDb = profile[mode]
             if modeDb then
                 if modeDb[inlineKey] then modeDb[inlineKey] = nil end
-                if not modeDb[refKey] then
-                    local presetName = DefaultPresetNameForMode(mode)
-                    modeDb[refKey] = lib[presetName] and presetName or DF.DEFAULT_PRESET
+                -- ☠☠ NEVER POINT BOTH MODES AT ONE PRESET TABLE. This used to fall back to
+                -- DF.DEFAULT_PRESET whenever the mode's own preset was missing from the
+                -- library — and it runs for party AND raid, so when both were missing it
+                -- WELDED the two modes to a single config, permanently, in saved data.
+                -- After that they are not "linked", they ARE one table: enable the Aura
+                -- Designer on Party and Raid reads back enabled, with nothing written on the
+                -- tab switch and nothing to find by grepping for a write. That is the
+                -- reported "Aura Designer enables itself when you change between Party and
+                -- Raid tabs" (Aphoex 2) — no write exists because none was needed.
+                -- ⇒ [[feedback_migration_before_defaults_backfill]]: a UI-time fallback that
+                -- WRITES saved data is a second migration, and this one wrote a data loss.
+                -- Materialise the mode's own preset from Default instead, so the two modes
+                -- stay independent. Also repairs a ref that NAMES a preset the library no
+                -- longer holds, which reaches the same shared-table state through
+                -- GetModeBaseAuraDesigner's `or lib[DF.DEFAULT_PRESET]`.
+                local presetName = DefaultPresetNameForMode(mode)
+                local ref = modeDb[refKey]
+                if not ref or not lib[ref] then
+                    if not lib[presetName] then
+                        lib[presetName] = DF:DeepCopy(lib[DF.DEFAULT_PRESET] or {})
+                    end
+                    modeDb[refKey] = presetName
                 end
             end
         end

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -2443,11 +2443,18 @@ function DF:UpdateAllDispelOverlays()
         end
         return
     end
-    DF:IterateAllFrames(function(frame)
+    local function updateFrame(frame)
         if frame then
             DF:UpdateDispelOverlay(frame)
         end
-    end)
+    end
+    DF:IterateAllFrames(updateFrame)
+    -- ☠ AND PINNED — DF:IterateAllFrames is arena OR party+raid and has no pinned arm, so
+    -- the dispel settings toggle, PLAYER_ENTERING_WORLD and both test-mode exits all left
+    -- pinned frames on whatever overlay state they last happened to render. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(updateFrame)
+    end
 end
 
 -- ============================================================

--- a/DandersFrames/Features/ElementAppearance.lua
+++ b/DandersFrames/Features/ElementAppearance.lua
@@ -1691,19 +1691,12 @@ function DF:UpdateAllFrameAppearances()
         DF:IterateAllFrames(updateFrame)
     end
     
-    -- Pinned frames
-    if DF.PinnedFrames and DF.PinnedFrames.initialized and DF.PinnedFrames.headers then
-        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
-            local header = DF.PinnedFrames.headers[setIndex]
-            if header then
-                for i = 1, 40 do
-                    local child = header:GetAttribute("child" .. i)
-                    if child then
-                        updateFrame(child)
-                    end
-                end
-            end
-        end
+    -- Pinned frames.
+    -- ☠ THROUGH THE SHARED WALKER, NOT A HAND-ROLLED HEADER LOOP — this one walked
+    -- PinnedFrames.headers only, so pinned BOSS frames got no colour or alpha refresh at
+    -- all, including from FullProfileRefresh on a profile switch. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(updateFrame)
     end
 end
 

--- a/DandersFrames/Features/Highlights.lua
+++ b/DandersFrames/Features/Highlights.lua
@@ -1083,20 +1083,20 @@ local function UpdateAllHighlights()
         end)
     end
     
-    -- Update pinned frame children (they share units with main frames)
-    if DF.PinnedFrames and DF.PinnedFrames.initialized then
-        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
-            local header = DF.PinnedFrames.headers[setIndex]
-            if header and header:IsShown() then
-                local maxChildren = IsInRaid() and 40 or 5
-                for i = 1, maxChildren do
-                    local child = header:GetAttribute("child" .. i)
-                    if child and child:IsShown() and child.unit then
-                        DF:UpdateHighlights(child)
-                    end
-                end
+    -- Update pinned frames (they share units with main frames).
+    -- ☠ THROUGH THE SHARED WALKER, NOT A HAND-ROLLED HEADER LOOP. This walked
+    -- PinnedFrames.headers only, so pinned BOSS frames were never highlighted: target a
+    -- friendly healable NPC on a pinned boss set and the selection highlight never painted,
+    -- because PLAYER_TARGET_CHANGED lands here. DF.IteratePinnedFrames covers both pools.
+    -- ⚠ It also retires a second bug this loop carried: `IsInRaid() and 40 or 5` capped a
+    -- party-mode sweep at five children, so a pinned set holding more than five units —
+    -- which the set editor allows — left the rest unhighlighted. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(function(child)
+            if child and child:IsShown() and child.unit then
+                DF:UpdateHighlights(child)
             end
-        end
+        end)
     end
 end
 

--- a/DandersFrames/Features/PinnedFrames.lua
+++ b/DandersFrames/Features/PinnedFrames.lua
@@ -3593,6 +3593,21 @@ local function CreatePlayerTestFrame(setIndex, index, container, isRaidMode, isB
     frame.dfIsTestFrame = true
     frame.dfIsDandersFrame = true
     frame.dfIsPinnedTestFrame = true  -- distinguish from testPartyFrames/testRaidFrames
+    -- ☠ THIS IS A PINNED FRAME, AND TWO LIVE GUARDS ALREADY ASSUME IT SAYS SO. The pool
+    -- stamped dfIsPinnedTestFrame and isPinnedBossFrame but never this one, so both of
+    -- them silently took their non-pinned branch on every preview slot:
+    --   * Frames/Update.lua:126 picks the preview's test data by it. Its own ☠ note
+    --     describes the bug it was written to fix — party pools are 0-based, pinned
+    --     pools 1-based, and the boss flag has to be passed — and the fix never ran,
+    --     because the flag it tests was nil. A pinned slot kept taking another
+    --     scenario's absorbs and heals whenever the fill object was replaced.
+    --   * Frames/Bars.lua:65 gives pinned frames the resource bar's solo-mode bypass;
+    --     TestMode.lua:1773 mirrors it for the preview. Without the stamp the preview
+    --     drew a bar the live frame would not (or the reverse).
+    -- Every other reader wants preview slots included too, so this is a plain fix
+    -- rather than a scope widening: Features/Auras.lua:3136's players-only missing-buff
+    -- term is bypassed wholesale in test mode, and the rest are debug.
+    frame.isPinnedFrame = true
     frame.isPinnedBossFrame = isBossSet or false
     frame.pinnedSetIndex = setIndex
 

--- a/DandersFrames/Features/PinnedFrames.lua
+++ b/DandersFrames/Features/PinnedFrames.lua
@@ -4100,7 +4100,13 @@ end
 -- those are entry-only concerns.
 function PinnedFrames:RefreshTestMode(withLayout)
     if not self.testModeActive then return end
-    if InCombatLockdown() then return end
+    -- ☠ NO COMBAT GUARD, DELIBERATELY. There was one, and it bought nothing while costing
+    -- the feature: every frame this touches is a plain non-secure Button under UIParent,
+    -- and BOTH callers — DF:RefreshTestFrames and DF:RefreshTestFramesWithLayout — refresh
+    -- the main party/raid pools in combat with no guard at all. Nothing in the regen drain
+    -- replayed it either, so a settings edit made with test mode up in combat froze the
+    -- pinned previews while the main ones tracked it, and they stayed frozen until test
+    -- mode was toggled out of combat. (Audit, 2026-08-17.)
 
     local isRaidMode
     if DF.raidTestMode then
@@ -4143,6 +4149,22 @@ end
 -- manipulation needed — Test Mode never touched them.
 function PinnedFrames:ExitTestMode()
     if InCombatLockdown() then
+        -- ☠☠ HIDE THE PREVIEW *NOW*; ONLY THE SECURE HALF MAY BE DEFERRED. This used to
+        -- return outright, and the one thing in this function that actually needs lockdown
+        -- protection is `self.headers[setIndex]:Show()` on a secure group header. The test
+        -- frames and their containers are plain CreateFrame Buttons/Frames under UIParent
+        -- (see CreatePlayerTestFrame / EnsureTestContainer) — hiding them in combat is
+        -- legal, and the main party/raid pools are hidden inline on this very path.
+        -- The consequence of the blanket return: combat ends test mode, the main preview
+        -- vanishes, and the FAKE PINNED FRAMES STAY ON SCREEN OVER THE LIVE UI for the
+        -- whole fight. (Audit, 2026-08-17.)
+        for setIndex = 1, PinnedFrames.MAX_SETS do
+            self:HidePlayerTestFrames(setIndex)
+        end
+        -- ⚠ Hiding is not enough on its own: the Aura Designer parents its indicators to
+        -- UIParent, so they outlive the frame. TeardownTestFrameVisuals owns that teardown
+        -- for every pool including these, and its own header says it is combat-safe.
+        if DF.TeardownTestFrameVisuals then DF:TeardownTestFrameVisuals() end
         -- The global test flags may already be off (HideTestFrames runs in
         -- combat) — if we just drop this, testModeActive sticks true and
         -- Hide-from-Main + the solo gate stay disabled until /reload. Queue a

--- a/DandersFrames/Features/PinnedFrames.lua
+++ b/DandersFrames/Features/PinnedFrames.lua
@@ -1185,8 +1185,13 @@ function PinnedFrames:UpdateBossHandlerConfig(setIndex)
             if f then
                 f.dfPinnedWidth, f.dfPinnedHeight = frameWidth, frameHeight
                 f.dfPinnedBorderDB = borderDB
+                -- ☠ `dfPinnedEffDB` IS the Hide Auras / Hide Icons mechanism — BuildPinnedEffDB
+                -- forces showBuffs/showDebuffs/defensiveIconEnabled/missingBuffIconEnabled
+                -- false on it and every updater reads it through DF:GetFrameDB. A
+                -- `dfPinnedHideAuras` stamp used to sit beside this on all four sites and was
+                -- READ NOWHERE — dead state that reads exactly like the implementation, so the
+                -- next person to "fix Hide Auras" would have edited it and changed nothing.
                 f.dfPinnedEffDB = effDB
-                f.dfPinnedHideAuras = set.hideAuras
                 -- Per-set Aura/Text Designer preset (nil = inherit the mode's preset;
                 -- the resolver falls back to FrameMode when the stamp is nil).
                 f.dfAuraPresetOverride = set.auraDesignerPreset
@@ -1966,8 +1971,7 @@ function PinnedFrames:ApplyLayoutSettings(setIndex)
             -- sizes from the shared per-mode db) keeps this set's Match/Custom size.
             child.dfPinnedWidth, child.dfPinnedHeight = frameWidth, frameHeight
             child.dfPinnedBorderDB = borderDB
-            child.dfPinnedEffDB = effDB
-            child.dfPinnedHideAuras = set.hideAuras
+            child.dfPinnedEffDB = effDB   -- the Hide Auras/Icons mechanism; see the note at the boss site
             -- Per-set Aura/Text Designer preset (nil = inherit the mode's preset).
             child.dfAuraPresetOverride = set.auraDesignerPreset
             child.dfTextPresetOverride = set.textDesignerPreset
@@ -3870,7 +3874,6 @@ function PinnedFrames:EnsurePlayerTestFramePool(setIndex, count, isRaidMode, isB
             pool[i].dfPinnedWidth, pool[i].dfPinnedHeight = fw, fh
             pool[i].dfPinnedBorderDB = GetSetBorderDB(setDB, GetSetBaselineDB(setDB, db))
             pool[i].dfPinnedEffDB = setDB and BuildPinnedEffDB(db, setDB.hideAuras, setDB.hideIcons) or nil
-            pool[i].dfPinnedHideAuras = setDB and setDB.hideAuras
             pool[i].dfAuraPresetOverride = setDB and setDB.auraDesignerPreset
             pool[i].dfTextPresetOverride = setDB and setDB.textDesignerPreset
             pool[i]:SetSize(fw, fh)
@@ -3928,7 +3931,6 @@ function PinnedFrames:ApplyPlayerTestLayout(setIndex, set, isRaidMode)
                 f.dfPinnedWidth, f.dfPinnedHeight = frameWidth, frameHeight
                 f.dfPinnedBorderDB = borderDB
                 f.dfPinnedEffDB = effDB
-                f.dfPinnedHideAuras = set.hideAuras
                 f.dfAuraPresetOverride = set.auraDesignerPreset
                 f.dfTextPresetOverride = set.textDesignerPreset
                 f:SetSize(frameWidth, frameHeight)

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5143,7 +5143,32 @@ end
 local function IdentityUnavailable(unit)
     local okC, connected = pcall(UnitIsConnected, unit)
     if okC and not (issecretvalue and issecretvalue(connected)) and connected == false then
-        return "offline"
+        -- ☠☠ PLAYERS ONLY — AN NPC HAS NO CONNECTION, SO UnitIsConnected READS FALSE
+        -- FOR IT. This probe is the SEVENTH consumer of that API in the addon and was
+        -- the only one without the guard; the other six all carry it, added by #989 /
+        -- #1042, and one of them names the very unit class that broke here:
+        -- Frames/Update.lua:520 "a pinned NPC (Lura's healable crystals) rendered as an
+        -- offline player ... Only a player can be offline." (Also Update.lua's fast
+        -- path, ElementAppearance.lua twice, Frames/Core.lua and the missing-buff gate
+        -- in Features/Auras.lua.) This one arrived later, when dead/disconnected were
+        -- folded into the assist verdict, and the sibling sweep never reached it.
+        --
+        -- The consequence was total on a friendly NPC frame: "offline" makes the caller
+        -- set can = false, which marks the handle untrusted, which parks every gated
+        -- group at maxFrameCount 0 — and _noteGateRecovery only re-parses on a
+        -- false->true ASSIST edge, which an NPC never produces. So the row was dark from
+        -- the moment it was built and stayed dark for the container's whole life. Field
+        -- report: pinned boss frames on friendly NPCs showing no auras at all with Hide
+        -- Auras unchecked (Ruben, 2026-08-16, on "Dusk Crystal" — the same NPC family).
+        -- ⚠ Only the CONNECTED half is scoped. UnitIsDeadOrGhost below is meaningful for
+        -- an NPC and stays as it is.
+        -- ★ Fails OPEN on a refused or secret UnitIsPlayer, like every other probe in
+        -- this gate: if we cannot confirm the unit is a player we cannot conclude
+        -- "offline" means anything, and any doubt SHOWS.
+        local okP, isPlayer = pcall(UnitIsPlayer, unit)
+        if okP and not (issecretvalue and issecretvalue(isPlayer)) and isPlayer then
+            return "offline"
+        end
     end
     local okD, dead = pcall(UnitIsDeadOrGhost, unit)
     if okD and not (issecretvalue and issecretvalue(dead)) and dead == true then

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -2868,11 +2868,18 @@ function NativeBackend:build()
         -- plain neighbours. Dropping this capture was the own-preview regression:
         -- the important-debuff highlight vanished from test mode entirely (field
         -- report 2026-08-14). _buildOwnPreview resolves slot k's style from this.
-        local testStyles, allStyled = {}, true
+        -- ☠ THE DISTINCTNESS TERM — see the long note on the engine route below. Two records
+        -- sharing ONE importantStyle table satisfied "all styled" and enlarged every slot.
+        local testStyles, allStyled, stylesDiffer = {}, true, false
         for _, r in ipairs(filters) do
-            if r.style then testStyles[#testStyles + 1] = r.style else allStyled = false end
+            if r.style then
+                testStyles[#testStyles + 1] = r.style
+                if testStyles[1] ~= r.style then stylesDiffer = true end
+            else
+                allStyled = false
+            end
         end
-        local perSlotStyles = (allStyled and #testStyles > 1) and testStyles or nil
+        local perSlotStyles = (allStyled and stylesDiffer and #testStyles > 1) and testStyles or nil
         -- Assigned UNCONDITIONALLY (nil when no styles): the pooled preview slots
         -- persist across rebuilds, so a rebuild with the highlight switched off must
         -- clear the previous build's styles or they would re-stamp forever.
@@ -2914,13 +2921,35 @@ function NativeBackend:build()
         -- leave the rest plain — a preview that differs from live in RENDERING rather
         -- than in data, which is the one thing a preview may never do.
         --
-        -- So: all records styled and more than one => per-slot, slot k wears member k's
-        -- style. Otherwise the original single-styled-slot behaviour, unchanged.
-        local testStyles, allStyled = {}, true
+        -- So: all records styled, more than one, AND THE STYLES ACTUALLY DIFFER => per-slot,
+        -- slot k wears member k's style. Otherwise the original single-styled-slot
+        -- behaviour, unchanged.
+        --
+        -- ☠☠ THE DISTINCTNESS TERM IS LOAD-BEARING AND WAS MISSING. "Every record styled"
+        -- was meant to identify a LAYOUT GROUP, where each member carries its OWN look. The
+        -- debuff row can satisfy it by accident: `bossrole` and `priority` are the only two
+        -- records that take a style and they take THE SAME `importantStyle` TABLE, so
+        -- ticking Boss and/or Role together with Priority — and nothing else — made
+        -- `allStyled` true with two entries and put the enlarged, badged important treatment
+        -- on BOTH preview slots instead of one styled against a plain neighbour. At the test
+        -- Debuffs count of 2 that is the whole row. Reported as the debuff preview "bugging
+        -- out" on particular checkbox combinations (Aphoex 7); the enormous icons in the
+        -- screenshots are this, and the mis-wrap beside it is the flow cap below.
+        -- ⚠ Identity, not deep-compare: two members with coincidentally equal looks are
+        -- still two members and must stay per-slot.
+        -- ☠ MIRRORED IN THREE PLACES — the own-preview route above, this engine route, and
+        -- the Indicator Info probe in DandersFrames_Options/TestMode/Labels.lua, which
+        -- measures the region and must agree with what renders. Change one, change all three.
+        local testStyles, allStyled, stylesDiffer = {}, true, false
         for _, r in ipairs(filters) do
-            if r.style then testStyles[#testStyles + 1] = r.style else allStyled = false end
+            if r.style then
+                testStyles[#testStyles + 1] = r.style
+                if testStyles[1] ~= r.style then stylesDiffer = true end
+            else
+                allStyled = false
+            end
         end
-        local perSlotStyles = (allStyled and #testStyles > 1) and testStyles or nil
+        local perSlotStyles = (allStyled and stylesDiffer and #testStyles > 1) and testStyles or nil
         local testStyle = testStyles[1]
         local testStyleSlots = (not perSlotStyles) and (testStyle and math.min(1, maxCount) or 0) or 0
         local testStyleLayout = recordGroupLayout(groupLayout, testStyle)

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -2378,6 +2378,36 @@ local function resolveLayoutPin(L, anchorFrame, pp)
     return G, px, py, scale, resolved
 end
 
+-- ☠ THE LINE CAP MUST ALLOW FOR RECORD-STYLED CELLS, WHICH ARE BIGGER THAN `sx`.
+-- The flow wraps when the running row width exceeds the cap, and it measures each button's
+-- ACTUAL width — but the cap was built from the plain cell size alone. An important debuff
+-- renders at `debuffImportantScale` (default 1.25), so a row containing one overruns its cap
+-- by (scale-1)*sx against only half an icon of rounding slack, and the flow wraps a whole
+-- icon early: "Icons Per Row" set to 3 lays out 2+1. Reported as the debuff preview
+-- mis-flowing (Aphoex 7); it is equally wrong on live frames, the preview is just where you
+-- see it. Returns the slack to add to the cap: rounding headroom plus the widest styled
+-- cell's overhang.
+-- ☠☠ CLAMPED, AND THE CLAMP IS THE WHOLE SAFETY ARGUMENT. Slack must stay strictly under
+-- one full extra cell (`sx + spX`), or a row of PLAIN icons — the case where the styled aura
+-- simply is not up right now — would fit one more icon than the user asked for. Widening a
+-- cap can only ever cause that failure, so the bound is what makes this safe rather than a
+-- trade of one bug for another.
+local function flowLineSlack(sx, spX, records)
+    local styleExtra = 0
+    if type(records) == "table" then
+        for _, r in ipairs(records) do
+            local st = type(r) == "table" and r.style
+            local s = st and tonumber(st.scale)
+            if s and s > 1 then
+                local e = (s - 1) * sx
+                if e > styleExtra then styleExtra = e end
+            end
+        end
+    end
+    -- Half an icon absorbs pixel rounding and the border inset; see the note this replaces.
+    return math.min(sx * 0.5 + styleExtra, sx + spX - 0.5)
+end
+
 local function applyContainerLayout(c, handle)
     local config = handle.config
     local L = config.layout or {}
@@ -2392,7 +2422,8 @@ local function applyContainerLayout(c, handle)
     -- our `sx` (pixel rounding + border inset). A tight +0.5 slack let that fraction wrap
     -- one icon early. Half an icon of headroom absorbs the rounding yet stays well under
     -- the (sx + spX) a whole extra icon would need — so exactly `wrap` icons fit per row.
-    local headroom = sx * 0.5
+    -- ★ Slack now also covers a record-styled cell's overhang — see flowLineSlack.
+    local headroom = flowLineSlack(sx, spX, config.filter)
     local rowWidth
     if G.verticalPrimary then
         rowWidth = sx + headroom
@@ -4355,9 +4386,12 @@ local function flowSlotsIntoBox(box, anchorFrame, slots, count, config, pp)
     end)
     if not okPin then return false end
 
-    -- Row cap, including the half-icon headroom that stops the flow wrapping one
-    -- icon early on the measured button width (see applyContainerLayout).
-    local headroom = G.sx * 0.5
+    -- Row cap, including the slack that stops the flow wrapping one icon early on the
+    -- measured button width — and, since it shares flowLineSlack with the live path, the
+    -- overhang of a record-styled cell too. ☠ This is the entry point the AD canvas and the
+    -- Indicator Info probe measure through, so a cap that disagreed with the live one would
+    -- make every one of them flow differently from what renders.
+    local headroom = flowLineSlack(G.sx, G.spX, config and config.filter)
     local rowWidth
     if G.verticalPrimary then
         rowWidth = G.sx + headroom
@@ -4545,11 +4579,31 @@ end
 -- vocabulary applyContainerLayout translates onto the native flow, so the zones
 -- land on the rendered buttons; layoutRow is the reference math). Settings-derived
 -- by necessity — the buttons' own rects are off-limits to insecure anchors.
+-- ☠ A RECORD-STYLED SLOT IS BIGGER, AND THE HOVER GRID HAS TO KNOW. The zones were a
+-- uniform grid of BASE-size cells, so an important debuff (which renders at
+-- `debuffImportantScale`) got a zone the wrong size AND displaced every zone after it in
+-- its row by the width the real flow had already consumed. Symptom: the aura tooltip does
+-- not follow "Size Step" (Aphoex 7.1). Returns slot k's scale; the caller also sums the
+-- overhang of the slots BEFORE k in the same row.
+-- ⚠ Resolved from `_ownPreviewStyles`, the same table _buildOwnPreview paints from, so the
+-- zone and the icon cannot disagree about which slots are styled.
+local function testSlotScale(handle, slotIndex)
+    local ps = handle._ownPreviewStyles
+    if not ps then return 1 end
+    local st = (ps.perSlot and ps.perSlot[slotIndex])
+        or (ps.single and slotIndex == 1 and ps.single)
+        or nil
+    return (st and tonumber(st.scale)) or 1
+end
+
 function Handle:_positionTestTip(tip, index)
     local L = self.config.layout or {}
     local G = resolveGrowthLayout(L)
     local sx, sy, spX, spY = G.sx, G.sy, G.spX, G.spY
     local scale = tonumber(L.scale) or 1
+    -- This slot's own scale, and the overhang the styled slots before it in the SAME row
+    -- have already pushed along the primary axis.
+    local mine = testSlotScale(self, index)
     local n = math.max(self:_slotCount(), 1)
     -- Vertical-primary growth renders as a single column on the native flow.
     local wrap = G.verticalPrimary and 1 or (tonumber(L.wrap) or 0)
@@ -4569,7 +4623,14 @@ function Handle:_positionTestTip(tip, index)
         end
     end
     local strideY = sy + resv + spY
-    tip:SetSize(sx * scale, sy * scale)
+    -- Overhang accumulated by the styled slots earlier in this row (0 when nothing is
+    -- styled, which is every row that has no important debuff up).
+    local rowFirst = math.floor(idx / wrap) * wrap
+    local leadExtra = 0
+    for j = rowFirst, idx - 1 do
+        leadExtra = leadExtra + (testSlotScale(self, j + 1) - 1) * sx
+    end
+    tip:SetSize(sx * scale * mine, sy * scale * mine)
     tip:ClearAllPoints()
     if G.center then
         -- Mirror the centre-pinned box (resolveGrowthLayout): the box's
@@ -4587,9 +4648,16 @@ function Handle:_positionTestTip(tip, index)
             local col = idx % wrap
             local row = math.floor(idx / wrap)
             local m = math.min(wrap, n)
-            local rowW = m * sx + (m - 1) * spX
+            -- Row width includes every styled slot's overhang, or a centred row would sit
+            -- off to one side by half of it.
+            local rowExtra = 0
+            for j = rowFirst, rowFirst + m - 1 do
+                rowExtra = rowExtra + (testSlotScale(self, j + 1) - 1) * sx
+            end
+            local rowW = m * sx + (m - 1) * spX + rowExtra
             local rowDir = (G.secondary == "UP") and 1 or -1
-            x = (L.offsetX or 0) + (G.pinX + col * (sx + spX) - rowW / 2 + sx / 2) * scale
+            x = (L.offsetX or 0)
+                + (G.pinX + col * (sx + spX) + leadExtra - rowW / 2 + sx * mine / 2) * scale
             y = (L.offsetY or 0) + (G.pinY + rowDir * (inset + row * strideY + sy / 2)) * scale
         end
         tip:SetPoint("CENTER", self.frame, G.anchor, x, y)
@@ -4605,8 +4673,10 @@ function Handle:_positionTestTip(tip, index)
     local vSign = (G.vName == "Up") and 1 or -1
     local col = idx % wrap
     local row = math.floor(idx / wrap)
-    local x = (L.offsetX or 0) + (pAxis.x * col + sAxis.x * row) * (sx + spX) * scale
-    local y = (L.offsetY or 0) + ((pAxis.y * col + sAxis.y * row) * strideY + vSign * inset) * scale
+    local x = (L.offsetX or 0)
+        + ((pAxis.x * col + sAxis.x * row) * (sx + spX) + pAxis.x * leadExtra) * scale
+    local y = (L.offsetY or 0)
+        + ((pAxis.y * col + sAxis.y * row) * strideY + pAxis.y * leadExtra + vSign * inset) * scale
     tip:SetPoint(G.anchor, self.frame, G.anchor, x, y)
 end
 

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -208,7 +208,26 @@ function DF:LayoutResourceBar(frame, db)
     -- every border size (field-confirmed: bar x = 1.6 vs border width = 0.8).
     -- Flush against whichever boundary is innermost: the border band when it
     -- is thicker than the padding, the health bar's own inset otherwise.
-    local edgeInset = math.max(padding, bInset)
+    --
+    -- ☠☠ BUT ONLY WHILE THE BORDER CAN ACTUALLY HIDE THE BAR. The health bar this option
+    -- promises to match insets by `framePadding` ALONE (DF:AnchorHealthBarsToPadding), so
+    -- once Border Thickness exceeds the padding the resource bar lost 2px of length per
+    -- extra border pixel and stopped matching — Border Thickness read as padding on the
+    -- resource bar (Aphoex 5). The sliver the max() exists to prevent is only visible
+    -- through a TRANSLUCENT border; an opaque one covers whatever runs under it, which is
+    -- exactly the rule DF:GetAbsorbEdgeInset already applies a few hundred lines down
+    -- ("if alpha >= 1 then return 0"). Adopting it here makes the two bars agree and makes
+    -- the option's name true, without reopening the field-confirmed hairline.
+    -- ⚠ The old comment claimed this "matches other bar calculations". It did not — the
+    -- absorb bar has always had the alpha test and the health bar has never inset by the
+    -- border at all. That line is why the mismatch survived review.
+    local borderCanHide = true
+    if db.frameShowBorder ~= false then
+        local bc = db.frameBorderColor
+        local balpha = (bc and (bc.a or bc[4])) or 1
+        borderCanHide = balpha >= 1
+    end
+    local edgeInset = borderCanHide and padding or math.max(padding, bInset)
 
     if isVertical then
         -- SWAP: "Width" applies to Height (Length), "Height" applies to Width (Thickness)

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -2932,6 +2932,13 @@ function DF:UpdateAllRoleIcons()
     if DF.IterateRaidFrames then
         DF:IterateRaidFrames(updateFrame)
     end
+
+    -- ☠ AND PINNED. This runs on the combat-exit transition (see the HideInCombat note in
+    -- Frames/StatusIcons.lua), and neither iterator above reaches a pinned frame — so a
+    -- pinned role or leader icon hidden by roleIconHideInCombat never came back.
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(updateFrame)
+    end
 end
 
 function DF:UpdateLeaderIcon(frame)

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -6862,19 +6862,13 @@ function DF:RefreshAllHeaderChildFrames()
         end
     end
     
-    -- Refresh PinnedFrames if active
-    if DF.PinnedFrames and DF.PinnedFrames.headers then
-        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
-            local header = DF.PinnedFrames.headers[setIndex]
-            if header then
-                for i = 1, 40 do
-                    local child = header:GetAttribute("child" .. i)
-                    if child then
-                        RefreshFrame(child)
-                    end
-                end
-            end
-        end
+    -- Refresh PinnedFrames if active.
+    -- ☠ THROUGH THE SHARED WALKER, NOT A HAND-ROLLED HEADER LOOP — this walked
+    -- PinnedFrames.headers only, so the whole per-frame refresh block (role, absorb, raid
+    -- target, dispel, missing buff, highlights) never reached a pinned BOSS frame.
+    -- (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(RefreshFrame)
     end
 end
 

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -3920,6 +3920,19 @@ function DF:RefreshLiveFrames()
             end
         end)
     end
+
+    -- ☠ AND PINNED — a pinned frame IS a live frame. None of the three iterators above
+    -- reaches one, so every caller of this function silently skipped them: the combat-ENTRY
+    -- half of the HideInCombat gates (PLAYER_REGEN_DISABLED routes here through
+    -- RefreshAllVisibleFrames) plus every settings callback that refreshes data-driven
+    -- content. Boss sets included — they are unit frames for friendly, healable NPCs.
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(function(frame)
+            if frame and frame.unit then
+                DF:FullFrameRefresh(frame)
+            end
+        end)
+    end
 end
 
 -- Refresh ALL visible frames (both test and live)
@@ -7769,17 +7782,44 @@ headerChildEventFrame:RegisterEvent("READY_CHECK_FINISHED")
 headerChildEventFrame:RegisterEvent("PARTY_LEADER_CHANGED")
 
 -- Helper to iterate pinned frame children (forward-declared near file top)
+-- ☠ BOTH POOLS. This walked player-set header children ONLY, so every caller silently
+-- excluded pinned BOSS frames — which are real DF unit frames for friendly, healable
+-- NPCs, not a special case. The visible cost was raid-target markers: put a skull on a
+-- boss and the pinned frame kept the old icon until something else forced a
+-- FullFrameRefresh, because RAID_TARGET_UPDATE routes through here. Its own neighbour
+-- FindPinnedFrameForUnit has always walked bossFrames, so this was the odd one out.
+-- ⚠ The other callers (ready check, leader, AFK, summon, player flags, the roster
+-- name/leader safety net) are no-ops on an NPC rather than wrong — UnitIsPartyLeader and
+-- friends simply answer false — so widening costs them nothing.
+-- ★ PinnedFrames:ForEachActiveFrame is the same walk inside the pinned module; this one
+-- exists separately because it supports EARLY EXIT (a truthy callback stops the sweep)
+-- and that one does not. KEEP THEIR COVERAGE IDENTICAL.
 IteratePinnedFrames = function(callback)
-    if not DF.PinnedFrames or not DF.PinnedFrames.initialized or not DF.PinnedFrames.headers then
+    if not DF.PinnedFrames or not DF.PinnedFrames.initialized then
         return
     end
-    for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
-        local header = DF.PinnedFrames.headers[setIndex]
-        if header and header:IsShown() then
-            for i = 1, 40 do
-                local child = header:GetAttribute("child" .. i)
-                if child and child:IsVisible() then
-                    if callback(child) then return end
+    if DF.PinnedFrames.headers then
+        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
+            local header = DF.PinnedFrames.headers[setIndex]
+            if header and header:IsShown() then
+                for i = 1, 40 do
+                    local child = header:GetAttribute("child" .. i)
+                    if child and child:IsVisible() then
+                        if callback(child) then return end
+                    end
+                end
+            end
+        end
+    end
+    if DF.PinnedFrames.bossFrames then
+        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
+            local frames = DF.PinnedFrames.bossFrames[setIndex]
+            if frames then
+                for i = 1, 8 do
+                    local f = frames[i]
+                    if f and f:IsShown() and f.unit then
+                        if callback(f) then return end
+                    end
                 end
             end
         end

--- a/DandersFrames/Frames/Icons.lua
+++ b/DandersFrames/Frames/Icons.lua
@@ -85,6 +85,11 @@ function DF:UpdateAllMissingBuffIcons()
     if DF.IterateRaidFrames then
         DF:IterateRaidFrames(updateFrame)
     end
+
+    -- ☠ AND PINNED — same gap as the defensive sweep below; see its note.
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(updateFrame)
+    end
 end
 
 -- ========================================
@@ -177,6 +182,15 @@ function DF:UpdateAllDefensiveBars()
     -- Raid frames via iterator
     if DF.IterateRaidFrames then
         DF:IterateRaidFrames(updateFrame)
+    end
+
+    -- ☠ AND PINNED. This is the fullUpdate for the whole Defensive Icon page (~20 call
+    -- sites in the Indicators page), so without it every setting there was inert on pinned
+    -- frames until some aura event happened by — which for a quiet unit is minutes, and
+    -- mid-fight never. DF:UpdateAllAuras a few lines down has always walked pinned; these
+    -- siblings were never given the same treatment. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then
+        DF.IteratePinnedFrames(updateFrame)
     end
 end
 

--- a/DandersFrames/Frames/StatusIcons.lua
+++ b/DandersFrames/Frames/StatusIcons.lua
@@ -1192,8 +1192,7 @@ end
 -- way in and stay hidden until some unrelated event happened to repaint the frame.
 -- ⇒ ADD ANY NEW `<icon>HideInCombat` UPDATER HERE. The option is not finished without it.
 function DF:UpdateAllCombatGatedIcons()
-    if not DF.IterateAllFrames then return end
-    DF:IterateAllFrames(function(frame)
+    local function regate(frame)
         if not frame or not frame.unit then return end
         if DF.UpdateRoleIcon then DF:UpdateRoleIcon(frame, "CombatTransition") end
         if DF.UpdateLeaderIcon then DF:UpdateLeaderIcon(frame) end
@@ -1201,7 +1200,17 @@ function DF:UpdateAllCombatGatedIcons()
         if DF.UpdateReadyCheckIcon then DF:UpdateReadyCheckIcon(frame) end
         -- Covers summon / resurrection / phased / AFK / vehicle / MT-MA / BG carrier / combat.
         if DF.UpdateAllStatusIcons then DF:UpdateAllStatusIcons(frame) end
-    end)
+    end
+    if DF.IterateAllFrames then DF:IterateAllFrames(regate) end
+    -- ☠☠ AND PINNED — DF:IterateAllFrames IS ARENA *OR* PARTY+RAID AND HAS NO PINNED ARM.
+    -- So the whole HideInCombat family was ONE-WAY on pinned frames: combat entry
+    -- (RefreshAllVisibleFrames -> FullFrameRefresh) hid the icon, and this — the only thing
+    -- that undoes it — could not see the frame. Any pinned frame repainted mid-combat kept
+    -- its icons hidden until something unrelated refreshed it, which for a quiet unit is
+    -- never. A boss frame makes it near-certain: its own UNIT_FACTION handler calls
+    -- FullFrameRefresh. ⇒ the EXIT half is the one that goes missing, every time.
+    -- ⚠ The pinned walker takes a bare callback and is called with a DOT. (Audit 2026-08-17.)
+    if DF.IteratePinnedFrames then DF.IteratePinnedFrames(regate) end
 end
 
 -- ============================================================

--- a/DandersFrames/Locales/enUS.lua
+++ b/DandersFrames/Locales/enUS.lua
@@ -41,6 +41,7 @@ L["Auto-create profiles enabled."] = true
 L["Auto-created profile: %s"] = true
 L["Auto-profile evaluation and runtime overlay"] = true
 L["Identity gate: park/hide verdicts with reasons, latches, recovery"] = true
+L["Indicator Info"] = true
 L["Cannot delete the default profile"] = true
 L["Cannot rename the default profile"] = true
 L["Click-casting binding apply, hover, PreClick state"] = true

--- a/DandersFrames/Locales/enUS.lua
+++ b/DandersFrames/Locales/enUS.lua
@@ -2393,7 +2393,7 @@ L["Attached puts each pet beside its owner's frame, so you read them together. S
 L["Which side of your party or raid frames the whole pet block sits on. Use the offsets below to nudge it from there."] = true
 L["Sizes each pet frame to its owner's, so the pair stays aligned when you resize the unit frames. The Width slider below greys out while this is on."] = true
 L["Sizes each pet frame to its owner's, so the pair stays aligned when you resize the unit frames. The Height slider below greys out while this is on."] = true
-L["Keeps the resource bar the same width as the health bar it sits under, so it stays lined up when you resize the frame. The Width slider below greys out while this is on."] = true
+L["Keeps the resource bar the same length as the health bar it sits under, so it stays lined up when you resize the frame. The Width / Length slider greys out while this is on, and because the bar is pinned by its ends the Anchor only takes effect along the other axis."] = true
 L["Power Type gives each resource its own game colour — blue mana, yellow energy, red rage. Class colours every bar by the unit's class instead, and Custom uses one fixed colour for everyone."] = true
 L["Watches whichever raid buff your own class provides, and follows you when you change character. Turn it off to pick the buffs to watch by hand below."] = true
 L["Stops the raid buffs tracked here from also taking up a slot in the normal buff row, so the missing-buff icon is the only place they appear."] = true

--- a/DandersFrames_Options/Core/ExportCategories.lua
+++ b/DandersFrames_Options/Core/ExportCategories.lua
@@ -1115,6 +1115,7 @@ DF.ExportCategories = {
         "testShowAuras",
         "testShowDispelGlow",
         "testShowHealPrediction",
+        "testShowLabels",
         "testShowMissingBuff",
         "testShowOutOfRange",
         "testShowPersonalTargeted",

--- a/DandersFrames_Options/DandersFrames_Options.toc
+++ b/DandersFrames_Options/DandersFrames_Options.toc
@@ -97,6 +97,8 @@ ClickCasting\UI\Dialogs.lua
 # the entry points; these overwrite the stubs when this addon loads.
 TestMode\TestFramePool.lua
 TestMode\TestMode.lua
+# After TestMode.lua: it reads the frame pools that file owns.
+TestMode\Labels.lua
 
 # Debug tools (DebugConsole and Profiler stay resident in the main addon)
 Debug\AuraExplorer.lua

--- a/DandersFrames_Options/GUI/ColorPicker.lua
+++ b/DandersFrames_Options/GUI/ColorPicker.lua
@@ -1792,7 +1792,35 @@ local function OpenDFColorPickerWithBlizzard(info, useBlizzardAsBackend)
         
         -- Set up previousValues for Blizzard UI compatibility
         ColorPickerFrame.previousValues = { r = r, g = g, b = b, a = a }
-        
+
+        -- ☠☠ TAKE OWNERSHIP OF THE BLIZZARD FRAME'S CALLBACKS, OR THE LAST ADDON TO USE
+        -- IT KEEPS THEM. Direct mode never calls SetupColorPickerAndShow -- that is the
+        -- point of it -- but ApplyColor below still writes into ColorPickerFrame so DF's
+        -- own swatchFunc can read the values back from there. Blizzard's OnColorSelect
+        -- fires on EVERY SetColorRGB, shown or not, and calls self.swatchFunc,
+        -- self.opacityFunc and self.swatch:SetColorRGB (Blizzard_ColorPickerFrame /
+        -- Mainline / ColorPickerFrame.lua, verified against live) -- and Setup is the ONLY
+        -- writer of those fields, with nothing clearing them on Hide.
+        --
+        -- So after "Use DF Color Picker for All Addons" had routed another addon's picker
+        -- through here, that addon's swatchFunc was still armed on the frame, and the next
+        -- DF colour edit drove it too: picking a DF colour changed the other addon's colour
+        -- as well. Reported by Aphoex (2026-08-17) against Chattynator, Platynator and
+        -- WarpDeplete, with the two tells that name this exactly -- /reload fixed it (the
+        -- fields go with the frame), and closing DF's window did not (nothing touches
+        -- them); and it never happened between two NON-DF addons, because each of those
+        -- opens runs Setup, which replaces the callbacks.
+        --
+        -- Cleared rather than swapped: direct mode invokes info's own swatch / opacity /
+        -- cancel functions explicitly below, so the frame needs no callbacks of its own,
+        -- and nil is precisely the state a fresh /reload leaves behind. The next foreign
+        -- open re-arms them through Setup as usual.
+        ColorPickerFrame.swatchFunc  = nil
+        ColorPickerFrame.opacityFunc = nil
+        ColorPickerFrame.cancelFunc  = nil
+        ColorPickerFrame.swatch      = nil
+
+
         local function ApplyColor(newColor)
             -- Set values on ColorPickerFrame for addons that read from there
             if ColorPickerFrame.Content and ColorPickerFrame.Content.ColorPicker then

--- a/DandersFrames_Options/GUI/Pages/Auras.lua
+++ b/DandersFrames_Options/GUI/Pages/Auras.lua
@@ -1469,7 +1469,16 @@ function DF._SetupGUIPagesPart3(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         sizeGroup:AddWidget(GUI:CreateHeader(self.child, L["Size"]), 40)
         sizeGroup.disableChildrenOn = function(d) return not d.resourceBarEnabled end
         local rbMatch = sizeGroup:AddWidget(GUI:CreateCheckbox(self.child, L["Match Health Bar Width/Height"], db, "resourceBarMatchWidth", function() DF:UpdateAllFrames() end), 30)
-        rbMatch.tooltip = L["Keeps the resource bar the same width as the health bar it sits under, so it stays lined up when you resize the frame. The Width slider below greys out while this is on."]
+        -- ☠ THE SECOND SENTENCE IS THE ONE THAT WAS MISSING, AND IT COST A BUG REPORT.
+        -- Matching pins the bar by its two ENDS, so the Anchor dropdown's left/right half
+        -- stops applying: Top Left, Top and Top Right all render the same row, and the same
+        -- for the bottom trio (Aphoex 3.2, "only 3 position anchors work"). The dropdown
+        -- keeps all nine because they are all live the moment Match is off — the honest fix
+        -- is to say so here rather than to silently drop six entries the user may be about
+        -- to need. Also drops the old claim that "the Width slider greys out", which is only
+        -- true for a horizontal bar; on a vertical one the matched dimension is the length,
+        -- and Width / Length is exactly the control that owns it.
+        rbMatch.tooltip = L["Keeps the resource bar the same length as the health bar it sits under, so it stays lined up when you resize the frame. The Width / Length slider greys out while this is on, and because the bar is pinned by its ends the Anchor only takes effect along the other axis."]
         local widthSlider = sizeGroup:AddWidget(GUI:CreateSlider(self.child, L["Width / Length"], 10, 200, 1, db, "resourceBarWidth", nil, function() DF:LightweightUpdatePowerBarSize() end, true), 55)
         widthSlider.disableOn = function(d) return d.resourceBarMatchWidth end
         sizeGroup:AddWidget(GUI:CreateSlider(self.child, L["Height / Thickness"], 1, 20, 1, db, "resourceBarHeight", nil, function() DF:LightweightUpdatePowerBarSize() end, true), 55)

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -1115,7 +1115,21 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         local gridGroup = GUI:CreateSettingsGroup(self.child, 280)
         gridGroup:AddWidget(GUI:CreateHeader(self.child, L["Layout"]), 40)
         local debuffWrap = gridGroup:AddWidget(GUI:CreateSlider(self.child, L["Icons Per Row"], 1, 8, 1, db, "debuffWrap", nil, function() DF:LightweightUpdateAuraPosition("debuff") end, true), 55)
-        debuffWrap.disableOn = function(d) return not d.showDebuffs end
+        -- ☠ THE SAME VERTICAL-GROWTH GUARD ITS TWO SIBLINGS CARRY. Both layout paths ignore
+        -- the wrap count outright under vertical-primary growth (the row renders a single
+        -- column), so without this the slider stayed live-looking and did nothing — in test
+        -- mode AND in game. The buff row has carried the guard since the factory rows landed
+        -- and the defensive row copies it; the debuff row never got one, which is what
+        -- "Icons Per Row doesn't preview" is once Growth Direction is vertical. (Aphoex 7.2.)
+        -- Kept term-for-term identical to the buff version rather than rephrased, so the
+        -- three read as one rule.
+        debuffWrap.disableOn = function(d)
+            if not d.showDebuffs then return true end
+            local g = d.debuffGrowth or ""
+            -- Vertical-primary AND vertical-centred growth both render a single column.
+            return DF:FactoryOwnsDebuffRow(d) and (g:sub(1, 2) == "UP" or g:sub(1, 4) == "DOWN"
+                or g == "CENTER_LEFT" or g == "CENTER_RIGHT")
+        end
         local debuffPaddingX = gridGroup:AddWidget(GUI:CreateSlider(self.child, L["Spacing X"], -5, 10, 1, db, "debuffPaddingX", nil, function() DF:LightweightUpdateAuraPosition("debuff") end, true), 55)
         debuffPaddingX.disableOn = function(d) return not d.showDebuffs end
         local debuffPaddingY = gridGroup:AddWidget(GUI:CreateSlider(self.child, L["Spacing Y"], -5, 10, 1, db, "debuffPaddingY", nil, function() DF:LightweightUpdateAuraPosition("debuff") end, true), 55)

--- a/DandersFrames_Options/TestMode/Labels.lua
+++ b/DandersFrames_Options/TestMode/Labels.lua
@@ -141,19 +141,24 @@ local function flowedRect(frame, key, h)
     -- ★ IMPORTANT DEBUFFS RENDER BIGGER, and the box has to contain them (field: the
     -- scaled icon poked out of the highlight). The preview's own choice of WHICH slots
     -- wear a record style is deterministic -- Handle._build's test branch: when every
-    -- record carries a style and there is more than one, slot k wears style k;
-    -- otherwise exactly ONE slot wears the first style -- so the probe mirrors that
-    -- rather than guessing, and the measured cells match the rendered ones instead of
+    -- record carries a style, there is more than one, AND THE STYLES DIFFER, slot k wears
+    -- style k; otherwise exactly ONE slot wears the first style -- so the probe mirrors
+    -- that rather than guessing, and the measured cells match the rendered ones instead of
     -- being padded to a worst case.
-    local styles, allStyled = {}, true
+    -- ☠ THE DISTINCTNESS TERM MUST MATCH Frames/AuraContainer.lua's TWO COPIES, where the
+    -- long note lives. Without it, two debuff records sharing one importantStyle table read
+    -- as a layout group and every slot measures enlarged — the mark would then be sized for
+    -- a row that is not what renders, which is the one thing this probe may never do.
+    local styles, allStyled, stylesDiffer = {}, true, false
     for _, rec in ipairs(type(cfg.filter) == "table" and cfg.filter or {}) do
         if type(rec) == "table" and rec.style then
             styles[#styles + 1] = rec.style
+            if styles[1] ~= rec.style then stylesDiffer = true end
         else
             allStyled = false
         end
     end
-    local perSlot = (allStyled and #styles > 1) and styles or nil
+    local perSlot = (allStyled and stylesDiffer and #styles > 1) and styles or nil
     local single  = (not perSlot) and styles[1] or nil
 
     for i = 1, count do

--- a/DandersFrames_Options/TestMode/Labels.lua
+++ b/DandersFrames_Options/TestMode/Labels.lua
@@ -1,0 +1,1024 @@
+-- ============================================================
+-- TEST MODE — SECTION LABELS
+-- ============================================================
+-- "Which bar is this, and which page changes it?" — the question every new user asks
+-- of test mode, where every element renders at once. ONE opt-in setting
+-- (db.testShowLabels) answers it two ways at once, because nobody wants half:
+--
+--   * the element under the cursor is HIGHLIGHTED (corner brackets + a faint tint)
+--     and TAGGED with its name;
+--   * its tooltip names the element and the settings page that owns it — appended to
+--     the game's own tooltip where there is one, shown standalone where there is not.
+--
+-- ☠ ONLY ONE REGION IS EVER MARKED. Marking them all at once was tried and is
+-- unreadable at real frame sizes: three tags, three bracket sets and three tints on a
+-- 130px frame, with regions that legitimately overlap (an Aura Designer indicator sits
+-- inside the buff row). Don't "improve" this by showing everything again.
+--
+-- ☠ EVERY WIDGET HERE IS DF-OWNED AND ANCHORED **OVER** ITS TARGET, NEVER PARENTED
+-- UNDER IT. A frame created as a child of a native aura button inherits its forbidden
+-- aspects and access restrictions and can never be styled or scripted again
+-- (rules_12_1_engine_constraints). Everything below parents to the unit frame and
+-- anchors to the target's rect, which is the standing anchor-proxy pattern.
+--
+-- ☠ NOTHING HERE MAY TAKE THE MOUSE. An overlay with EnableMouse swallows the aura
+-- button's own tooltip — this feature shipped that bug once. Hover is detected by
+-- comparing the cursor against cached rects instead.
+--
+-- Each element is labelled on whichever test frame actually renders it: the preview
+-- spreads its samples deliberately (the defensive icon only on a tank/healer slot, the
+-- missing-buff badge on another), so the marks spread with them.
+
+local DF = DandersFrames
+local L = DF.L
+local TL = {}
+DF.TestLabels = TL
+
+-- Element identity colours. Deliberately NOT the addon's own semantic colours: these
+-- must not be confused with the dispel ring or the important-debuff marker, which are
+-- usually the things being judged when test mode is open.
+local TARGETS = {
+    { key = "buff",      color = { 0.37, 0.76, 0.48 } },
+    { key = "debuff",    color = { 0.88, 0.37, 0.42 } },
+    { key = "defensive", color = { 0.34, 0.65, 0.85 } },
+    { key = "missing",   color = { 0.77, 0.44, 0.79 } },
+    { key = "ad",        color = { 0.88, 0.66, 0.29 } },
+}
+
+-- Localised at call time, not at file scope: this file loads before the locale refresh
+-- on some paths, and a cached English string would survive a locale change.
+-- ⚠ The second return is the SETTINGS PAGE, and these strings must stay identical to
+-- the CreateSubTab labels in GUI/Pages — a tooltip naming a page that does not exist
+-- under that name is worse than no tooltip. (Note "Missing Buffs" is plural on the
+-- page while the test toggle beside it is singular; the page wins here.)
+local function labelFor(key)
+    -- ☠ PLAIN ">" — the game's fonts have no glyph for "▸" (U+25B8) and rendered it as
+    -- a filled diamond in game. Nothing else in the addon uses that character; the
+    -- breadcrumbs elsewhere are plain ASCII for exactly this reason.
+    local auras = L["Auras"] .. " > "
+    if key == "buff"      then return L["Buff Bar"],       auras .. L["Buff Bar"] end
+    if key == "debuff"    then return L["Debuff Bar"],     auras .. L["Debuff Bar"] end
+    if key == "defensive" then return L["Defensive Icon"], auras .. L["Defensive Icon"] end
+    if key == "missing"   then return L["Missing Buffs"],  auras .. L["Missing Buffs"] end
+    if key == "ad"        then return L["Aura Designer"],  auras .. L["Aura Designer"] end
+    return key, ""
+end
+
+-- ============================================================
+-- TARGET RESOLUTION
+-- ============================================================
+-- Every row hands back the DF-owned window frame it renders into. A row that is
+-- disabled, parked or not previewing has no rect worth labelling, so it drops out
+-- here rather than producing a tag pointing at nothing.
+-- ☠☠ THE ROW'S REAL RECT CANNOT BE MEASURED. Two dead ends, both learned the hard way:
+--   * `handle.frame` is only SIZED in `missing` mode; for the buff / debuff / defensive
+--     rows it is a bare anchor ORIGIN the container pins to, so it has no rect at all.
+--   * the CustomAuraContainer's own rect is SECRET — `GetRight()` on it returns a secret
+--     number and the first subtraction throws ("attempt to perform arithmetic on local
+--     'r' (a secret number value)"). The no-rect-math rule covers the container, not
+--     just its buttons.
+--
+-- ★ So the region is obtained the way every other preview surface obtains one: ask the
+-- LIVE flow. AuraContainer.FlowSlots pins a box and lays plain DF frames into it with
+-- the same AnchorUtil flow, growth, wrap headroom and strip reservation the real
+-- container uses — and OUR frames are plain, so their rects are readable. This is the
+-- shared entry point the AD canvas uses; its contract says a caller must never
+-- substitute maths of its own, and this one does not: when the flow is unavailable the
+-- element simply goes unlabelled.
+-- ⚠ COST, stated because it scales with the raid preview: one probe box plus `count`
+-- slot frames per labelled element per visible test frame — roughly 9 frames a frame,
+-- so ~90 at the default 10-frame raid preview and ~360 at a 40-frame one. Pooled and
+-- created once, never per pass, and only while the option is on; WoW never frees a
+-- frame, so if that ceiling ever matters the fix is to probe fewer frames rather than
+-- to rebuild them.
+local function ensureProbe(frame, key, count)
+    frame.dfTestLabelProbes = frame.dfTestLabelProbes or {}
+    local p = frame.dfTestLabelProbes[key]
+    if not p then
+        local box = CreateFrame("Frame", nil, frame)
+        box:SetSize(1, 1)
+        p = { box = box, slots = {} }
+        frame.dfTestLabelProbes[key] = p
+    end
+    for i = 1, count do
+        local s = p.slots[i]
+        if not s then
+            s = CreateFrame("Frame", nil, p.box)
+            -- Invisible and inert: this is a measuring stick, not art. It must never
+            -- take the mouse (that was the tooltip-stealing bug) and never draw.
+            s:EnableMouse(false)
+            p.slots[i] = s
+        end
+        s:Show()
+    end
+    for i = count + 1, #p.slots do p.slots[i]:Hide() end
+    return p
+end
+
+-- Union of the flowed probe slots = the region the row occupies.
+local function flowedRect(frame, key, h)
+    local cfg = h and h.config
+    if type(cfg) ~= "table" then return nil end
+    local FS = DF.AuraContainer and DF.AuraContainer.FlowSlots
+    if not FS then return nil end
+
+    -- How many icons the row is actually laying out. _slotCount is the live answer
+    -- (it already folds in test mode's count slider and the preview pool cap), so the
+    -- box matches what is on screen rather than the configured maximum.
+    local okCount, count = pcall(function() return h:_slotCount() end)
+    if not okCount then count = nil end
+    count = tonumber(count) or tonumber(cfg.max) or 0
+    if count < 1 then return nil end
+
+    local p = ensureProbe(frame, key, count)
+    p.box:Show()
+    -- The slots must carry the row's cell size before flowing: the flow reads each
+    -- element's size when the group declares none.
+    local L = cfg.layout or {}
+    local sx = tonumber(L.sizeX) or tonumber(L.size) or 16
+    local sy = tonumber(L.sizeY) or sx
+
+    -- ★ IMPORTANT DEBUFFS RENDER BIGGER, and the box has to contain them (field: the
+    -- scaled icon poked out of the highlight). The preview's own choice of WHICH slots
+    -- wear a record style is deterministic -- Handle._build's test branch: when every
+    -- record carries a style and there is more than one, slot k wears style k;
+    -- otherwise exactly ONE slot wears the first style -- so the probe mirrors that
+    -- rather than guessing, and the measured cells match the rendered ones instead of
+    -- being padded to a worst case.
+    local styles, allStyled = {}, true
+    for _, rec in ipairs(type(cfg.filter) == "table" and cfg.filter or {}) do
+        if type(rec) == "table" and rec.style then
+            styles[#styles + 1] = rec.style
+        else
+            allStyled = false
+        end
+    end
+    local perSlot = (allStyled and #styles > 1) and styles or nil
+    local single  = (not perSlot) and styles[1] or nil
+
+    for i = 1, count do
+        local s = p.slots[i]
+        local style = (perSlot and perSlot[i]) or (single and i == 1 and single) or nil
+        -- Stamping the style is what makes the FLOW hand this element the scaled CELL
+        -- (its GetElementSize checks dfImpRecStyle), so spacing comes out right...
+        s.dfImpRecStyle = style
+        -- ...and the element itself is sized the way applyRecordStyle sizes the real
+        -- button, so the measured UNION covers the bigger icon rather than just the
+        -- space reserved for it.
+        local ex, ey = sx, sy
+        if style then
+            local sz = style.layout and style.layout.size
+            if sz then ex, ey = sz, sz end
+            local sc = tonumber(style.scale) or 1
+            if sc ~= 1 then ex, ey = ex * sc, ey * sc end
+        end
+        s:SetSize(ex, ey)
+    end
+
+    local anchor = (h.GetFrame and h:GetFrame()) or h.frame
+    if not anchor then return nil end
+    local ok = FS(p.box, anchor, p.slots, count, cfg, h._pp)
+    if not ok then return nil end
+
+    local l, r, t, b
+    for i = 1, count do
+        local s = p.slots[i]
+        local sl, sr, st, sb = s:GetLeft(), s:GetRight(), s:GetTop(), s:GetBottom()
+        if sl and sr and st and sb then
+            l = (l and math.min(l, sl)) or sl
+            r = (r and math.max(r, sr)) or sr
+            t = (t and math.max(t, st)) or st
+            b = (b and math.min(b, sb)) or sb
+        end
+    end
+    if not l or (r - l) < 1 or (t - b) < 1 then return nil end
+    return l, r, t, b, anchor
+end
+
+-- `missing` mode is the one row whose window IS sized (it is a clip window exactly the
+-- badge's size), so it needs no flow probe. Takes a handle OR a plain frame, because
+-- the missing-buff STRIP is a bare frame with no handle wrapping it.
+local function windowRect(h)
+    local f
+    if type(h) == "table" and h.GetLeft then
+        f = h                                   -- already a frame
+    else
+        f = (h and h.GetFrame and h:GetFrame()) or (h and h.frame)
+    end
+    if type(f) ~= "table" or not f.GetLeft then return nil end
+    local ok, l, r, t, b = pcall(function()
+        if not f:IsShown() then return nil end
+        return f:GetLeft(), f:GetRight(), f:GetTop(), f:GetBottom()
+    end)
+    if not ok or not l or not r or not t or not b then return nil end
+    if (r - l) < 1 or (t - b) < 1 then return nil end
+    return l, r, t, b, f
+end
+
+local function handleRect(frame, key, h)
+    if not h then return nil end
+    if (h.config and h.config.mode) == "missing" then return windowRect(h) end
+    local l, r, t, b, anchor = flowedRect(frame, key, h)
+    if l then return l, r, t, b, anchor end
+    return windowRect(h)
+end
+
+-- The Aura Designer has no single window: each placed indicator is its own handle in
+-- the factory's `placed` store. Label the UNION of their rects, so the tag names the
+-- system once instead of once per indicator.
+local function adUnionRect(frame)
+    local store = frame.dfADFactory
+    local placed = store and store.placed
+    if type(placed) ~= "table" then return nil end
+    local l, r, t, b
+    local hosts = {}
+    local i = 0
+    for _, entry in pairs(placed) do
+        i = i + 1
+        -- Each placed indicator is its own single-slot handle; give each probe its own
+        -- key so they do not share (and overwrite) one measuring box.
+        local fl, fr, ft, fb, anchor = handleRect(frame, "ad" .. i, entry and entry.handle)
+        if fl then
+            l = (l and math.min(l, fl)) or fl
+            r = (r and math.max(r, fr)) or fr
+            t = (t and math.max(t, ft)) or ft
+            b = (b and math.min(b, fb)) or fb
+            if anchor then hosts[#hosts + 1] = anchor end
+        end
+    end
+    if not l then return nil end
+    return l, r, t, b, hosts
+end
+
+-- Returns the rect AND the frame to anchor against. ☠ ANCHOR TO THE TARGET, never to
+-- UIParent with these numbers: GetLeft/GetBottom report in the frame's own effective
+-- scale, so feeding them to a UIParent anchor misplaces every widget the moment the
+-- frames are scaled — which is exactly why the first cut drew its tags in roughly the
+-- right place and its outlines nowhere useful. The rect is still returned because the
+-- tag-collision pass compares rects, and every rect it compares comes from this same
+-- space.
+-- Returns rect, the frame to ANCHOR the overlay against, and the list of frames whose
+-- tooltips belong to this element. The two are not always the same: the AD union spans
+-- several indicator frames, so it anchors to the shared unit frame — and ☠ the unit
+-- frame must NEVER be registered as a tooltip host, or every aura on the frame would
+-- claim to be an Aura Designer indicator (the parent walk reaches it from everything).
+-- ☠ IS THIS ELEMENT ACTUALLY ON SCREEN RIGHT NOW? Two things needed this, and the
+-- first cut only did the first:
+--   * `flowedRect` measures a row from its CONFIG — it asks the live flow to lay out
+--     `_slotCount()` cells — and a row that is switched off still has a perfectly good
+--     config, so an unticked Buff Bar or a Defensives-at-0 row measured to a rect and
+--     got a mark over empty space.
+--   * ☠☠ AND THE ANSWER HAS TO BE RE-ASKED AT HOVER TIME, NOT ONLY AT SCAN TIME. The
+--     region list is rebuilt by TL:Update, so a check made only there freezes whatever
+--     was on when the list was last built: rows switched off after that kept their
+--     marks and rows switched on never got one, which reads exactly as "it only checks
+--     what was on when you opened test mode" (Krathe, 2026-08-17). The hover driver
+--     therefore re-asks per tick — and that is also why this must be CHEAP.
+-- ★ RENDERED STATE, NOT A SHOWN-CACHE and not a re-reading of the test toggles. The
+-- first cut used `dfBuffFactoryShown` and friends: correct as far as it went, but it is
+-- a description of what a drive last decided, and this asks the frame itself. One read
+-- covers every reason a row can be absent — the test toggle, the feature's own setting,
+-- the identity gate, the death and cinematic latches — because all of them actuate
+-- through the same `SetShown` on the handle's plain anchor frame.
+-- ⚠ Fail OPEN on a refused or secret read. A row that is genuinely rendering must never
+-- lose its mark because a probe misfired; the failure this guards against is a mark
+-- over EMPTY SPACE, which a false positive here cannot produce.
+local function elementShown(frame, key)
+    if key == "ad" then
+        -- The AD has no row frame: Factory:ClearFrame empties `placed`, so an empty
+        -- store IS the off state (and adUnionRect then finds no rect anyway).
+        local store = frame.dfADFactory
+        local placed = store and store.placed
+        return type(placed) == "table" and next(placed) ~= nil
+    end
+    if key == "missing" then
+        local s = frame.missingBuffStrip
+        return (s and s.IsShown and s:IsShown()) and true or false
+    end
+    local h = (key == "buff" and frame.buffFactory)
+           or (key == "debuff" and frame.debuffFactory)
+           or (key == "defensive" and frame.defensiveFactory)
+    if not (h and h.GetFrame) then return false end
+    -- ☠ A PARENT-DRIVEN handle inherits its host slot's SECRET shown state, so testing
+    -- it taints ("attempt to compare a secret boolean"). None of these three are ever
+    -- parent-driven — that is for containers nested in another container's slot — so
+    -- this is belt-and-braces rather than a live branch.
+    if h.config and h.config.parentDrivenVisibility then return true end
+    local f = h:GetFrame()
+    if not (f and f.IsShown) then return false end
+    local ok, shown = pcall(f.IsShown, f)
+    if not ok then return true end
+    if issecretvalue and issecretvalue(shown) then return true end
+    return shown and true or false
+end
+
+local function targetOf(frame, key)
+    if not elementShown(frame, key) then return nil end
+    if key == "ad" then
+        local l, r, t, b, hosts = adUnionRect(frame)
+        if not l then return nil end
+        return l, r, t, b, frame, hosts
+    end
+    -- ☠ MISSING BUFF IS NOT ONE HANDLE. `frame.missingFactory` is a MAP of spell key
+    -- -> handle, one cell per tracked buff, so passing it where a handle is expected
+    -- found nothing and the element never labelled at all (field-reported). Its cells
+    -- are all parented to `frame.missingBuffStrip`, which IS a plain sized DF frame --
+    -- so the strip is both the right region and the right tooltip host: the owner walk
+    -- reaches it from any badge inside it.
+    if key == "missing" then
+        local l, r, t, b, anchor = windowRect(frame.missingBuffStrip)
+        if not l then return nil end
+        return l, r, t, b, anchor, { anchor }
+    end
+    local h = (key == "buff" and frame.buffFactory)
+           or (key == "debuff" and frame.debuffFactory)
+           or (key == "defensive" and frame.defensiveFactory)
+    local l, r, t, b, anchor = handleRect(frame, key, h)
+    if not l then return nil end
+    return l, r, t, b, anchor, { anchor }
+end
+
+-- ============================================================
+-- WIDGET POOL
+-- ============================================================
+-- Pooled per unit frame and per element key, so a re-place reuses widgets rather than
+-- leaking frames — WoW never frees a frame, and this runs on every settings change.
+local function ensureWidgets(frame, key)
+    frame.dfTestLabels = frame.dfTestLabels or {}
+    local w = frame.dfTestLabels[key]
+    if w then return w end
+
+    local host = CreateFrame("Frame", nil, frame)
+    -- ☠ ONE STRATA ABOVE THE FRAME'S OWN, not a fixed "HIGH". The first cut pinned HIGH
+    -- with a capped level and the outline landed BEHIND the very icons it was meant to
+    -- bound — invisible, because it sits exactly on their edges. Strata beats level
+    -- across unrelated frames, so derive it rather than guessing a number.
+    local order = { BACKGROUND = 1, LOW = 2, MEDIUM = 3, HIGH = 4, DIALOG = 5,
+                    FULLSCREEN = 6, FULLSCREEN_DIALOG = 7, TOOLTIP = 8 }
+    local names = { "BACKGROUND", "LOW", "MEDIUM", "HIGH", "DIALOG",
+                    "FULLSCREEN", "FULLSCREEN_DIALOG", "TOOLTIP" }
+    local at = order[frame:GetFrameStrata() or "MEDIUM"] or 3
+    -- Stop below TOOLTIP: that is the game tooltip's own layer, and an outline drawn
+    -- over a tooltip is worse than one drawn under an icon.
+    host:SetFrameStrata(names[math.min(at + 1, 7)])
+    host:SetFrameLevel(20)
+
+    -- ☠ A TEXTURE'S DRAW LAYER ONLY ORDERS IT WITHIN ITS OWN FRAME. Strata wins across
+    -- frames, so the "BACKGROUND" tint that used to live on this host was drawing OVER
+    -- the icons, not under them — the comment claiming otherwise was simply wrong, and
+    -- raising its alpha would have washed out the very art being judged.
+    --
+    -- So the fill gets its OWN frame UNDER the row. Backing the region rather than
+    -- washing it is what makes a section of tightly-packed icons read as one block:
+    -- the colour shows in the inflation margin and between the icons while the icons
+    -- themselves stay untouched, so it can carry real weight.
+    -- ⚠ Its strata/level are DERIVED from the row it backs at place() time (one level
+    -- below), never hardcoded — the row's own level moves with the frame's.
+    local under = CreateFrame("Frame", nil, frame)
+    local fill = under:CreateTexture(nil, "BACKGROUND")
+    fill:SetAllPoints()
+
+    -- A much fainter wash ON TOP, purely to tie the backing to the brackets over
+    -- opaque icons. Kept low: this one does touch the art.
+    local wash = host:CreateTexture(nil, "BACKGROUND")
+    wash:SetAllPoints()
+
+    -- ☠ CORNER BRACKETS, NOT A CONTINUOUS BOX. A full rectangle hugging an icon is
+    -- exactly what the addon's OWN art looks like -- the dispel ring, the AD border,
+    -- the important-debuff marker -- so a coloured box read as another aura state
+    -- rather than as an annotation (field: "they blend into the actual borders").
+    -- Four L-shaped brackets with open edges are a mark the addon never draws for
+    -- content, so they cannot be mistaken for one; it is the crop-marks language,
+    -- which is what this overlay actually is.
+    -- 8 arms: two per corner (horizontal + vertical).
+    local edges = {}
+    for i = 1, 8 do edges[i] = host:CreateTexture(nil, "OVERLAY") end
+
+    local tagBG = host:CreateTexture(nil, "OVERLAY", nil, 6)
+    tagBG:SetColorTexture(0.05, 0.04, 0.07, 0.88)
+    local tag = host:CreateFontString(nil, "OVERLAY", "DFFontHighlightSmall")
+
+    w = { host = host, under = under, fill = fill, wash = wash,
+          edges = edges, tag = tag, tagBG = tagBG }
+    frame.dfTestLabels[key] = w
+    return w
+end
+
+-- The mark is TWO frames (backing under the row, brackets over it), so every
+-- show/hide/alpha path has to drive both or the halves separate.
+local function setMarkAlpha(w, a)
+    if not w then return end
+    w.host:SetAlpha(a)
+    if w.under then w.under:SetAlpha(a) end
+end
+
+local function hideMark(w)
+    if not w then return end
+    w.host:Hide()
+    if w.under then w.under:Hide() end
+end
+
+local function hideWidgets(frame)
+    local set = frame.dfTestLabels
+    if set then
+        for _, w in pairs(set) do hideMark(w) end
+    end
+    -- The measuring probes are invisible either way, but a pooled frame handed back to
+    -- live rendering should not keep a flowed box parented to it.
+    local probes = frame.dfTestLabelProbes
+    if probes then
+        for _, p in pairs(probes) do
+            for _, s in ipairs(p.slots) do s:Hide() end
+            p.box:Hide()
+        end
+    end
+end
+
+-- ============================================================
+-- TOOLTIPS — APPEND, NEVER REPLACE
+-- ============================================================
+-- ☠ NO INVISIBLE HIT FRAME OVER THE ICONS. The first cut laid a mouse-enabled frame
+-- across each element to catch hover, which SWALLOWED the mouse before it reached the
+-- aura button underneath — so the game's own spell tooltip never appeared and ours
+-- showed in its place, anchored to a frame the user could not see. Wrong on both
+-- counts: it replaced the information people actually want, and it broke hover on the
+-- element it was describing.
+--
+-- Instead the game tooltip is left entirely alone and simply APPENDED to: when it
+-- shows for anything living inside a labelled region, the element name and its
+-- settings page are added underneath the spell's own text. Nothing is intercepted,
+-- nothing is blocked, and an element that shows no tooltip of its own simply gets none
+-- (the outline and tag already identify it).
+local regionOf = setmetatable({}, { __mode = "k" })   -- targetFrame -> element key
+
+-- Walk up from the tooltip's owner looking for a registered region. The owner is an
+-- aura BUTTON, whose parent chain runs button -> container -> the row's window frame,
+-- which is what gets registered. Bounded rather than while-true: a parent cycle would
+-- otherwise hang the client, and nothing legitimate is deeper than a few links.
+local function regionForOwner(owner)
+    local node, depth = owner, 0
+    while node and depth < 10 do
+        local key = regionOf[node]
+        if key then return key end
+        local ok, parent = pcall(node.GetParent, node)
+        if not ok then return nil end
+        node = parent
+        depth = depth + 1
+    end
+    return nil
+end
+
+-- Is either test pool asking for labels? One toggle now drives both halves, and the
+-- tooltip hook fires from anywhere, so it has to ask both dbs rather than assume a mode.
+local function labelsWanted()
+    if not (DF.testMode or DF.raidTestMode) then return false end
+    if DF.testMode then
+        local db = DF.GetDB and DF:GetDB()
+        if db and db.testShowLabels then return true end
+    end
+    if DF.raidTestMode then
+        local db = DF.GetRaidDB and DF:GetRaidDB()
+        if db and db.testShowLabels then return true end
+    end
+    return false
+end
+
+local hooked = false
+local function ensureTooltipHook()
+    if hooked then return end
+    hooked = true
+    GameTooltip:HookScript("OnShow", function(tt)
+        if not labelsWanted() then return end
+        local ok, owner = pcall(tt.GetOwner, tt)
+        if not ok or not owner then return end
+        local key = regionForOwner(owner)
+        if not key then return end
+        local name, page = labelFor(key)
+        -- A blank spacer keeps DF's two lines visibly separate from the spell's own
+        -- text rather than reading as part of it.
+        tt:AddLine(" ")
+        tt:AddLine(name, 0.58, 0.51, 0.79)
+        if page ~= "" then tt:AddLine(page, 0.62, 0.6, 0.66) end
+        tt:Show()   -- re-layout: added lines do not resize an already-shown tooltip
+    end)
+end
+
+-- ============================================================
+-- TAG PLACEMENT — the anti-clash pass
+-- ============================================================
+-- Each tag gets a preference order of corners derived from where its element sits on
+-- the frame (an element hugging the bottom-left prefers to label below-left, and so
+-- on), then takes the first candidate whose rect overlaps nothing already placed.
+-- If every candidate collides, it takes the one that collides LEAST — a slightly
+-- overlapping tag still reads, a hidden one does not.
+local TAG_H, PAD, GAP = 12, 2, 3
+-- How far the bracket sits OUTSIDE the region. 3px rather than 1: hugging the art is
+-- what made the first cut read as another border on the icon. Standing clear of it is
+-- half of why the brackets now read as annotation.
+local PUSH = 3
+
+-- Anchor origin of the frame an overlay is measured against. Zero when the rect is not
+-- resolvable, which only happens mid-layout — the caller has already established the
+-- target has a rect, so this is a guard rather than a path.
+local function lOf(f) return (f and f.GetLeft and f:GetLeft()) or 0 end
+local function bOf(f) return (f and f.GetBottom and f:GetBottom()) or 0 end
+
+local function overlapArea(a, b)
+    local dx = math.min(a.r, b.r) - math.max(a.l, b.l)
+    local dy = math.min(a.t, b.t) - math.max(a.b, b.b)
+    if dx <= 0 or dy <= 0 then return 0 end
+    return dx * dy
+end
+
+-- Candidate tag rects for an element rect, in preference order. `above` and `left`
+-- describe which half of the FRAME the element occupies, so tags radiate outward
+-- rather than crossing the frame.
+local function candidates(l, r, t, b, tw, above, left)
+    local outT, outB = t + GAP, b - GAP - TAG_H
+    local inL, inR = l, r - tw
+    local c = {}
+    local function add(x, y) c[#c + 1] = { l = x, r = x + tw, b = y, t = y + TAG_H } end
+    if above then
+        if left then add(inL, outT); add(inR, outT); add(inL, outB); add(inR, outB)
+        else       add(inR, outT); add(inL, outT); add(inR, outB); add(inL, outB) end
+    else
+        if left then add(inL, outB); add(inR, outB); add(inL, outT); add(inR, outT)
+        else       add(inR, outB); add(inL, outB); add(inR, outT); add(inL, outT) end
+    end
+    -- Clear of the element's sides entirely.
+    add(l - tw - GAP, b + (t - b - TAG_H) / 2)
+    add(r + GAP,      b + (t - b - TAG_H) / 2)
+    -- ☠ FAR RANKS, so "the tag always shows" is actually true. A full spell tooltip is
+    -- big enough to sit over every close candidate at once; without somewhere further
+    -- out to go, the least-overlapping pick is still underneath it. One row further
+    -- above and below, at both ends, gives the scorer a clear spot in every realistic
+    -- case while staying close enough to read as this element's label.
+    local farT, farB = outT + TAG_H + GAP, outB - TAG_H - GAP
+    add(inL, farT); add(inR, farT); add(inL, farB); add(inR, farB)
+    return c
+end
+
+local function place(frame, key, color, l, r, t, b, target, taken)
+    local w = ensureWidgets(frame, key)
+    local name = labelFor(key)
+    w.tag:SetText(name)
+    local tw = (w.tag:GetStringWidth() or 20) + PAD * 2
+
+    -- Which half of the frame does this element live in? Decided from the element's
+    -- CENTRE against the frame's, so an element that has been dragged elsewhere still
+    -- labels outward rather than at a hardcoded corner.
+    local fl, fr = frame:GetLeft(), frame:GetRight()
+    local ft, fb = frame:GetTop(), frame:GetBottom()
+    if not (fl and fr and ft and fb) then return end
+    local above = ((t + b) / 2) >= ((ft + fb) / 2)
+    local left  = ((l + r) / 2) <  ((fl + fr) / 2)
+
+    local best, bestCost
+    for _, cand in ipairs(candidates(l, r, t, b, tw, above, left)) do
+        local cost = 0
+        for _, used in ipairs(taken) do cost = cost + overlapArea(cand, used) end
+        -- Off-screen is worse than any overlap: a tag drawn past the screen edge is
+        -- simply gone, which reads as "that element has no label".
+        if cand.l < 0 or cand.r > UIParent:GetWidth() then cost = cost + 1e6 end
+        if cost == 0 then best, bestCost = cand, 0; break end
+        if not bestCost or cost < bestCost then best, bestCost = cand, cost end
+    end
+    if not best then return end
+    taken[#taken + 1] = best
+
+    -- ☠ ANCHOR TO THE TARGET, NOT TO UIParent WITH THESE NUMBERS. Every coordinate
+    -- here is in the target's effective scale; handing it to a UIParent anchor is only
+    -- correct while the two scales happen to match. Offsets FROM the target are exact
+    -- at any scale and track whatever the element's own anchors do afterwards.
+    -- Inflated by PUSH so the brackets stand clear of the art rather than tracing it.
+    local host = w.host
+    local bw, bh = math.max(1, r - l) + PUSH * 2, math.max(1, t - b) + PUSH * 2
+    local ox, oy = (l - lOf(target)) - PUSH, (b - bOf(target)) - PUSH
+    host:ClearAllPoints()
+    host:SetPoint("BOTTOMLEFT", target, "BOTTOMLEFT", ox, oy)
+    host:SetSize(bw, bh)
+
+    -- Backing plate, same rect, but UNDER the row it marks. Strata and level are
+    -- derived from the target every pass rather than set once: the row's own level
+    -- moves with the frame, and a stale number would put the plate over the icons (or
+    -- behind the health bar, where it is invisible).
+    local under = w.under
+    if under then
+        under:ClearAllPoints()
+        under:SetPoint("BOTTOMLEFT", target, "BOTTOMLEFT", ox, oy)
+        under:SetSize(bw, bh)
+        local okS, tStrata = pcall(target.GetFrameStrata, target)
+        local okL, tLevel = pcall(target.GetFrameLevel, target)
+        if okS and tStrata then under:SetFrameStrata(tStrata) end
+        if okL and tLevel then under:SetFrameLevel(math.max(0, tLevel - 1)) end
+        under:Show()
+    end
+
+    local cr, cg, cb = color[1], color[2], color[3]
+    -- The backing can be bold — it never touches the icon art, only the margin around
+    -- it and the gaps between icons, which is exactly what makes a packed row read as
+    -- one block. The wash over the top stays faint for the opposite reason: that one
+    -- DOES tint the icons, so it may hint at the region but must never recolour what
+    -- is being judged. Raise FILL, not WASH, if the effect wants more weight.
+    w.fill:SetColorTexture(cr, cg, cb, 0.80)
+    w.wash:SetColorTexture(cr, cg, cb, 0.12)
+    -- Arm length scales with the region but stays short: a bracket that grows to meet
+    -- its neighbour is a box again, which is the thing being avoided. Capped at a
+    -- third of the shorter side so even a single-icon region keeps open edges.
+    local bw, bh = math.max(1, r - l) + PUSH * 2, math.max(1, t - b) + PUSH * 2
+    local arm = math.max(3, math.min(9, math.min(bw, bh) / 3))
+    local e = w.edges
+    for i = 1, 8 do e[i]:SetColorTexture(cr, cg, cb, 1); e[i]:ClearAllPoints() end
+    -- Two arms per corner, anchored AT the corner and growing inward along each edge.
+    local function bracket(hArm, vArm, point)
+        hArm:SetPoint(point); hArm:SetSize(arm, 2)
+        vArm:SetPoint(point); vArm:SetSize(2, arm)
+    end
+    bracket(e[1], e[2], "TOPLEFT")
+    bracket(e[3], e[4], "TOPRIGHT")
+    bracket(e[5], e[6], "BOTTOMLEFT")
+    bracket(e[7], e[8], "BOTTOMRIGHT")
+
+    -- ☠ THE TAG ALWAYS SHOWS. An earlier cut stood it down while a spell tooltip was
+    -- naming the element, on the theory that the name was already on screen -- Krathe's
+    -- call is that the tag is the thing tying the name to the region and it must never
+    -- disappear. The tooltip is avoided by MOVING the tag (see the obstacle pass), not
+    -- by hiding it.
+    local tx, ty = best.l - lOf(target), best.b - bOf(target)
+    w.tag:ClearAllPoints()
+    w.tag:SetPoint("BOTTOMLEFT", target, "BOTTOMLEFT", tx + PAD, ty + 1)
+    w.tag:SetTextColor(cr, cg, cb)
+    w.tagBG:ClearAllPoints()
+    w.tagBG:SetPoint("BOTTOMLEFT", target, "BOTTOMLEFT", tx, ty)
+    w.tagBG:SetSize(tw, TAG_H)
+    w.tag:Show(); w.tagBG:Show()
+    host:Show()
+end
+
+-- ============================================================
+-- DRIVE
+-- ============================================================
+-- Called from the test-mode refresh, and from the two toggles. Cheap enough to run on
+-- every refresh: a handful of rect reads over one frame.
+-- Label ONE frame per active preview. Party test frames are keyed 0-4 and raid ones
+-- 1-N, so the "first" differs per pool -- taking [1] for both would silently label
+-- nothing in party mode.
+-- ★★ ONE SECTION AT A TIME, UNDER THE CURSOR. Marking every element at once is what
+-- the concept warned about and the field confirmed: three tags, three bracket sets and
+-- three tints on a 130px frame is unreadable no matter how the marks are styled, and
+-- overlapping regions (an Aura Designer indicator sitting inside the buff row) make it
+-- worse. Highlighting only what the mouse is over removes the clutter completely and
+-- answers the actual question -- "what is THIS?" -- at the moment it is asked.
+--
+-- Hover is detected by comparing the cursor against the cached region rects rather
+-- than by a mouse-enabled frame: an overlay that takes the mouse swallows the aura
+-- button's own tooltip, which is the bug this feature already shipped once.
+local hoverRegions = {}   -- { frame, key, color, l, r, t, b, host, scale }
+
+-- ★ EVERY ELEMENT ON EVERY VISIBLE TEST FRAME IS REGISTERED. An earlier cut let each
+-- element claim the FIRST frame that rendered it, which was a holdover from marking
+-- everything at once — with only the hovered region marked there is no clutter to
+-- avoid, and pointing at unit 3's buffs should name them just as readily as unit 1's.
+-- It also stops the preview lying by omission: the defensive icon previews on a
+-- tank/healer slot and the missing-buff badge on another, so a single claimed frame
+-- left whole elements unhoverable with nothing to say why.
+local function scanFrame(frame)
+    if not frame or not frame.GetLeft or not frame:GetLeft() or not frame:IsShown() then
+        return
+    end
+    for _, target in ipairs(TARGETS) do
+        local l, r, t, b, host, hosts = targetOf(frame, target.key)
+        if l and host then
+            for _, hf in ipairs(hosts or {}) do
+                if hf ~= frame then regionOf[hf] = target.key end
+            end
+            local okScale, scale = pcall(host.GetEffectiveScale, host)
+            hoverRegions[#hoverRegions + 1] = {
+                frame = frame, key = target.key, color = target.color,
+                l = l, r = r, t = t, b = b, host = host,
+                scale = (okScale and scale) or 1,
+            }
+        end
+    end
+end
+
+-- Smallest containing region wins, so an Aura Designer indicator sitting inside the
+-- buff row identifies as the indicator rather than as the row around it.
+local function regionUnderCursor()
+    local cx, cy = GetCursorPosition()
+    local best, bestArea
+    for _, reg in ipairs(hoverRegions) do
+        local s = reg.scale
+        -- ☠ RE-ASKED HERE, not just when the list was built. See elementShown: a scan-time
+        -- check freezes the answer until something rebuilds the list, which is what made
+        -- the marks reflect only what was switched on when test mode opened. The rect can
+        -- go stale the same way, but a rebuild follows every settings change that MOVES a
+        -- row — where an on/off flip has to read true the moment it happens.
+        if s and s > 0 and elementShown(reg.frame, reg.key) then
+            local x, y = cx / s, cy / s
+            if x >= reg.l and x <= reg.r and y >= reg.b and y <= reg.t then
+                local area = (reg.r - reg.l) * (reg.t - reg.b)
+                if not bestArea or area < bestArea then best, bestArea = reg, area end
+            end
+        end
+    end
+    return best
+end
+
+-- ★ OUR OWN TOOLTIP, shown only when the element has none of its own. Aura tooltips
+-- are a setting people switch off, and icons outside the aura rows never had one, so
+-- appending to the game tooltip alone left those elements silently unnamed. A separate
+-- tooltip object rather than GameTooltip: nothing to fight over, and no chance of
+-- clearing a tooltip the game owns.
+local ownTip
+local function ensureOwnTip()
+    if ownTip then return ownTip end
+    ownTip = CreateFrame("GameTooltip", "DFTestLabelTooltip", UIParent, "GameTooltipTemplate")
+    return ownTip
+end
+
+-- Stands down when the GAME's tooltip is already naming this element (our hook has
+-- appended to it) — two tooltips saying the same thing is worse than one. The on-frame
+-- tag is never suppressed either way; it moves instead.
+local function showOwnTip(reg)
+    local tt = ensureOwnTip()
+    if GameTooltip:IsShown() then
+        local ok, owner = pcall(GameTooltip.GetOwner, GameTooltip)
+        if ok and owner and regionForOwner(owner) then tt:Hide(); return end
+    end
+    local name, page = labelFor(reg.key)
+    tt:SetOwner(reg.host, "ANCHOR_RIGHT")
+    tt:ClearLines()
+    tt:AddLine(name, 1, 1, 1)
+    if page ~= "" then tt:AddLine(page, 0.58, 0.51, 0.79) end
+    tt:Show()
+end
+
+-- ★ A VISIBLE TOOLTIP IS AN OBSTACLE, not a thing to work around by hand. The tag and
+-- the tooltip both want the free space beside the element, so the tooltip covered the
+-- tag whenever it opened on that side. Rather than picking a fixed opposite corner --
+-- which just moves the collision somewhere else, since the tooltip's own side depends
+-- on where the frame sits on screen — its rect is fed to the same candidate-scoring
+-- pass the tags already use against each other, and the tag steps aside on its own.
+-- ⚠ Converted into the REGION's coordinate space: a tooltip carries its own effective
+-- scale, and comparing raw rects across scales silently misjudges the overlap.
+local function tipObstacle(tt, scale)
+    if not (tt and tt.IsShown and tt:IsShown()) then return nil end
+    local ok, l, r, t, b, ts = pcall(function()
+        return tt:GetLeft(), tt:GetRight(), tt:GetTop(), tt:GetBottom(), tt:GetEffectiveScale()
+    end)
+    if not ok or not l or not r or not t or not b then return nil end
+    local k = (ts or 1) / ((scale and scale > 0) and scale or 1)
+    return { l = l * k, r = r * k, t = t * k, b = b * k }
+end
+
+local hoverDriver, hoverShown
+local clearFades   -- forward declaration: defined with the fade machinery below
+local function stopHover()
+    if hoverDriver then hoverDriver:Hide() end
+    if ownTip then ownTip:Hide() end
+    if clearFades then clearFades() end
+    if hoverShown then
+        local set = hoverShown.frame and hoverShown.frame.dfTestLabels
+        local w = set and set[hoverShown.key]
+        if w then setMarkAlpha(w, 1); hideMark(w) end
+        hoverShown = nil
+    end
+end
+
+-- ============================================================
+-- FADE
+-- ============================================================
+-- Snapping a mark on and off as the cursor crosses a frame reads as aggressive, which
+-- is the opposite of what an explanatory overlay should feel like. Three timings:
+--   * FADE_IN   — quick enough to feel responsive to the point.
+--   * LINGER    — a beat of hold after the cursor leaves EVERYTHING, so a mark that was
+--                 glanced at does not vanish before it has been read.
+--   * FADE_OUT  — the ease-off itself.
+-- ☠ MOVING BETWEEN two regions does NOT linger: holding the old one while the new one
+-- rises puts two marks on screen at once, which is the clutter this whole design was
+-- rebuilt to avoid. Only leaving to empty space holds.
+local FADE_IN, FADE_OUT, LINGER = 0.12, 0.28, 0.6
+
+-- Marks that are on their way out. Small by construction (one per region crossed
+-- during a fade), and entries are removed as they finish.
+local fadingOut = {}
+
+local function widgetFor(reg)
+    local set = reg and reg.frame and reg.frame.dfTestLabels
+    return set and set[reg.key]
+end
+
+local function beginFadeOut(reg, linger)
+    local w = widgetFor(reg)
+    if not w then return end
+    -- Resurrect rather than duplicate if this region is already fading.
+    for _, f in ipairs(fadingOut) do
+        if f.reg == reg then f.wait = linger; f.state = "wait"; return end
+    end
+    fadingOut[#fadingOut + 1] = {
+        reg = reg, alpha = w.host:GetAlpha() or 1, wait = linger, state = "wait",
+    }
+end
+
+local function advanceFades(dt)
+    for i = #fadingOut, 1, -1 do
+        local f = fadingOut[i]
+        local w = widgetFor(f.reg)
+        if not w then
+            table.remove(fadingOut, i)
+        else
+            if f.state == "wait" then
+                f.wait = f.wait - dt
+                if f.wait <= 0 then f.state = "out" end
+            else
+                f.alpha = f.alpha - dt / FADE_OUT
+                if f.alpha <= 0 then
+                    setMarkAlpha(w, 1)   -- restore for the next show
+                    hideMark(w)
+                    table.remove(fadingOut, i)
+                else
+                    setMarkAlpha(w, f.alpha)
+                end
+            end
+        end
+    end
+end
+
+-- Drop every in-flight fade immediately (settings changed, test mode ended): a mark
+-- fading toward a rect that no longer exists is worse than one that simply vanishes.
+-- Assigns the forward-declared local above — a `local function` here would shadow it
+-- and leave stopHover calling nil.
+function clearFades()
+    for i = #fadingOut, 1, -1 do
+        local w = widgetFor(fadingOut[i].reg)
+        if w then setMarkAlpha(w, 1); hideMark(w) end
+        fadingOut[i] = nil
+    end
+end
+
+local function ensureHoverDriver()
+    if hoverDriver then return hoverDriver end
+    hoverDriver = CreateFrame("Frame")
+    local elapsed, inAlpha = 0, 0
+    hoverDriver:SetScript("OnUpdate", function(_, dt)
+        -- ⚠ The FADES advance every frame; only the HIT TEST is throttled. Running the
+        -- alpha maths at the poll rate made the fade visibly step.
+        advanceFades(dt)
+
+        elapsed = elapsed + dt
+        if elapsed >= 0.05 then
+            elapsed = 0
+            -- Polled rather than event-driven: a mouse-enabled overlay would swallow
+            -- the aura button's own tooltip. A handful of rect comparisons, only while
+            -- the option is on and only in test mode.
+            local reg = regionUnderCursor()
+            if reg ~= hoverShown then
+                if hoverShown then
+                    -- Crossing to another region ends the old one promptly; leaving to
+                    -- nothing gets the hold.
+                    beginFadeOut(hoverShown, reg and 0 or LINGER)
+                end
+                if reg then
+                    -- Pick up where a fade left off, so sweeping back onto a region
+                    -- that is still visible does not restart it from transparent.
+                    local w = widgetFor(reg)
+                    inAlpha = (w and w.host:IsShown() and w.host:GetAlpha()) or 0
+                    for i = #fadingOut, 1, -1 do
+                        if fadingOut[i].reg == reg then table.remove(fadingOut, i) end
+                    end
+                end
+                hoverShown = reg
+                if not reg and ownTip then ownTip:Hide() end
+            end
+        end
+
+        local reg = hoverShown
+        if not reg then return end
+
+        -- Re-evaluated every tick rather than only on entry: the game tooltip can
+        -- appear or vanish while the cursor sits still (moving between two icons
+        -- inside one region), and both the fallback tooltip and the tag's placement
+        -- have to follow that.
+        showOwnTip(reg)
+        -- Re-placed WITH the live tooltip rects as obstacles, so the tag moves out from
+        -- under a tooltip the moment one opens and returns when it closes.
+        local taken = {}
+        local o1 = tipObstacle(GameTooltip, reg.scale)
+        if o1 then taken[#taken + 1] = o1 end
+        local o2 = tipObstacle(ownTip, reg.scale)
+        if o2 then taken[#taken + 1] = o2 end
+        place(reg.frame, reg.key, reg.color, reg.l, reg.r, reg.t, reg.b, reg.host, taken)
+
+        if inAlpha < 1 then
+            inAlpha = math.min(1, inAlpha + dt / FADE_IN)
+        end
+        local w = widgetFor(reg)
+        if w then setMarkAlpha(w, inAlpha) end
+    end)
+    return hoverDriver
+end
+
+local function eachTestFrame(fn)
+    for i = 0, 4 do
+        local f = DF.testPartyFrames and DF.testPartyFrames[i]
+        if f then fn(f) end
+    end
+    for i = 1, 40 do
+        local f = DF.testRaidFrames and DF.testRaidFrames[i]
+        if f then fn(f) end
+    end
+end
+
+-- One toggle drives both halves, asked per pool: party and raid keep separate test
+-- settings, so each pool answers for itself.
+local function poolWants(isRaid)
+    if isRaid then
+        if not (DF.raidTestMode and DF.testRaidFrames) then return false end
+        local db = DF.GetRaidDB and DF:GetRaidDB()
+        return (db and db.testShowLabels) and true or false
+    end
+    if not (DF.testMode and DF.testPartyFrames) then return false end
+    local db = DF.GetDB and DF:GetDB()
+    return (db and db.testShowLabels) and true or false
+end
+
+-- ☠ THE FIRST PASS AFTER A RELOAD MEASURES NOTHING, AND ONE TICK IS NOT ENOUGH.
+-- Test-mode ENTRY already knows this about itself -- DF:ShowTestFrames repaints on
+-- the next tick with the note "an anchor-derived rect is 0 for the whole creation
+-- tick ... which is why only the first entry per reload was broken and any toggle
+-- fixed it". The marks are a harder case of the same thing: a region is only
+-- measurable once its aura container has been built AND laid out, so on a fresh
+-- login the scan found no rects at all and left the registry empty. Nothing rebuilt
+-- it until a settings change came along -- hence "they don't show until you toggle
+-- Indicator Info off and on" (Krathe, 2026-08-17).
+-- ★ RETRY ON AN EMPTY RESULT rather than guessing a longer fixed delay: it converges
+-- as soon as the rects exist, whether that is the next frame or the tenth, and it
+-- cannot outlive the budget. Bounded at ~1.5s total.
+-- ⚠ A pool with every indicator switched off legitimately scans to zero, so it burns
+-- the full budget of (cheap, self-cancelling) timers before going quiet. Accepted:
+-- the alternative is distinguishing "nothing to show" from "not measurable yet",
+-- which is the very question the scan cannot answer while the rects are zero.
+local SETTLE_GAP, SETTLE_TRIES = 0.15, 10
+local settleGen, settleLeft = 0, 0
+
+local function scheduleSettle()
+    local gen = settleGen
+    C_Timer.After(SETTLE_GAP, function()
+        -- Superseded by a newer full pass: that one owns the budget now.
+        if gen ~= settleGen then return end
+        if not (poolWants(false) or poolWants(true)) then return end
+        TL:Update(true)
+    end)
+end
+
+-- `settling` marks a retry from scheduleSettle: it keeps the current budget and
+-- generation, where any other caller starts a fresh one.
+function TL:Update(settling)
+    ensureTooltipHook()
+    if not settling then
+        settleGen = settleGen + 1
+        settleLeft = SETTLE_TRIES
+    end
+    -- Hide first, then label the one frame per pool: a frame count reduced since the
+    -- last pass would otherwise strand its tags on a hidden frame.
+    eachTestFrame(hideWidgets)
+    -- Rebuilt every pass: the regions move whenever a setting does, and a stale rect
+    -- would highlight where an element used to be.
+    stopHover()
+    for i = #hoverRegions, 1, -1 do hoverRegions[i] = nil end
+    for k in pairs(regionOf) do regionOf[k] = nil end
+
+    if poolWants(false) then
+        for i = 0, 4 do scanFrame(DF.testPartyFrames[i]) end
+    end
+    if poolWants(true) then
+        for i = 1, 40 do scanFrame(DF.testRaidFrames[i]) end
+    end
+
+    if #hoverRegions > 0 then
+        settleLeft = 0
+        ensureHoverDriver():Show()
+    elseif settleLeft > 0 and (poolWants(false) or poolWants(true)) then
+        settleLeft = settleLeft - 1
+        scheduleSettle()
+    end
+end
+
+-- Teardown on test-mode exit. The widgets are pooled on the frames, so they only need
+-- hiding; the region registry is wiped too, or a pooled frame handed back to live
+-- rendering would keep appending "Buff Bar" to real spell tooltips. (The hook itself
+-- stays — it is a no-op outside test mode, and HookScript cannot be undone.)
+function TL:Clear()
+    -- Cancel any pending settle retry: test mode is going away, and a retry that
+    -- landed after teardown would re-scan pooled frames handed back to live rendering.
+    settleGen = settleGen + 1
+    settleLeft = 0
+    stopHover()
+    for i = #hoverRegions, 1, -1 do hoverRegions[i] = nil end
+    eachTestFrame(hideWidgets)
+    for k in pairs(regionOf) do regionOf[k] = nil end
+end
+
+function DF:UpdateTestLabels() TL:Update() end
+function DF:ClearTestLabels()  TL:Clear()  end

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -2167,6 +2167,18 @@ function DF:TeardownTestFrameVisuals()
     if DF.testRaidFrames then
         for i = 1, 40 do cleanFrame(DF.testRaidFrames[i]) end
     end
+    -- ☠ AND THE PINNED POOLS — the paragraph above is about them too and they were the one
+    -- set it never reached. Pinned test frames run the same AD preview, so their indicators
+    -- are parented to UIParent by the same mechanism and survive the frame being hidden.
+    -- The pools are per-set and sparse, so walk what exists rather than a fixed range.
+    if DF.PinnedFrames and DF.PinnedFrames.testFrames then
+        for setIndex = 1, (DF.PinnedFrames.MAX_SETS or 4) do
+            local pool = DF.PinnedFrames.testFrames[setIndex]
+            if pool then
+                for _, f in pairs(pool) do cleanFrame(f) end
+            end
+        end
+    end
 
     if DF.HideAllTestPetFrames then DF:HideAllTestPetFrames() end
     if DF.HideAllTestRaidPetFrames then DF:HideAllTestRaidPetFrames() end

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -2532,11 +2532,25 @@ function DF:UpdateRaidTestFrames()
         end
     end
     
+    -- ☠ PINNED TEST FRAMES FOLLOW RAID SETTINGS CHANGES TOO. This function is the
+    -- RAID arm of what DF:RefreshTestFrames does for party — every raid-side test
+    -- control lands here (the panel checkboxes, the Quick Presets, the sliders via
+    -- ThrottledUpdateRaidTestFrames, and DF:UpdateAll's raid branch) — and it was the
+    -- only one of the three refresh entry points that never touched the pinned pools.
+    -- So in RAID test mode a pinned set kept whatever it rendered at Test Mode entry:
+    -- unticking Show Auras / Missing Buff / Aura Designer emptied the raid grid and
+    -- left the pinned preview fully dressed. `true` because this pass applies layout
+    -- to each raid frame (ApplyTestFrameLayout above), so the pinned frames get the
+    -- same treatment their raid siblings just had. (Krathe, 2026-08-17.)
+    if DF.PinnedFrames and DF.PinnedFrames.RefreshTestMode then
+        DF.PinnedFrames:RefreshTestMode(true)
+    end
+
     -- Update group labels if enabled (only in group-based layout)
     if db.raidUseGroups and db.groupLabelEnabled and DF.UpdateRaidGroupLabels then
         DF:UpdateRaidGroupLabels()
     end
-    
+
     -- Handle animation
     if db.testAnimateHealth then
         DF:StartTestAnimation()
@@ -2546,6 +2560,12 @@ function DF:UpdateRaidTestFrames()
         if not (DF.testMode and partyDb.testAnimateHealth) then
             DF:StopTestAnimation()
         end
+    end
+
+    -- Indicator Info marks label the rows this pass just rebuilt, so they re-place
+    -- LAST and one tick later — same reason and same shape as DF:RefreshTestFrames.
+    if DF.UpdateTestLabels then
+        C_Timer.After(0, function() if DF.UpdateTestLabels then DF:UpdateTestLabels() end end)
     end
 end
 

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -1980,6 +1980,14 @@ function DF:RefreshTestFrames()
     if DF.PinnedFrames and DF.PinnedFrames.RefreshTestMode then
         DF.PinnedFrames:RefreshTestMode(false)
     end
+
+    -- Section labels re-place LAST and one tick later: they measure the rows they
+    -- label, and a row rebuilt during this pass has a zero rect until the layout
+    -- settles (the creation-tick rule that bit the bar toggles). A stale label is
+    -- worse than a late one — it points at where an element used to be.
+    if DF.UpdateTestLabels then
+        C_Timer.After(0, function() if DF.UpdateTestLabels then DF:UpdateTestLabels() end end)
+    end
 end
 
 -- Apply layout/style settings to a test frame (fonts, sizes, textures, borders, etc.)
@@ -2178,6 +2186,10 @@ function DF:HideTestFrames(silent)
         DF:StopTestAnimation()
     end
     
+    -- Labels first: their hit areas are mouse-enabled, and a pooled frame handed back
+    -- to live rendering with an invisible hit area over it eats hover on a real unit.
+    if DF.ClearTestLabels then DF:ClearTestLabels() end
+
     -- Hide all test party frames
     for i = 0, 4 do
         local frame = DF.testPartyFrames[i]
@@ -2405,6 +2417,10 @@ function DF:HideRaidTestFrames(silent)
         DF:StopTestAnimation()
     end
     
+    -- Labels first — see the party exit for why the hit areas must go before the
+    -- frames return to the pool.
+    if DF.ClearTestLabels then DF:ClearTestLabels() end
+
     -- Hide all test raid frames
     for i = 1, 40 do
         local frame = DF.testRaidFrames[i]
@@ -4301,6 +4317,16 @@ function DF:CreateTestPanel()
         end
     end)
 
+    -- Section labels: mark whichever element the cursor is over, on the FIRST preview
+    -- frame (they are identical, so labelling forty says nothing extra). Marking all
+    -- of them at once was unreadable at real frame sizes -- see Labels.lua.
+    -- Both OFF by default -- test mode is also how people pixel-tune spacing.
+    -- ONE toggle for both halves (highlight + naming): they are the same question
+    -- asked two ways, and a user who wants one always wants the other.
+    panel.showLabelsCheck = secGeneral:AddCheckbox(L["Indicator Info"], "testShowLabels", function()
+        if DF.UpdateTestLabels then DF:UpdateTestLabels() end
+    end)
+
     -- Frame count slider (below checkboxes)
     local fcRow = CreateFrame("Frame", nil, secGeneral.content)
     fcRow:SetHeight(28)
@@ -4792,6 +4818,13 @@ function DF:CreateTestPanel()
         self.showReducedMaxCheck:SetChecked(db.testShowReducedMaxHealth ~= false)
         if self.showTextDesignerCheck then
             self.showTextDesignerCheck:SetChecked(db.testShowTextDesigner ~= false)
+        end
+        -- ☠ EVERY CHECKBOX BELONGS IN THIS LIST. A toggle left out keeps the widget's
+        -- own default (unchecked) while the DB value stays true, so the feature runs
+        -- with its box showing off until the user clicks it twice -- exactly what was
+        -- reported for the section labels.
+        if self.showLabelsCheck then
+            self.showLabelsCheck:SetChecked(db.testShowLabels)
         end
         self.showAurasCheck:SetChecked(db.testShowAuras)
         self.showDispelGlowCheck:SetChecked(db.testShowDispelGlow)

--- a/DandersFrames_Options/TestMode/TestMode.lua
+++ b/DandersFrames_Options/TestMode/TestMode.lua
@@ -3079,6 +3079,12 @@ TEST_PRESETS.DEFAULT = {
     testShowTargetedList     = true,
     testAnimateTargetedList  = true,
     testShowPersonalTargeted = true,
+    -- ☠ Count-shaped, so this `true` is written as 1 (see TEST_COUNT_KEYS). Present because
+    -- Config.lua's testDefensiveCount now defaults to 1 and the two MUST mirror — and
+    -- because a preset that omits a key ZEROES it, so without this the three presets that
+    -- left it out re-zeroed the row on every click. That is how the defensive preview came
+    -- to look as though it never worked at all (Aphoex 6).
+    testDefensiveCount       = true,
 }
 
 -- Full = every toggle on. Built from the key list so a newly added toggle is

--- a/DandersFrames_Options/TextDesigner/UI/Options.lua
+++ b/DandersFrames_Options/TextDesigner/UI/Options.lua
@@ -2488,6 +2488,12 @@ function DF.BuildTextDesignerPage(GUI, page, db)
                 self.child:SetWidth(GUI.contentFrame:GetWidth() - 30)
             end
         end
+        -- Frame size and Preview Scale are settings like any other, so the mock
+        -- re-derives here rather than waiting for a page rebuild — the same hook
+        -- AuraDesigner_RefreshPage gives the Aura Designer's preview.
+        if state.previewPanel and state.previewPanel.RefreshGeometry then
+            state.previewPanel.RefreshGeometry()
+        end
     end
 
     -- Detect mode change OR auto-layout switch: tear down every cached widget so
@@ -2761,6 +2767,10 @@ function DF.BuildTextDesignerPage(GUI, page, db)
         healthFill:SetWidth(FRAME_W * 0.72)
         healthFill:SetTexture(healthTexPath)
         healthFill:SetVertexColor(0.18, 0.80, 0.44, 0.85)
+        -- Stashed for RefreshGeometry: both fills are sized in ABSOLUTE pixels off the
+        -- frame width read at build, so a live resize has to re-derive them or the bar
+        -- keeps the old frame's proportions inside the new outline.
+        previewPanel.healthFill = healthFill
 
         -- Missing health region
         local missingHealth = mockFrame:CreateTexture(nil, "ARTWORK")
@@ -2772,6 +2782,7 @@ function DF.BuildTextDesignerPage(GUI, page, db)
         end
         missingHealth:SetWidth(FRAME_W * 0.28)
         missingHealth:SetColorTexture(0, 0, 0, 0.4)
+        previewPanel.missingHealth = missingHealth
 
         -- Power bar (only if enabled in current frame settings)
         if showPower then
@@ -2797,15 +2808,57 @@ function DF.BuildTextDesignerPage(GUI, page, db)
         -- Anchor dots disabled until drag-to-place is implemented (Phase 2).
     end
 
+    -- Live geometry — the twin of AuraDesigner/UI/Cards.lua's container.RefreshGeometry,
+    -- and it is here for the same two reasons that fix names.
+    --   * Frame width/height and Preview Scale were read ONCE, at build, so the preview
+    --     only caught up when something else forced a full page rebuild — resizing the
+    --     window, or leaving the settings and coming back (Aphoex, 2026-08-17, reporting
+    --     it as the twin of the Aura Designer one).
+    --   * ☠ CLAMP BOTH AXES. The panel is anchored on all four sides and the mock is
+    --     centred inside at the configured size times the user's scale, with nothing
+    --     bounding it — so a tall frame or a high Preview Scale spilled the mock out
+    --     through the panel edge. Fitting to the smaller of the two ratios keeps the
+    --     preview honest about proportions: it shrinks, it does not letterbox.
+    -- ⚠ The two fills are re-derived as well. AD's version does not need to (its own
+    -- resize path rebuilds), but here they are absolute pixel widths taken from the
+    -- build-time frame width, so sizing the mock without them would leave a 72% bar
+    -- reading as some other fraction of the new outline.
+    previewPanel.RefreshGeometry = function()
+        local m = state.mockFrame
+        if not m then return end
+        local fdb = (DF.GetDB and DF:GetDB((GUI and GUI.SelectedMode) or "party")) or DF.PartyDefaults or {}
+        local w = fdb.frameWidth or 125
+        local h = fdb.frameHeight or 64
+        m:SetSize(w, h)
+        if previewPanel.healthFill then previewPanel.healthFill:SetWidth(w * 0.72) end
+        if previewPanel.missingHealth then previewPanel.missingHealth:SetWidth(w * 0.28) end
+
+        local want = tdDB.previewScale or 1.0
+        -- Before the first layout pass the panel has no size yet; honour the user's
+        -- scale rather than clamping against a zero and collapsing the mock.
+        local cw, ch = previewPanel:GetWidth() or 0, previewPanel:GetHeight() or 0
+        if cw < 2 or ch < 2 then
+            m:SetScale(want)
+            return
+        end
+        -- 16 = the panel's own left/right padding; 28 = that plus the "FRAME PREVIEW"
+        -- label strip along the top. Same constants as the Aura Designer's.
+        local fit = math.min((cw - 16) / w, (ch - 28) / h)
+        m:SetScale(math.max(0.2, math.min(want, fit)))
+    end
+    previewPanel.RefreshGeometry()
+
     -- Preview Scale slider (top-left of preview panel, below the FRAME PREVIEW
     -- label). Mirrors AuraDesigner/Options.lua:3872-3885 — release callback +
     -- lightweight per-tick callback so the mockFrame scales live during drag.
+    -- ⚠ BOTH callbacks go through RefreshGeometry, never SetScale directly — a raw
+    -- SetScale is exactly what let the mock climb out of its box.
     local scaleSlider = GUI:CreateSlider(previewPanel, L["Preview Scale"], 0.75, 2.5, 0.05, tdDB, "previewScale",
         function()
-            if state.mockFrame then state.mockFrame:SetScale(tdDB.previewScale or 1.0) end
+            if previewPanel.RefreshGeometry then previewPanel.RefreshGeometry() end
         end,
         function()
-            if state.mockFrame then state.mockFrame:SetScale(tdDB.previewScale or 1.0) end
+            if previewPanel.RefreshGeometry then previewPanel.RefreshGeometry() end
         end
     )
     scaleSlider:SetPoint("TOPLEFT", previewLabel, "BOTTOMLEFT", -4, -4)


### PR DESCRIPTION
Field reports from testing `v5.2.0-alpha.2`, plus a pinned-frame audit that came out of two of them. Based on `v5.3.0-alpha.1`.

One reported item — the absorb texture preview showing the wrong texture after a reload — is **not** here: it was already fixed in `v5.2.0`.

## Pinned frames were left behind by the 12.1 rework

Two field reports landed on pinned frames in two days, so the surface got an audit. The pattern behind most of it: **`DF:IterateAllFrames` is arena *or* party+raid and has no pinned arm**, and the walker that does cover pinned (`DF.IteratePinnedFrames`) only ever walked player-set header children — never boss sets. Six sweeps had each rolled their own header-only loop.

* **No auras on friendly NPC boss frames.** The identity gate's `IdentityUnavailable` probe read `UnitIsConnected == false` as "offline". An NPC has no connection, so that is false for every NPC: the handle went untrusted, every gated group parked at `maxFrameCount 0`, and `_noteGateRecovery` only re-parses on a false→true *assist* edge that an NPC never produces — so the row was dark from build for the container's whole life. This is the **seventh** consumer of `UnitIsConnected` in the addon and was the only one without the players-only guard; one of the other six names this exact unit class in its comment. Scoped to the connected probe only (`UnitIsDeadOrGhost` is meaningful for an NPC), fail-open on a refused or secret read.
* **Every `<icon>HideInCombat` gate was one-way on pinned frames.** Combat entry hid the icon; the exit sweeps could not see the frame, so it stayed hidden until something unrelated repainted it. All three transition sweeps now walk pinned, and `RefreshLiveFrames` with them.
* **Pinned test frames survived combat.** `ExitTestMode` returned outright under lockdown, so the fake frames sat over the live UI for the whole fight. Only `headers[i]:Show()` genuinely needs deferring; the preview is plain non-secure frames and is hidden immediately now. `TeardownTestFrameVisuals` gained the pinned pools it never walked — its own header asks callers not to hand-copy a subset, so `ExitTestMode` calls it.
* **Boss sets reached from six more sweeps** — highlights (a targeted boss NPC never got its selection highlight), element appearance, the header-child refresh block, the Aura Designer force-refresh, and raid-target markers. Two extras fell out: a `IsInRaid() and 40 or 5` cap that left a party-mode pinned set of more than five units partly unhighlighted, and the defensive / missing-buff / dispel bulk updaters, which had no pinned arm at all.
* Pinned **test** frames were never stamped `isPinnedFrame`, so two live guards that branch on it took their non-pinned arm — including one whose own note describes the bug it was written to fix.
* Dropped `dfPinnedHideAuras`: written on four sites, read nowhere, and it reads exactly like the Hide Auras implementation, so the next person to fix that feature would have edited it and changed nothing.

## Aura row geometry, and the debuff preview

Three defects with one root cause: geometry computed from the plain cell size while an important debuff renders at `debuffImportantScale`.

* **The flow's line cap** was built from `sx` alone, so a row holding one styled icon overran it against half an icon of rounding slack and wrapped a whole icon early — Icons Per Row 3 laying out 2+1. `flowLineSlack` now folds the widest styled cell's overhang in, and is shared by the live path and the `FlowSlots` entry point the Aura Designer canvas measures through. **Clamped strictly under one whole extra cell**, because widening a cap can otherwise let a row of *plain* icons fit one more than asked for.
* **"Every record styled" was matching by accident.** That test identifies a layout group, where each member has its own look — but `bossrole` and `priority` are the only styled debuff records and they share one `importantStyle` table. Ticking Priority with Boss and/or Role and nothing else put the enlarged badged treatment on every slot instead of one against a plain neighbour. Now also requires the styles to differ, by identity.
* **Test-mode hover zones** were a uniform grid of base-size cells, so a styled slot got a zone of the wrong size and displaced every zone after it in its row — the aura tooltip not following Size Step.
* The debuff **Icons Per Row** slider gained the vertical-growth guard its buff and defensive siblings already carry; both layout paths ignore the wrap count under vertical growth, so it sat there live-looking and inert.

## Resource bar

* **The bar vanished while dragging Offset X/Y.** Both "lightweight" drag callbacks were forks of `DF:LayoutResourceBar`. With Match Health Bar Width/Height on — the default — the real layout sizes the matched axis by two anchor points and never calls `SetWidth`, so the bar has no explicit width at all; the fork's single `SetPoint` collapsed it to zero. The other fork never read the orientation, so on a vertical bar the two size sliders drove the wrong dimensions. Both now call the live function.
* **Border Thickness padded the bar.** Matching inset by `max(framePadding, frameBorderSize)` while the health bar it matches insets by `framePadding` alone, so past that threshold every extra border pixel shortened the bar by two. The `max()` guards a field-confirmed hairline that is only visible through a translucent border, so it now applies only then — the rule `DF:GetAbsorbEdgeInset` already used.
* **"Only 3 of 9 anchors work."** Correct, and inherent: matching pins the bar by its ends, so the dropdown's left/right half stops applying. The dropdown keeps all nine because every one is live the moment Match is off; the tooltip now says what Match actually does, and drops its orientation-blind claim about "the Width slider".

## Aura Designer enabling itself on a Party/Raid tab switch

No code enables it on a tab switch — there are exactly two writes to that flag in the addon and both are the checkbox's own `OnClick`. Both modes were resolving to **the same config table**: a fallback pointed party and raid at the one `Default` preset when neither named preset was in the library, and persisted it. Once welded they are not linked, they are one table, so enabling on Party reads back enabled on Raid with nothing to find by grepping for a write. Each mode's preset is now materialised from Default instead, and a ref naming a preset the library no longer holds is repaired the same way.

## Two judgement calls worth a look

* **`testDefensiveCount` now defaults to 1** and is listed in the Default quick preset. It shipped at 0, inherited from the checkbox it replaced — but a *count* of 0 is indistinguishable from a broken feature, and three of the five presets re-zeroed it on click, which is why the report was "Defensive Icons don't show up in test mode — ever". This is a default change rather than a fix and reverses cleanly: set it back to 0 and drop the key from `TEST_PRESETS.DEFAULT`.
* **Anchor dropdown** — made honest rather than made to work, per above. Filtering it to the three meaningful entries while Match is on is the alternative if that reads better.

## Also here

* **Indicator Info** — an opt-in test-mode toggle that names what each preview element is. Hover any element on any test unit for a backing plate, corner brackets and a colour-keyed tag, plus a tooltip naming it and the settings page that owns it. It measures through `AuraContainer.FlowSlots` rather than reading rects, because the container's own rect is secret and the row's anchor frame has none; and it asks whether an element is shown at hover time, from rendered state, so a toggle takes effect immediately.
* **Text Designer Frame Preview** now follows frame size and Preview Scale live and stays inside its panel — the twin of the Aura Designer preview fix.
* **Colour picker**: with "Use DF Color Picker for All Addons" on, editing a colour in another addon and then one in DF changed both. Blizzard's `SetupColorPickerAndShow` is the only writer of the frame's `swatchFunc`/`opacityFunc`/`cancelFunc` and nothing clears them on hide, while `OnColorSelect` fires on every `SetColorRGB` — so our direct mode, which deliberately skips Setup but still writes colours into the frame, was driving whichever addon last used the picker.
* **Macro import** read `MAX_ACCOUNT_MACROS` as a bare global; it moved into `Constants.MacroConsts`.

## Verification notes

None of this is verified in game yet. The ones I would look at first:

* Enter combat with a pinned preview up — the fake pinned frames should go immediately, not at combat end.
* A pinned boss set on a friendly healable NPC should show auras with Hide Auras unchecked (`/df debug idgate` should read `parked=false` on those handles).
* Drag the resource bar's Offset X with Match on — the bar should stay visible; and on a vertical bar the two size sliders should drive the axes they name.
* Debuff bar with Priority + Boss/Role ticked and nothing else, Debuffs ≥ 2: one enlarged icon against plain neighbours, and Icons Per Row honoured.
* Party/Raid tab switch with the Aura Designer off on one of them.
