### PR TITLE
Dispel overlay: never white, not even once — the unbound carrier and the retry gate that could never fire

### DIFF
--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -7139,8 +7139,16 @@ DF._MainEventDispatcher = function(self, event, arg1)
                     if ok then return a, b end
                     return nil
                 end
+                -- ☠ AN ABSENT OBJECT PRINTS "ABSENT". IT DOES NOT PRINT NOTHING.
+                -- Both helpers used to `return` on nil, so a missing region rendered as
+                -- SILENCE -- indistinguishable from a region this style never builds, and
+                -- from a line the reader skimmed past. That cost a diagnosis: five frames
+                -- whose gradient carrier did not exist produced a dump whose every printed
+                -- field looked healthy, because the one that mattered was not printed at
+                -- all (2026-08-20). This dump's whole subject is whether the art exists,
+                -- so absence is the most important thing it can report.
                 local function dumpBar(tag, bar, hostFrame)
-                    if not bar then return end
+                    if not bar then o:Line(("%s: ABSENT"):format(tag), "bad") return end
                     local mn, mx, val, w, h, pw, lvl, blend, alpha, shown, orient, rev
                     pcall(function() mn, mx = bar:GetMinMaxValues() end)
                     pcall(function() val = bar:GetValue() end)
@@ -7160,7 +7168,7 @@ DF._MainEventDispatcher = function(self, event, arg1)
                         num(orient), num(rev), num(blend), num(alpha), num(shown), num(lvl)))
                 end
                 local function dumpTex(tag, tex)
-                    if not tex then return end
+                    if not tex then o:Line(("%s: ABSENT"):format(tag), "bad") return end
                     local w, h, blend, alpha, shown, layer, sub
                     pcall(function() w, h = tex:GetSize() end)
                     pcall(function() blend = tex:GetBlendMode() end)
@@ -7220,10 +7228,36 @@ DF._MainEventDispatcher = function(self, event, arg1)
                             -- and every widget/texture method call rides one pcall that
                             -- degrades to a FORBIDDEN line instead of killing the dump at
                             -- the exact moment it is most needed.
+                            -- ☠ bind= READS THE BUTTON'S OWN STAMP, NOT THE GLOBAL.
+                            -- DF._dispelBindErr is keyed by slot key alone, so every
+                            -- frame's "main" overwrites every other frame's; printing it
+                            -- here reported one frame's success against another frame's
+                            -- button, and five carrier-less frames all read "ok x3".
+                            -- carriers= now separates "never stamped" from "stamped
+                            -- empty" -- BindDispelCarriers only stamps when it has one,
+                            -- so nil is the signal that the secure init did not finish.
+                            local nCar = btn._dfDispelCarriers and #btn._dfDispelCarriers
                             o:Line(("slot[%s] styleErr=%s bind=%s carriers=%s"):format(
                                 tostring(key), tostring(btn._dfDispelStyleErr),
-                                tostring(DF._dispelBindErr and DF._dispelBindErr[key]),
-                                tostring(btn._dfDispelCarriers and #btn._dfDispelCarriers)))
+                                tostring(btn._dfDispelBindRes or "never recorded"),
+                                nCar and tostring(nCar) or "NONE (init did not finish)"),
+                                nCar and "neutral" or "bad")
+                            -- Declared vs built, on one line. The roles table says what
+                            -- this slot is supposed to own; anything declared without a
+                            -- carrier behind it is the fault, stated rather than implied.
+                            local dRoles = btn._dfDispelRoles
+                            if dRoles then
+                                local want = {}
+                                if dRoles.gradient then want[#want + 1] = "gradient=" .. tostring(dRoles.gradient) end
+                                if dRoles.border then want[#want + 1] = "border" end
+                                if dRoles.edges then want[#want + 1] = "edges" end
+                                if dRoles.badge then want[#want + 1] = "badge" end
+                                o:Line(("slot[%s] declares: %s"):format(tostring(key),
+                                    #want > 0 and table.concat(want, " ") or "(nothing)"))
+                            else
+                                o:Line(("slot[%s] declares: NOTHING RECORDED — secure init never reached its roles stamp"):format(
+                                    tostring(key)), "bad")
+                            end
                             local okSlot = true
                             do
                                 local wdg = btn.dfDispelWidget
@@ -7240,19 +7274,28 @@ DF._MainEventDispatcher = function(self, event, arg1)
                                     dumpBar("slot.gradient", wdg.gradient, frame)
                                     dumpTex("slot.nativeGradient", wdg.nativeGradient)
                                     local ng = wdg.nativeGradient
-                                    if ng then
-                                        -- ★ THE LINE THIS WHOLE DUMP EXISTS FOR. rel= says
-                                        -- whether the style pass ever re-anchored the
-                                        -- carrier ("btn" = still on the secure init's
-                                        -- SetAllPoints, i.e. it never ran). Every read here
-                                        -- is individually guarded so a refusal costs one
-                                        -- FIELD, never this line.
-                                        local nPts = tryv(ng.GetNumPoints, ng)
-                                        local _, relTo = tryv(ng.GetPoint, ng, 1)
+                                    -- ★ THE LINE THIS WHOLE DUMP EXISTS FOR, AND IT NOW
+                                    -- PRINTS EVEN WHEN THE CARRIER IS GONE. It used to sit
+                                    -- inside `if ng then`, so the one state it most needed
+                                    -- to report -- no carrier at all -- was the one state
+                                    -- that silently skipped it (2026-08-20). rel= says
+                                    -- whether the style pass ever re-anchored the carrier
+                                    -- ("btn" = still on the secure init's SetAllPoints, i.e.
+                                    -- it never ran). The DIM HOSTS are plain DF frames whose
+                                    -- alpha is always readable, and they are worth printing
+                                    -- whether or not the carrier survived -- a live dim host
+                                    -- with no carrier localises the failure to the texture
+                                    -- create, one line below the frame create. Every read is
+                                    -- individually guarded so a refusal costs one FIELD.
+                                    do
+                                        local nPts = ng and tryv(ng.GetNumPoints, ng)
+                                        local _, relTo
+                                        if ng then _, relTo = tryv(ng.GetPoint, ng, 1) end
                                         local healthFill = frame.healthBar
                                             and tryv(frame.healthBar.GetStatusBarTexture, frame.healthBar)
                                         local relName = "?"
-                                        if relTo == btn then relName = "btn"
+                                        if not ng then relName = "NO CARRIER"
+                                        elseif relTo == btn then relName = "btn"
                                         elseif relTo == wdg.gradient then relName = "gradRect"
                                         elseif healthFill and relTo == healthFill then relName = "healthFill"
                                         elseif relTo == wdg then relName = "widget"
@@ -7269,21 +7312,32 @@ DF._MainEventDispatcher = function(self, event, arg1)
                                             and tryv(btn.dfDispelBadgeDim.GetAlpha, btn.dfDispelBadgeDim)
                                         o:Line(("slot[%s] carrier points=%s rel=%s gradDim=%s ringDim=%s badgeDim=%s"):format(
                                             tostring(key), tostring(nPts), relName,
-                                            num(dimA), num(ringA), num(badgeA)))
+                                            num(dimA), num(ringA), num(badgeA)),
+                                            ng and "neutral" or "bad")
                                     end
                                 end
-                                if btn.dfDispelRing then dumpTex("slot[" .. tostring(key) .. "].ring", btn.dfDispelRing) end
+                                -- ⚠ Dumped only when the slot DECLARED them, but then
+                                -- dumped unconditionally so a declared-and-missing one
+                                -- prints ABSENT. Gating on the object itself (the old
+                                -- `if btn.dfDispelRing then`) hid exactly the case worth
+                                -- seeing; gating on the declaration keeps a style that
+                                -- legitimately builds no ring from printing a false alarm.
+                                local dR = btn._dfDispelRoles
+                                if not dR or dR.border then
+                                    dumpTex("slot[" .. tostring(key) .. "].ring", btn.dfDispelRing)
+                                end
                                 -- Edge strips are keyed BY SIDE now (all four ride the one
                                 -- overlay slot since the carriers were consolidated).
-                                if type(btn.dfDispelEdgeTex) == "table" then
+                                if not dR or dR.edges then
+                                    local et = btn.dfDispelEdgeTex
                                     for _, side in ipairs({ "TOP", "BOTTOM", "LEFT", "RIGHT" }) do
-                                        local et = btn.dfDispelEdgeTex[side]
-                                        if et then dumpTex("slot[" .. tostring(key) .. "].edge" .. side, et) end
+                                        dumpTex("slot[" .. tostring(key) .. "].edge" .. side,
+                                            type(et) == "table" and et[side] or nil)
                                     end
                                 end
                             end
                             if not okSlot then
-                                o:Line(("slot[%s] widget reads REFUSED (auras secret) — the fields above are still valid; rel=/alpha need an out-of-combat run"):format(
+                                o:Line(("slot[%s] widget reads REFUSED (auras secret) — every DF-owned field above is still valid, including bind=, carriers=, declares= and rel=NO CARRIER; only values read OFF the slot widgets degrade, and those need an out-of-combat run"):format(
                                     tostring(key)), "neutral")
                             end
                         end

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -7245,6 +7245,15 @@ DF._MainEventDispatcher = function(self, event, arg1)
                             -- Declared vs built, on one line. The roles table says what
                             -- this slot is supposed to own; anything declared without a
                             -- carrier behind it is the fault, stated rather than implied.
+                            -- ★ THE BIRTH-TIME REFUSAL, NAMED. Slot init runs inside the
+                            -- container's pcall, so its error never reaches the user;
+                            -- Dispel's onInit stamps it here. This prints even on a client
+                            -- that had the DISPEL log category switched off when it
+                            -- happened, which is exactly the case that cost a diagnosis.
+                            if btn._dfDispelInitErr then
+                                o:Line(("slot[%s] INIT REFUSED AT BIRTH: %s"):format(
+                                    tostring(key), tostring(btn._dfDispelInitErr)), "bad")
+                            end
                             local dRoles = btn._dfDispelRoles
                             if dRoles then
                                 local want = {}

--- a/DandersFrames/Core/Profile.lua
+++ b/DandersFrames/Core/Profile.lua
@@ -443,6 +443,15 @@ function DF:SetProfile(name)
         DF:MigrateRaidCenterMode()
     end
 
+    -- ☠ The dispel palette is a PROCESS-LIFETIME cache, so it does not follow DF.db.
+    -- DF.debuffBorderCurve and DF.dispelColorMap are built once and reused; without this
+    -- the new profile renders the OLD profile's dispel colours, and because the generation
+    -- never moves, no carrier is ever re-bound to correct it -- wrong colours until a
+    -- reload. Worse when the incoming profile's dispelColors is partial or absent: the
+    -- curve rebuilds from a different source than the one the map was cached from, so the
+    -- two disagree. Must run BEFORE the refresh so the rebuild reads the new profile.
+    if DF.InvalidateDispelColorCurve then DF:InvalidateDispelColorCurve() end
+
     -- Apply the profile — runtime state is already clear so the proxy reads
     -- the new profile directly with no stale overlay
     DF:FullProfileRefresh()
@@ -1619,12 +1628,20 @@ function DF:ApplyImportedProfile(importData, selectedCategories, selectedFrameTy
     -- payload) rather than DF.db, so it is unaffected by the category merge dropping the
     -- legacy keys, and it must stay AHEAD of RunV5LegacyMigrations.
     local function importDispelColors()
+        local wrote = false
         if importData.dispelColors then
             DF.db.dispelColors = importData.dispelColors
+            wrote = true
         elseif DF.BuildDispelColorsFromLegacy then
             local legacy = DF:BuildDispelColorsFromLegacy(importData.party, importData.raid)
-            if legacy then DF.db.dispelColors = legacy end
+            if legacy then DF.db.dispelColors = legacy wrote = true end
         end
+        -- ☠ Same process-lifetime cache as the profile switch: writing dispelColors does
+        -- not invalidate the built curve or map, so an imported palette would not reach
+        -- any live carrier and the generation would never move to force a re-bind.
+        -- An imported table is also only shape-checked, never key-checked, so it can be
+        -- partial -- which is exactly the input the curve's per-key fallback exists for.
+        if wrote and DF.InvalidateDispelColorCurve then DF:InvalidateDispelColorCurve() end
     end
 
     -- If it's a full export (legacy or "all categories"), use direct replacement

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1965,6 +1965,29 @@ end
 -- carrier pins to its rect). EDGE rides four dedicated strip slots
 -- (StyleGameEdgeSlot); the border rides its OWN slot (StyleGameBorderSlot) —
 -- one bindable region per slot.
+-- ☠☠ IS THIS SLOT'S BIND CURRENTLY CONFIRMED? The born-dark contract had three alpha
+-- writers and only one of them asked: RevealDispelCarriers runs on the bind's success
+-- branch, but the four stylers below raised their dim hosts on region EXISTENCE alone.
+-- The chain that slipped through review (found in the 2026-08-21 PR pass): a combat-born
+-- slot whose bind failed stays dark -- the fix working -- then out of combat the recovery
+-- re-init runs, the bind fails AGAIN (any deterministic AddDispelTypeTexture refusal),
+-- artOK is still true on that first pass because the stale latch only trips on the
+-- SECOND consecutive failure, StyleOneSlot runs, and the stylers revealed every unbound
+-- white texture at the configured opacity. One narrow door, but it was the last one.
+--
+-- _dfDispelCurveGen is the exact signal: stamped ONLY after a successful
+-- AddDispelTypeTexture pass, cleared by ResetSlotArt with the art it describes, and
+-- compared against the live generation -- so "equal" means "the carriers this styler is
+-- about to reveal are the ones the engine currently owns". A stale-but-once-bound slot
+-- reads unequal, and StyleOneSlot's re-bind runs BEFORE the stylers, so a successful
+-- re-bind still reveals on the same pass with no extra latency.
+-- ⚠ The stylers now assert `or 0` on the failure side rather than skipping the write:
+-- a slot that WAS revealed and then failed a palette re-bind must go back to dark, not
+-- keep last pass's alpha on carriers the engine may no longer colour.
+local function SlotBindConfirmed(btn)
+    return btn._dfDispelCurveGen ~= nil and btn._dfDispelCurveGen == DF.dispelCurveGen
+end
+
 local function StyleGameMainSlot(btn, frame, db)
     local w = EnsureSlotWidget(btn, frame)   -- created in DispelSlotSecureInit (secure)
 
@@ -2018,7 +2041,8 @@ local function StyleGameMainSlot(btn, frame, db)
             -- 2026-08-13) — the alpha channel is the engine's once bound. The dim host
             -- is a plain DF frame, so this write is ours at any time, combat included.
             if w.nativeGradientDim then
-                w.nativeGradientDim:SetAlpha(showGradient and ResolveGradientAlpha(db) or 0)
+                w.nativeGradientDim:SetAlpha((showGradient and SlotBindConfirmed(btn))
+                    and ResolveGradientAlpha(db) or 0)
             end
             -- Normalise the carrier's own alpha where the write still lands (older
             -- builds left 0.3 here; a client where region writes work would otherwise
@@ -2071,7 +2095,9 @@ local function StyleGameBadge(btn, frame, db)
     badge:SetPoint(pos, btn.dfDispelBadgeHolder, pos, db.dispelIconOffsetX or 0, db.dispelIconOffsetY or 0)
     badge:SetSize(size, size)
     -- Opacity on the dim host; bound texture normalised (dim-host rule, StyleGameMainSlot).
-    if btn.dfDispelBadgeDim then btn.dfDispelBadgeDim:SetAlpha(db.dispelIconAlpha or 1) end
+    if btn.dfDispelBadgeDim then
+        btn.dfDispelBadgeDim:SetAlpha(SlotBindConfirmed(btn) and (db.dispelIconAlpha or 1) or 0)
+    end
     pcall(badge.SetAlpha, badge, 1)
     -- The badge holder re-levels above (contentOverlay band); the DIM must follow or the
     -- art — the dim's region — stays at the stale level. Same rule as ring and edges.
@@ -2098,7 +2124,9 @@ local function StyleGameBorderSlot(btn, frame, db)
     -- layout-version bumps, so a resize catches up on the next dispel pass.
     ApplyDispelRingGeometry(ring, btn, db, frame:GetWidth(), frame:GetHeight())
     -- Opacity on the dim host; bound texture normalised (dim-host rule, StyleGameMainSlot).
-    if btn.dfDispelRingDim then btn.dfDispelRingDim:SetAlpha(db.dispelBorderAlpha or 0.8) end
+    if btn.dfDispelRingDim then
+        btn.dfDispelRingDim:SetAlpha(SlotBindConfirmed(btn) and (db.dispelBorderAlpha or 0.8) or 0)
+    end
     pcall(ring.SetAlpha, ring, 1)
     ring:SetBlendMode("BLEND")
     -- ☠ RE-LEVEL EVERY PASS — the init's value goes stale when the Frame Level slider
@@ -2159,7 +2187,7 @@ local function StyleGameEdgeSlot(btn, frame, db, edge)
     -- StyleGameMainSlot). ☠ tex:SetAlpha here LOOKED like it worked for the strip
     -- styles — that was the pre-bind default surviving, not the write landing.
     local dim = btn.dfDispelEdgeDim and btn.dfDispelEdgeDim[edge]
-    if dim then dim:SetAlpha(ResolveGradientAlpha(db)) end
+    if dim then dim:SetAlpha(SlotBindConfirmed(btn) and ResolveGradientAlpha(db) or 0) end
     pcall(tex.SetAlpha, tex, 1)
     -- ☠ RE-LEVEL EVERY PASS — the init's edgeLvl goes stale when the Frame Level
     -- slider moves the band. Holder AND dim: the strip is the dim's region, so the

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1928,6 +1928,32 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
 
     -- ONE bind pass for every carrier (clear-once-then-append; see BindDispelCarriers).
     BindDispelCarriers(btn, carriers, db, key)
+
+    -- ★ THE LIFECYCLE LINE, AND WHY IT HAS TO EXIST. Every other DISPEL log call in this
+    -- file is a DebugWarn or DebugError on a failure path, and every one of them is a
+    -- session one-shot -- so a healthy client logged NOTHING, and a client where this
+    -- function never ran at all also logged nothing. Those two states were
+    -- indistinguishable from the log, which is the one thing a log has to do.
+    --
+    -- ☠ THAT MATTERS MORE SINCE THE OVERLAY STARTED FAILING DARK. Trading a white frame
+    -- for an invisible one is only honest if something still says so; otherwise a
+    -- completely dead overlay ships silently and nobody can tell. This line is that
+    -- something: one entry per slot birth naming the unit, what the slot declared, how
+    -- many carriers were built and what the bind returned. Healthy looks like
+    -- "carriers=3 result=ok x3"; every failure mode reads differently at a glance.
+    --
+    -- Guarded on DebugActive because the roles summary allocates -- the documented
+    -- pattern for a log whose ARGUMENTS cost something (see DF:DebugActive).
+    if DF.DebugActive and DF:DebugActive("DISPEL") then
+        local want = {}
+        if roles.gradient then want[#want + 1] = "gradient=" .. tostring(roles.gradient) end
+        if roles.border then want[#want + 1] = "border" end
+        if roles.edges then want[#want + 1] = "edges" end
+        if roles.badge then want[#want + 1] = "badge" end
+        DF:Debug("DISPEL", "slot %s unit=%s declares=[%s] carriers=%d result=%s",
+            tostring(key), tostring(frame and frame.unit),
+            table.concat(want, " "), #carriers, tostring(btn._dfDispelBindRes))
+    end
 end
 
 -- GAME-COLOUR mode, main slot. The ONE natively-tintable region per slot (source-
@@ -2300,6 +2326,14 @@ local function StyleDispelSlots(frame, db, h, slots)
                         tostring(frame.unit))
                 end
             else
+                -- ★ SAY THAT THE RECOVERY FIRED, not only that it failed. A rebuild is
+                -- the single most interesting thing this subsystem does -- it means a slot
+                -- was found broken and is being repaired -- and until now it produced no
+                -- entry at all unless the repair itself threw. A user reporting "it went
+                -- white once and came back" had nothing in the log to show for it.
+                DF:Debug("DISPEL", "slot %s on %s found %s - rebuilding",
+                    tostring(info.key), tostring(frame.unit),
+                    unreachable and "forbidden" or "without carriers")
                 btn._dfDispelArtStale = true
                 ResetSlotArt(btn)
                 -- pcall'd for the SAME reason as the style pass below (bug #1011):

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -2126,14 +2126,51 @@ local function StyleDispelSlots(frame, db, h, slots)
         -- error spam for a rebuild spam. The latch clears the moment a probe passes, so
         -- a later reclaim is still recoverable.
         local artOK = true
-        if btn and btn.dfDispelWidget and not pcall(ProbeSlotArt, btn.dfDispelWidget) then
+        -- ☠ TWO WAYS A SLOT CAN NEED REBUILDING, AND ONLY ONE OF THEM WAS TESTED.
+        -- ProbeSlotArt asks "is the art REACHABLE" -- a liveness test. The second failure
+        -- is COMPLETENESS: DispelSlotSecureInit ran, was refused partway, and left a slot
+        -- whose art is perfectly reachable and whose carriers do not exist. The probe
+        -- passes on such a slot, so the recovery below could never see it.
+        --
+        -- HOW IT HAPPENS: the client creates these buttons lazily on the first dispellable
+        -- debuff, i.e. MID-COMBAT, so onInit runs while auras are secret and the button
+        -- subtree carries DenyTaintedAccessWhenAurasAreSecret. Creating the gradient's dim
+        -- host is a child materialization on a denied subtree and is refused exactly like a
+        -- setter. Handle:_makeInitializeFrame pcalls onInit, so the refusal is SWALLOWED --
+        -- no error, no log, and a half-built slot with nothing recording that it is half
+        -- built. BindDispelCarriers only stamps btn._dfDispelCarriers when it has at least
+        -- one carrier, so its absence IS the completeness signal.
+        --
+        -- WHY IT NEVER HEALED: out of combat the art probes fine, so the branch below was
+        -- skipped and _dfDispelArtStale cleared; StyleOneSlot then succeeded (it only
+        -- DRESSES carriers, it never creates them) and the caller latched
+        -- dfDispelFactoryVersion / dfDispelStyledGen, after which the fast path in
+        -- DriveDispelOverlayFactory returns before reaching here at all. The overlay stayed
+        -- dead until a reload, and every field a dump could read looked healthy --
+        -- styleErr=nil, style latched, widget present. Field-reported as whole frames
+        -- washing white in a key (Krathe, 2026-08-20): with no DF carrier the engine's own
+        -- dispel texture renders at its white base coat, unopposed.
+        --
+        -- next(info.roles) guards the all-disabled config (EDGE style with gradient, border
+        -- and badge all off) -- roles is then an empty table, no carrier is meant to exist,
+        -- and testing for one would rebuild on every pass.
+        local incomplete = btn and info.roles and next(info.roles) ~= nil
+            and btn._dfDispelCarriers == nil
+        local unreachable = btn and btn.dfDispelWidget
+            and not pcall(ProbeSlotArt, btn.dfDispelWidget)
+        if btn and (unreachable or incomplete) then
             if btn._dfDispelArtStale then
                 artOK = false
                 if not frame.dfDispelArtForbiddenLogged then
                     frame.dfDispelArtForbiddenLogged = true
+                    -- Name WHICH test tripped: "forbidden" and "carriers never built"
+                    -- are different faults with different causes, and a message that
+                    -- asserts the wrong one sends the next reader after the wrong thing.
                     DF:DebugWarn("AURACONTAINER",
-                        "StyleDispelSlots: slot art still forbidden after a rebuild, "
-                        .. "skipping the dispel overlay on %s", tostring(frame.unit))
+                        "StyleDispelSlots: slot %s still %s after a rebuild, "
+                        .. "skipping the dispel overlay on %s", tostring(info.key),
+                        unreachable and "forbidden" or "missing its carriers",
+                        tostring(frame.unit))
                 end
             else
                 btn._dfDispelArtStale = true

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1573,6 +1573,42 @@ end
 -- Pre-68914 fallback: the deprecated alias can only hold ONE region, so the first
 -- carrier wins there (matching the old one-slot-per-carrier behaviour as closely as a
 -- single slot can).
+-- ★ THE REVEAL. Every dispel carrier is born at alpha 0 on its DF-owned dim host and
+-- stays there until AddDispelTypeTexture has accepted it; this is what turns it back on.
+--
+-- ☠ WHY IT IS A SEPARATE STEP RATHER THAN A BIRTH VALUE. These carriers are OUR textures
+-- with the ENGINE'S colour. Between creating one and binding it, nothing colours it, so it
+-- renders at the default vertex colour -- WHITE -- across whatever it covers. For the
+-- gradient that is the whole frame. Birth used to hand each host the user's configured
+-- alpha immediately ("born with the user's value", because birth is usually mid-combat and
+-- the style pass is out-of-combat only), which is correct for cosmetics and exactly wrong
+-- for visibility: it made an unbound carrier maximally visible.
+--
+-- ☠ THE ALPHA MUST LIVE ON THE DIM HOST, NOT THE TEXTURE. AddDispelTypeTexture takes
+-- SecretAspect.Alpha and .Shown on the texture at bind time, after which neither is ours to
+-- write. The dim hosts are plain DF frames and are never restricted, so they are the only
+-- lever that still works on a slot whose subtree the client has locked -- which is the
+-- slot that needs it.
+--
+-- Mirrors the values the stylers apply, so a revealed carrier looks identical to one that
+-- was never held back. The stylers re-assert these every pass anyway; this only has to
+-- cover the window between a successful bind and the first out-of-combat style pass.
+function DF:RevealDispelCarriers(btn, db)
+    if not btn or not db then return end
+    local w = btn.dfDispelWidget
+    if w and w.nativeGradientDim then
+        w.nativeGradientDim:SetAlpha(db.dispelShowGradient ~= false and ResolveGradientAlpha(db) or 0)
+    end
+    if type(btn.dfDispelEdgeDim) == "table" then
+        local a = ResolveGradientAlpha(db)
+        for _, dim in pairs(btn.dfDispelEdgeDim) do
+            if dim then dim:SetAlpha(a) end
+        end
+    end
+    if btn.dfDispelRingDim then btn.dfDispelRingDim:SetAlpha(db.dispelBorderAlpha or 0.8) end
+    if btn.dfDispelBadgeDim then btn.dfDispelBadgeDim:SetAlpha(db.dispelIconAlpha or 1) end
+end
+
 local function BindDispelCarriers(btn, carriers, db, key)
     -- ☠ RECORD THE RESULT ON THE BUTTON, NOT ONLY IN THE GLOBAL. DF._dispelBindErr is
     -- keyed by SLOT KEY alone, so every frame's "main" slot overwrites every other
@@ -1643,6 +1679,15 @@ local function BindDispelCarriers(btn, carriers, db, key)
     btn._dfDispelBindRes = ok and ("ok x" .. #carriers) or tostring(err)
     if ok then
         btn._dfDispelCurveGen = DF.dispelCurveGen
+        -- ★ REVEAL ONLY NOW. The carriers were built at alpha 0 on their DF-owned dim
+        -- hosts, because until this call returns nothing colours them and an unowned
+        -- texture renders WHITE across whatever it covers -- frame-sized, in the gradient's
+        -- case. Restoring the configured alpha here, on the success branch only, makes a
+        -- refused bind cost the overlay rather than paint the frame white.
+        -- ☠ THE FAILURE BRANCH MUST NOT REVEAL, and must not "helpfully" hide either: the
+        -- hosts are already at 0, and a slot that never binds simply stays dark until the
+        -- recovery in StyleDispelSlots rebuilds it out of combat.
+        if DF.RevealDispelCarriers then DF:RevealDispelCarriers(btn, db) end
     elseif not warnedTintBind then
         warnedTintBind = true
         if DF.DebugWarn then DF:DebugWarn("DISPEL", "dispel bind %s failed: %s", tostring(key), tostring(err)) end
@@ -1766,7 +1811,19 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
             w.nativeGradient:SetAllPoints(btn)
         end
         w.nativeGradient:SetBlendMode(db.dispelGradientBlendMode or "ADD")
-        w.nativeGradientDim:SetAlpha(db.dispelShowGradient ~= false and ResolveGradientAlpha(db) or 0)
+        -- ☠☠ BORN INVISIBLE. HELD INVISIBLE UNTIL THE BIND IS CONFIRMED.
+        -- This carrier is OUR texture and the ENGINE is what colours it. Until
+        -- AddDispelTypeTexture has accepted it, nothing colours it at all -- it renders at
+        -- the default vertex colour, which is WHITE, across the whole frame. That is the
+        -- field report: not a wrong colour, an unowned texture.
+        --
+        -- The alpha lives on nativeGradientDim, a DF-OWNED frame, deliberately: the engine
+        -- takes SecretAspect.Alpha and .Shown on the texture itself at bind time, so the
+        -- texture's own visibility stops being ours to set. The dim host is never
+        -- restricted, so this is the one lever that still works on a slot whose subtree
+        -- the client has locked -- which is exactly the slot that needs it.
+        -- BindDispelCarriers restores the configured alpha, and ONLY on success.
+        w.nativeGradientDim:SetAlpha(0)
         carriers[#carriers + 1] = { tex = w.nativeGradient }
         -- Name the gradient carrier explicitly. StyleGameMainSlot must dress THIS one;
         -- addressing it as "the bound carrier" only worked while a slot held exactly one,
@@ -1791,7 +1848,7 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
             local dim = CreateFrame("Frame", nil, holder)
             dim:SetAllPoints(btn)
             dim:SetFrameLevel(edgeLvl)
-            dim:SetAlpha(ResolveGradientAlpha(db))   -- born with the user's value (mid-combat creation)
+            dim:SetAlpha(0)   -- born DARK; revealed only once the bind is confirmed
             local tex = dim:CreateTexture(nil, "ARTWORK", nil, 2)
             tex:SetTexture(EDGE_GRADIENT_TEXTURES[edge])
             tex:SetAllPoints(btn)   -- anchored for the bind; StyleGameEdgeSlot positions the strip
@@ -1813,7 +1870,7 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
         local ringDim = CreateFrame("Frame", nil, holder)
         ringDim:SetAllPoints(btn)
         ringDim:SetFrameLevel(hbLvl + 15)
-        ringDim:SetAlpha(db.dispelBorderAlpha or 0.8)   -- born with the user's value
+        ringDim:SetAlpha(0)   -- born DARK; revealed only once the bind is confirmed
         local ring = ringDim:CreateTexture(nil, "ARTWORK")
         ring:SetTexture("Interface\\AddOns\\DandersFrames\\Media\\DF_SquareBorder")
         ring:SetAllPoints(btn)   -- anchored for the bind; StyleGameBorderSlot crops/insets
@@ -1845,7 +1902,7 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
         local badgeDim = CreateFrame("Frame", nil, holder)
         badgeDim:SetAllPoints(btn)
         badgeDim:SetFrameLevel(holder:GetFrameLevel())
-        badgeDim:SetAlpha(db.dispelIconAlpha or 1)   -- born with the user's value
+        badgeDim:SetAlpha(0)   -- born DARK; revealed only once the bind is confirmed
         local badge = badgeDim:CreateTexture(nil, "OVERLAY")
         badge:SetAllPoints(btn)   -- anchored for the bind; StyleGameBadge sizes/places it
         btn.dfDispelBadgeDim = badgeDim

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1552,6 +1552,18 @@ end
 -- carrier wins there (matching the old one-slot-per-carrier behaviour as closely as a
 -- single slot can).
 local function BindDispelCarriers(btn, carriers, db, key)
+    -- ☠ RECORD THE RESULT ON THE BUTTON, NOT ONLY IN THE GLOBAL. DF._dispelBindErr is
+    -- keyed by SLOT KEY alone, so every frame's "main" slot overwrites every other
+    -- frame's -- last writer wins across the whole roster. A dump reading it reports one
+    -- frame's success against another frame's button, which is exactly how five frames
+    -- with no carriers at all printed "bind=ok x3" (2026-08-20). The global stays for the
+    -- site summary in /df debug dispelids, where cross-frame aggregation is the point.
+    --
+    -- Stamped BEFORE the early return, so "we got here and had nothing to bind" is a
+    -- recorded state rather than an absence indistinguishable from "never called".
+    if btn then
+        btn._dfDispelBindRes = (carriers and carriers[1]) and "pending" or "no carriers built"
+    end
     if not (btn and carriers and carriers[1]) then return end
     btn._dfDispelCarriers = carriers
     -- _dfDispelCurveGen is stamped AFTER a SUCCESSFUL bind (below), not here. The only
@@ -1606,6 +1618,7 @@ local function BindDispelCarriers(btn, carriers, db, key)
     end)
     DF._dispelBindErr = DF._dispelBindErr or {}
     DF._dispelBindErr[key or "?"] = ok and ("ok x" .. #carriers) or tostring(err)
+    btn._dfDispelBindRes = ok and ("ok x" .. #carriers) or tostring(err)
     if ok then
         btn._dfDispelCurveGen = DF.dispelCurveGen
     elseif not warnedTintBind then
@@ -1636,6 +1649,12 @@ local function DispelSlotSecureInit(btn, slotInfo, db, frame)
     local key = slotInfo.key
     local roles = slotInfo.roles
     if not roles then return end   -- icon slots bind nothing (plain art on the slot's SetShown)
+    -- ★ STAMP WHAT THIS SLOT IS SUPPOSED TO BUILD, BEFORE BUILDING IT. Absence is this
+    -- subsystem's failure mode, and a dump that renders a missing carrier as SILENCE
+    -- cannot show it -- which is precisely how a refused init read as healthy. With the
+    -- declaration recorded, the dump can say "declared gradient, no carrier" instead of
+    -- printing nothing for the one thing that mattered.
+    btn._dfDispelRoles = roles
     local hbLvl = (frame.healthBar and frame.healthBar:GetFrameLevel())
         or (frame:GetFrameLevel() + 3)
     -- ☠ The edge holders below must stay LEVEL WITH THE WIDGET, and the widget's band is
@@ -2094,6 +2113,11 @@ end
 local function ResetSlotArt(btn)
     btn.dfDispelWidget = nil
     btn._dfDispelCarriers = nil
+    -- The two diagnostic stamps go with the art they describe: a survivor would describe
+    -- the abandoned generation, which is the same trap as the dim hosts below.
+    -- DispelSlotSecureInit re-stamps both on the way back in.
+    btn._dfDispelRoles = nil
+    btn._dfDispelBindRes = nil
     btn._dfDispelCurveGen = nil
     btn._dfDispelGradientCarrier = nil
     btn.dfDispelEdgeTex = nil

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -27,6 +27,24 @@ local EDGE_GRADIENT_TEXTURES = {
     RIGHT = "Interface\\AddOns\\DandersFrames\\Media\\DF_Gradient_H_Rev",  -- Solid right, fades left
 }
 
+-- ☠☠ SEED THE GENERATION AT LOAD. It used to be created only by the first
+-- InvalidateDispelColorCurve call, whose ONLY callers are options-page callbacks and a
+-- debug command -- so on any session where nobody edited a dispel colour it stayed nil
+-- for the whole session.
+--
+-- That silently disabled the re-bind retry. BindDispelCarriers stamps
+-- btn._dfDispelCurveGen only on SUCCESS, so a failed bind leaves it nil, and the retry
+-- gate in StyleDispelSlots reads `btn._dfDispelCurveGen ~= DF.dispelCurveGen` --
+-- `nil ~= nil` -- which is FALSE. A carrier that failed to bind was therefore never
+-- retried, for the rest of the session, while its texture kept the default white vertex
+-- colour and was shown on every dispellable debuff. Seeding 0 makes the nil stamp
+-- genuinely unequal, so the existing gate does its job with no other change.
+--
+-- ☠ The tell that this was live: `/df debug dispelids` calls the invalidator, which
+-- bumps the counter -- so RUNNING THE DIAGNOSTIC HEALED THE BUG on the next
+-- out-of-combat style pass. Anyone who dumped first and looked second saw a clean frame.
+DF.dispelCurveGen = 0
+
 -- Invalidate the shared debuff-type colour curve when dispel colour settings
 -- change (Frames/Border.lua lazy-rebuilds it on next use).
 function DF:InvalidateDispelColorCurve()
@@ -2182,8 +2200,17 @@ local function StyleDispelSlots(frame, db, h, slots)
         -- next(info.roles) guards the all-disabled config (EDGE style with gradient, border
         -- and badge all off) -- roles is then an empty table, no carrier is meant to exist,
         -- and testing for one would rebuild on every pass.
+        -- ☠ TEST THE BIND RESULT, NOT JUST THE CARRIER LIST. The first version of this
+        -- gate asked `_dfDispelCarriers == nil`, which only catches "no carrier was ever
+        -- built". It CANNOT catch a carrier that was built and then failed to BIND,
+        -- because BindDispelCarriers stamps the carrier list BEFORE it attempts the bind
+        -- -- so a failed bind reads as complete, the art probes fine, and StyleOneSlot
+        -- succeeds because it only dresses. Same white outcome, different door.
+        -- _dfDispelBindRes records the truth: "ok x<n>" only on a completed bind.
+        local bindRes = btn and btn._dfDispelBindRes
+        local bound = type(bindRes) == "string" and bindRes:match("^ok x%d+$") ~= nil
         local incomplete = btn and info.roles and next(info.roles) ~= nil
-            and btn._dfDispelCarriers == nil
+            and (btn._dfDispelCarriers == nil or not bound)
         local unreachable = btn and btn.dfDispelWidget
             and not pcall(ProbeSlotArt, btn.dfDispelWidget)
         if btn and (unreachable or incomplete) then

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -332,6 +332,21 @@ local function BuildDispelOverlayWidget(host, gradientHost, iconHost)
     -- Options: Create custom texture OR use existing WoW gradients
     overlay.gradient:SetStatusBarTexture("Interface\\Buttons\\WHITE8x8")
     overlay.gradient:GetStatusBarTexture():SetBlendMode("ADD")
+    -- ☠☠ THIS IS THE OBJECT THAT PAINTED THE FRAME WHITE. Solid WHITE8x8, value at full
+    -- extent, blend ADD, sized to the whole gradient parent -- and it was the ONLY region
+    -- in this builder created SHOWN. gradientDarken, gradientTop/Bottom/Left/Right and
+    -- borderRingHost are all :Hide()n on the line after they are made; this one was not.
+    --
+    -- On the 12.1 slot path it is not the carrier at all and never renders anything --
+    -- StyleGameMainSlot hides it and dresses btn._dfDispelGradientCarrier instead. But
+    -- that Hide sits INSIDE `if carrier then`, so a slot whose carrier was never built
+    -- skipped it, and this bar was left exactly as created: white, full width, additive,
+    -- across the frame. Two independent faults chained -- a missing carrier, and a legacy
+    -- region whose only reason to be invisible was a branch that had stopped running.
+    --
+    -- Born hidden now, like its siblings. The one path that genuinely uses it (the legacy
+    -- non-slot widget) calls Show() explicitly, so nothing that wants it loses it.
+    overlay.gradient:Hide()
     
     -- Store reference to set gradient texture later based on style
     overlay.gradientStyle = "FULL"

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1313,6 +1313,10 @@ end
 -- drift. See BadgeCarrierOptions and the badge block in DispelSlotSecureInit.
 local warnedTintBind = false
 local warnedSlotStyle = false
+-- Slot BIRTH refusal (the onInit hook), separate from the style-pass latch above: they
+-- are different failures on different paths, and one shared one-shot would let whichever
+-- fired first hide the other for the rest of the session.
+local warnedSlotInit = false
 
 -- Slot plan from settings.
 local function dispelSlotPlan(db)
@@ -2296,7 +2300,36 @@ local function dispelFilterRecords(slots, db, frame)
                     -- container's initializeFrame (the only context where a texture child
                     -- of the secret button isn't access-constrained). Geometry/alpha stay
                     -- in StyleGame*Slot.
-                    onInit = function(btn) DispelSlotSecureInit(btn, si, db, frame) end }
+                    -- ☠ REPORT OUR OWN BIRTH FAILURE, ON OUR OWN CHANNEL.
+                    -- The container pcalls this hook (Handle:_makeInitializeFrame), so a
+                    -- refusal here is SWALLOWED: the slot is left half built, nothing
+                    -- records it, and the container's own warning rides AURACONTAINER.
+                    -- That is how a refused init produced a dump in which every printed
+                    -- field looked healthy (2026-08-20). Birth is normally MID-COMBAT --
+                    -- the client creates these buttons lazily on the first dispellable
+                    -- debuff -- so the button subtree carries
+                    -- DenyTaintedAccessWhenAurasAreSecret and creating the gradient's dim
+                    -- host is refused exactly like a setter.
+                    -- Stamped as well as logged: the stamp is what /df debug dispeldbg
+                    -- prints, so one paste names the exact refused call even from a
+                    -- client that had the DISPEL category switched off at the time.
+                    onInit = function(btn)
+                        local okI, errI = pcall(DispelSlotSecureInit, btn, si, db, frame)
+                        if not okI then
+                            if btn then btn._dfDispelInitErr = tostring(errI) end
+                            if not warnedSlotInit then
+                                warnedSlotInit = true
+                                if DF.DebugWarn then
+                                    DF:DebugWarn("DISPEL",
+                                        "slot init %s refused at birth - carriers missing "
+                                        .. "until the next out-of-combat rebuild: %s",
+                                        tostring(si.key), tostring(errI))
+                                end
+                            end
+                        elseif btn then
+                            btn._dfDispelInitErr = nil
+                        end
+                    end }
     end
     return recs
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -102,8 +102,10 @@ local warnedCreate = false
 -- StopAnimation loop in _teardownContainer.
 local warnedLayout, warnedTeardownAnim = false, false
 -- Slot BIRTH. Deliberately not warnedRestyle: sharing that latch let whichever of the
--- two failed first permanently silence the other.
-local warnedInitFrame = false
+-- two failed first permanently silence the other. The consumer hook gets a third latch
+-- for the same reason -- it is a separate call now, and a fault in one must not hide the
+-- other.
+local warnedInitFrame, warnedInitHook = false, false
 -- Filter-string tuning rejected for a key the container does not have. Latched
 -- because applyGroupTuning runs per frame per settings change; one line is enough
 -- to name the offending consumer.
@@ -4983,13 +4985,8 @@ function Handle:_makeInitializeFrame(gen, fixedIndex, onInit, recStyle, seqStart
                     handle:_paintTestSlot(button, testIndex)
                 else
                     handle:_bindNativeSlot(button)     -- native inbound setters
-                    -- Consumer secure init (overlay dispel carriers): runs in THIS
-                    -- securecallfunction pass, so any texture it creates on the button
-                    -- and binds via SetAuraBorder is created in secure context and is
-                    -- NOT access-constrained (the tainted style pass can't do the bind —
-                    -- cab.lua:15). Inside the pcall, so a fault warns and doesn't abort
-                    -- Blizzard's batch build.
-                    if onInit then onInit(button) end
+                    -- ☠ The consumer's onInit USED TO BE CALLED HERE, last inside this
+                    -- pcall. It now runs below, on its own. See the block after the pcall.
                 end
             end
         end)
@@ -5006,6 +5003,37 @@ function Handle:_makeInitializeFrame(gen, fixedIndex, onInit, recStyle, seqStart
             warnedInitFrame = true
             DF:DebugWarn(DBG, "initializeFrame failed (slot art may be incomplete): %s",
                 tostring(err))
+        end
+        -- ☠☠ THE CONSUMER HOOK GETS ITS OWN CALL, BECAUSE IT WAS LAST IN A SHARED PCALL.
+        -- It used to sit at the END of the pass above, after the mouse setters,
+        -- _acceptSlot and _bindNativeSlot. Any throw in ANY of those skipped straight past
+        -- it, so the button came out with its own regions built and bound and the
+        -- consumer's carriers never created at all.
+        --
+        -- ★ THAT ASYMMETRY IS THE FIELD SIGNATURE. Every reported white dispel overlay had
+        -- a correctly coloured debuff-icon ring on the same frame at the same moment: the
+        -- ring is built and bound by _acceptSlot / _bindNativeSlot EARLIER in this pass, so
+        -- it always completed, while the overlay's init was the only thing an earlier fault
+        -- could silently cost. It was never a difference between the two lanes' colour
+        -- handling -- it was their position in this function.
+        --
+        -- Still inside the same securecallfunction pass, which is what the hook needs: the
+        -- engine applies its access restrictions only after this whole callback RETURNS, so
+        -- a texture created here is still made in secure context. A pcall boundary is error
+        -- handling, not a context change -- moving the call out of the inner one does not
+        -- move it out of the window.
+        --
+        -- Conditions replicated from where the call used to sit: not destroyed, same
+        -- generation, real button, not `missing` mode (which builds no regions at all), and
+        -- not a test-shaped container (which paints curated art instead of binding).
+        if onInit and button and not handle._destroyed and handle._gen == gen
+            and handle.config.mode ~= "missing" and not testShape then
+            local okHook, errHook = pcall(onInit, button)
+            if not okHook and not warnedInitHook then
+                warnedInitHook = true
+                DF:DebugWarn(DBG, "initializeFrame consumer hook failed (slot carriers "
+                    .. "will be missing until the out-of-combat rebuild): %s", tostring(errHook))
+            end
         end
     end
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -98,6 +98,9 @@ local warnedCurve, warnedBorder, warnedNativeDispel = false, false, false
 -- (warnedMouse was a third latch here with no warning behind it — removed.)
 local warnedRestyle, warnedRefresh = false, false
 local warnedCreate = false
+-- Slot subtrees the client turned FORBIDDEN under us -- see placeButton and the
+-- StopAnimation loop in _teardownContainer.
+local warnedLayout, warnedTeardownAnim = false, false
 -- Filter-string tuning rejected for a key the container does not have. Latched
 -- because applyGroupTuning runs per frame per settings change; one line is enough
 -- to name the offending consumer.
@@ -2615,6 +2618,28 @@ local function buildGroupLayout(config)
     }
 end
 
+-- One button's placement, guarded by the caller.
+--
+-- ☠ ENGINE-OWNED BUTTONS CAN TURN FORBIDDEN UNDER US. Addons stopped creating AuraButtons
+-- at PTR-4 (see the header at the top of this file), so every entry in handle.buttons
+-- belongs to the client, and it can reclaim or re-initialise a slot's subtree at any point
+-- -- after which SetScale/SetPoint on that button throw "Attempt to access forbidden object
+-- from code tainted by an AddOn". Dispel.lua's ProbeSlotArt and TextDesigner/Render.lua's
+-- mirrorWrite already carry this guard for their own art; this is it for the row layout.
+--
+-- ★ THE COST OF NOT GUARDING WAS THE WHOLE ROW, NOT ONE ICON. The throw unwound out of the
+-- MIDDLE of layoutRow's loop, so every button after the forbidden one was left unpositioned.
+-- Reported in game as "no debuffs showing" after switching the debuff filter to All Debuffs
+-- inside a key (Krathe, 2026-08-20). Guarding per button costs one icon instead.
+--
+-- Declared once rather than inlined as a closure so the pcall stays allocation-free on this
+-- per-button-per-pass path -- same reasoning as ProbeSlotArt.
+local function placeButton(b, scale, anchor, parent, x, y)
+    b:SetScale(scale)
+    b:ClearAllPoints()
+    b:SetPoint(anchor, parent, anchor, x, y)
+end
+
 local function layoutRow(handle)
     local config = handle.config
     local L = config.layout or {}
@@ -2651,9 +2676,10 @@ local function layoutRow(handle)
             x = ppSnapScaled(x, scale)
             y = ppSnapScaled(y, scale)
         end
-        b:SetScale(scale)
-        b:ClearAllPoints()
-        b:SetPoint(anchor, handle.frame, anchor, x, y)
+        if not pcall(placeButton, b, scale, anchor, handle.frame, x, y) and not warnedLayout then
+            warnedLayout = true
+            DF:DebugWarn(DBG, "layoutRow: slot %d refused placement (forbidden subtree?)", i)
+        end
     end
 end
 
@@ -5885,7 +5911,22 @@ function Handle:_teardownContainer(park)
     -- refresh (bug #1079). Do not add any other write to slot subtrees in here.
     if DF.Border then
         for _, slot in pairs(self.buttons) do
-            if slot and slot.dfBorder then DF.Border:StopAnimation(slot.dfBorder) end
+            -- Guarded for the same reason as the binding loop just below, and as
+            -- layoutRow: the border's edge textures are children of the aura button, so
+            -- they go forbidden with it, and StopAnimation's resetEdgeAlphas then throws
+            -- on SetAlpha. Unguarded, that unwound out of THIS loop and the remaining
+            -- slots never got stopped at all -- their UIParent-hosted OnUpdate drivers
+            -- kept ticking against torn-down textures, which is the exact leak this
+            -- chokepoint exists to prevent (Krathe, 2026-08-20).
+            -- ⚠ unregisterAnimTick runs FIRST inside StopAnimation, so the driver for a
+            -- refused border is still stopped; what is lost is only its cosmetic alpha
+            -- reset, which cannot be applied to a forbidden object anyway.
+            if slot and slot.dfBorder then
+                if not pcall(DF.Border.StopAnimation, DF.Border, slot.dfBorder) and not warnedTeardownAnim then
+                    warnedTeardownAnim = true
+                    DF:DebugWarn(DBG, "_teardownContainer: StopAnimation refused (forbidden subtree?)")
+                end
+            end
         end
     end
     -- Test-mode native countdowns: a DurationTextBinding holds a reference to the

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -101,6 +101,9 @@ local warnedCreate = false
 -- Slot subtrees the client turned FORBIDDEN under us -- see placeButton and the
 -- StopAnimation loop in _teardownContainer.
 local warnedLayout, warnedTeardownAnim = false, false
+-- Slot BIRTH. Deliberately not warnedRestyle: sharing that latch let whichever of the
+-- two failed first permanently silence the other.
+local warnedInitFrame = false
 -- Filter-string tuning rejected for a key the container does not have. Latched
 -- because applyGroupTuning runs per frame per settings change; one line is enough
 -- to name the offending consumer.
@@ -4981,9 +4984,19 @@ function Handle:_makeInitializeFrame(gen, fixedIndex, onInit, recStyle, seqStart
                 end
             end
         end)
-        if not ok and not warnedRestyle then
-            warnedRestyle = true
-            DF:DebugWarn(DBG, "initializeFrame styling failed: %s", tostring(err))
+        -- ☠ ITS OWN LATCH, AND ITS OWN WORDING. This shared `warnedRestyle` with
+        -- ApplyStyle's restyle loop, which is a one-shot for the session -- so whichever
+        -- of the two failed first permanently silenced the other. Slot birth and restyle
+        -- are unrelated failures on unrelated paths; one latch between them meant the
+        -- second was guaranteed to be invisible.
+        -- The wording said "styling failed", but everything from _acceptSlot to the
+        -- consumer's onInit hook lands here, and a message that names the wrong stage
+        -- sends the next reader to the wrong file. It names the button's group instead
+        -- and leaves the stage to the error text.
+        if not ok and not warnedInitFrame then
+            warnedInitFrame = true
+            DF:DebugWarn(DBG, "initializeFrame failed (slot art may be incomplete): %s",
+                tostring(err))
         end
     end
 end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -2053,6 +2053,15 @@ local function bindNative(slot, config)
                 if DF.GetDispelColorMap then map = DF:GetDispelColorMap() end
                 if DF.GetDispelColorCurve then curve = DF:GetDispelColorCurve() end
             end
+            -- ☠☠ THE CURVE, WHICH THIS LANE WAS MISSING. Two comments in this repo
+            -- asserted the ring had passed it "since 68824"; it never did, and one of
+            -- them was used to explain away a field report -- correctly-coloured row
+            -- borders sitting next to a white overlay were read as proof the two lanes
+            -- differed in this field, when in fact NEITHER lane had it.
+            -- The map alone is the original white bug: a raw table index that resolves
+            -- private-side, with the style step's paint left standing if it misses.
+            -- Same reasoning as the overlay's tintOpts in Features/Dispel.lua.
+            local curve = DF.GetDispelColorCurve and DF:GetDispelColorCurve() or nil
             local ok, err = pcall(function()
                 local opts = {
                     style = styleEnum,

--- a/DandersFrames/Frames/Border.lua
+++ b/DandersFrames/Frames/Border.lua
@@ -845,21 +845,53 @@ function DF:GetDispelColorCurve()
     if not (C_CurveUtil and C_CurveUtil.CreateColorCurve) then return nil end
     local E = DF:FindDispelTypeEnum()
     if not E then return nil end
-    local colors = (DF.db and DF.db.dispelColors) or DF:GetGameDispelPalette()
+    -- ☠☠ PER-KEY FALLBACK, NOT A WHOLE-TABLE `or`. GetDispelColorMap has always done
+    -- this; the curve did not, and the difference was a live bug.
+    -- `db.dispelColors` has NO defaults entry, so it does not exist until the user edits
+    -- a dispel colour -- and the Colors page only ever writes the five DISPELLABLE types
+    -- (Magic/Curse/Disease/Poison/Bleed). The moment it exists it SHADOWED the complete
+    -- game palette wholesale, so `colors.None` was nil and the loop below skipped the
+    -- point at index 0 entirely. Verified against a live profile carrying exactly those
+    -- five keys (2026-08-20).
+    --
+    -- ☠☠ WHY A HOLE AT 0 MATTERS MORE THAN IT LOOKS: the engine lets the curve
+    -- UNCONDITIONALLY OVERRIDE the colour map --
+    -- `if options.customDispelColorCurve then color = GetAuraDispelTypeColor(...) end`,
+    -- Blizzard_CustomAuraButton.lua:410-412, no test on the map result. So a curve with a
+    -- hole is WORSE than no curve at all: it discards a perfectly good map lookup and
+    -- substitutes whatever the curve clamps to. An aura with no dispel type keys "None",
+    -- which the map resolves correctly and the holed curve did not.
+    local D = DF:GetGameDispelPalette()
+    local colors = (DF.db and DF.db.dispelColors) or D
+    local function pick(c, fb) return (type(c) == "table" and c.r) and c or fb end
     local candidates = {
-        { E.Magic,   colors.Magic },
-        { E.Curse,   colors.Curse },
-        { E.Disease, colors.Disease },
-        { E.Poison,  colors.Poison },
-        { E.Bleed,   colors.Bleed },
-        { E.Enrage,  colors.Enrage or colors.Bleed },
-        { E.None,    colors.None },
+        { E.Magic,   pick(colors.Magic,   D.Magic) },
+        { E.Curse,   pick(colors.Curse,   D.Curse) },
+        { E.Disease, pick(colors.Disease, D.Disease) },
+        { E.Poison,  pick(colors.Poison,  D.Poison) },
+        { E.Bleed,   pick(colors.Bleed,   D.Bleed) },
+        { E.Enrage,  pick(colors.Enrage or colors.Bleed, D.Enrage) },
+        { E.None,    pick(colors.None,    D.None) },
     }
     local points = {}
+    local haveZero = false
     for _, pair in ipairs(candidates) do
         local x, c = pair[1], pair[2]
         if type(x) == "number" and type(c) == "table" then
             points[#points + 1] = { x, CreateColor(c.r or 0, c.g or 0, c.b or 0, 1) }
+            if x == 0 then haveZero = true end
+        end
+    end
+    -- ★ ANCHOR INDEX 0 EVEN IF THE ENUM LOOKUP FOR "None" FAILED. Index 0 is the
+    -- no-dispel-type case, and on a debuff row it is the value the curve is evaluated at
+    -- most often -- so it must never be one the curve has to extrapolate towards. An
+    -- unanchored 0 does not read as missing either: the curve still returns a colour, just
+    -- the wrong one, which is why this was invisible until the palette was compared
+    -- against the point set.
+    if not haveZero then
+        local n = pick(colors.None, D.None)
+        if type(n) == "table" then
+            table.insert(points, 1, { 0, CreateColor(n.r or 0, n.g or 0, n.b or 0, 1) })
         end
     end
     if #points == 0 then return nil end

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -1141,7 +1141,28 @@ function DF:CreatePartyHeader()
     -- ★ LIVE-ONLY: the preview reads growDirection via SecureSort:UpdateLayoutParams, so
     -- the preview was right and live was wrong. (Test-vs-live audit, 2026-08-07.)
     local horizontal = (db.growDirection == "HORIZONTAL")
-    local spacing = db.frameSpacing or 2
+    -- ☠☠ SNAP THE STRIDE, or every frame after the first walks off the pixel grid.
+    -- Blizzard's header lays children out by REPEATED OFFSET, so a fractional spacing is
+    -- not a one-off rounding error — it ACCUMULATES down the party. Measured on a live
+    -- party at UIParent scale 0.64, where 1 UI unit = 1.2 physical px, so the default
+    -- spacing of 1 carries 0.2px of fraction: the five frames landed at -0.4, -0.2, 0.0,
+    -- +0.2 and +0.4 physical px, walking 0.8px across a pixel boundary. Anything anchored
+    -- to a frame inherits its host's sub-pixel offset and rounds differently per frame --
+    -- reported as the resource bar's Offset Y showing a gap on some frames and not others,
+    -- and as test mode disagreeing with live (Aphoex, 2026-08-19; /df debug ppdump showed
+    -- every live host frac at ±0.2/±0.4 against 0.000 for every test frame).
+    -- ⚠ Snap the LOCAL too, not just the stored attribute: the local feeds xOffset/yOffset,
+    -- which IS the stride the header repeats. Snapping only the "spacing" attribute below
+    -- would leave the actual layout fractional and look like a fix.
+    -- ★ The grouped raid handler has always done this (snapInit, ~:2101). Party and arena
+    -- were the two headers that never got it.
+    local function snapInit(value)
+        if db.pixelPerfect and DF.PixelPerfect then
+            return DF:PixelPerfect(value)
+        end
+        return value
+    end
+    local spacing = snapInit(db.frameSpacing or 2)
     DF.partyHeader:SetAttribute("point", horizontal and "LEFT" or "TOP")
     -- IMPORTANT: Don't use Lua ternary with 0! (0 is falsy)
     if horizontal then
@@ -1155,9 +1176,9 @@ function DF:CreatePartyHeader()
     DF.partyHeader:SetAttribute("unitsPerColumn", 5)
     
     -- Store layout values for secure positioning code
-    DF.partyHeader:SetAttribute("frameWidth", db.frameWidth or 120)
-    DF.partyHeader:SetAttribute("frameHeight", db.frameHeight or 50)
-    DF.partyHeader:SetAttribute("spacing", db.frameSpacing or 2)
+    DF.partyHeader:SetAttribute("frameWidth", snapInit(db.frameWidth or 120))
+    DF.partyHeader:SetAttribute("frameHeight", snapInit(db.frameHeight or 50))
+    DF.partyHeader:SetAttribute("spacing", spacing)
     DF.partyHeader:SetAttribute("horizontal", horizontal)
     -- (The `growFromCenter` attribute write that used to sit here was removed. It read a
     -- db key nothing defines or writes, and the ONLY snippet that consumed it was the
@@ -1242,7 +1263,17 @@ function DF:CreateArenaHeader()
     -- ★ LIVE-ONLY: the preview reads growDirection via SecureSort:UpdateLayoutParams, so
     -- the preview was right and live was wrong. (Test-vs-live audit, 2026-08-07.)
     local horizontal = (db.growDirection == "HORIZONTAL")
-    local spacing = db.frameSpacing or 2
+    -- Same stride snap as the party header above, for the same reason — the arena header
+    -- is that code with a different frame set, so a fractional spacing accumulates here
+    -- identically. Fixed together deliberately: leaving one of a copied pair unsnapped is
+    -- how this survived in party while the grouped raid handler had it all along.
+    local function snapInit(value)
+        if db.pixelPerfect and DF.PixelPerfect then
+            return DF:PixelPerfect(value)
+        end
+        return value
+    end
+    local spacing = snapInit(db.frameSpacing or 2)
     DF.arenaHeader:SetAttribute("point", horizontal and "LEFT" or "TOP")
     if horizontal then
         DF.arenaHeader:SetAttribute("xOffset", spacing)
@@ -1255,9 +1286,9 @@ function DF:CreateArenaHeader()
     DF.arenaHeader:SetAttribute("unitsPerColumn", 5)  -- Max 5 for arena (2v2, 3v3, 5v5)
     
     -- Store layout values for secure positioning code
-    DF.arenaHeader:SetAttribute("frameWidth", db.frameWidth or 120)
-    DF.arenaHeader:SetAttribute("frameHeight", db.frameHeight or 50)
-    DF.arenaHeader:SetAttribute("spacing", db.frameSpacing or 2)
+    DF.arenaHeader:SetAttribute("frameWidth", snapInit(db.frameWidth or 120))
+    DF.arenaHeader:SetAttribute("frameHeight", snapInit(db.frameHeight or 50))
+    DF.arenaHeader:SetAttribute("spacing", spacing)
     DF.arenaHeader:SetAttribute("horizontal", horizontal)
 
     -- SetFrameRef for secure snippets
@@ -5450,10 +5481,18 @@ function DF:UpdateRaidHeaderLayout()
         for i = 1, 8 do
             local header = DF.raidSeparatedHeaders[i]
             if header then
-                header:SetAttribute("yOffset", -(db.frameSpacing or 2))
+                -- ☠ SNAP, matching CreateRaidSeparatedHeaders. The creator already snaps
+                -- this stride and this updater did not, so a separated-header layout was
+                -- born on the grid and walked off it on the next settings change -- the
+                -- worst version of this bug, because it looks correct until something
+                -- unrelated re-runs the layout. Same accumulation as the party header
+                -- above; see its note for the measurement.
+                local sp = db.frameSpacing or 2
+                if db.pixelPerfect and DF.PixelPerfect then sp = DF:PixelPerfect(sp) end
+                header:SetAttribute("yOffset", -sp)
                 header:SetAttribute("frameWidth", db.frameWidth or 80)
                 header:SetAttribute("frameHeight", db.frameHeight or 40)
-                header:SetAttribute("spacing", db.frameSpacing or 2)
+                header:SetAttribute("spacing", sp)
             end
         end
     end

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -1155,8 +1155,18 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
         debuffOffsetY.disableOn = function(d) return not d.showDebuffs end
         Add(positionGroup, nil, 1)
 
+        -- ☠ A SECOND, DRIFTED COPY OF THE INVALIDATION CONTRACT. This nilled the curve by
+        -- hand and stopped there: it left DF.dispelColorMap cached and never bumped
+        -- DF.dispelCurveGen, so the curve was rebuilt while every live carrier kept a
+        -- reference to the OLD one and neither re-bind gate could fire -- colour changes
+        -- from this control did not reach the frames. Call the one owner instead: it nils
+        -- both caches, bumps the generation, and breaks the drive's fast-path latch.
         local function InvalidateAndUpdate()
-            DF.debuffBorderCurve = nil
+            if DF.InvalidateDispelColorCurve then
+                DF:InvalidateDispelColorCurve()
+            else
+                DF.debuffBorderCurve = nil
+            end
             DF:UpdateAllFrames()
         end
         


### PR DESCRIPTION
## What this is

Follow-up to the dispel work already merged. Field reports of whole frames washing white kept arriving **after** that fix, so this started as a re-diagnosis and turned into a research pass over the 12.1 dispel pipeline, read against Blizzard's own interface source.

The headline: the earlier fix was aimed at the wrong layer, one defect it left in place made the overlay unrecoverable for a whole session, and the white frame is now structurally impossible rather than merely recoverable.

## The re-diagnosis

A `/df debug dispeldbg` from an affected client showed every printed field healthy — `styleErr=nil`, style latched at the current version, widget present, `bind=ok x3`. The fault was in what the dump did **not** print: no carrier line at all, because the helper returned early on a nil texture and the carrier's own line lived inside `if carrier then`.

The carrier did not exist. And with no carrier, nothing the colour pipeline does matters.

**The whiteness is itself the evidence.** Our carriers request `PreserveAsset`, which is the only one of the five dispel-texture styles that does *not* base-coat `SetVertexColor(1, 1, 1, 1)` — it paints the game's own dispel colour, `"None"` fallback included. So if the engine had been driving the texture it could not have come out white. White means the engine never touched it: a plain addon texture, frame-sized, shown by our own code, sitting at its default vertex colour.

### Why the debuff-icon ring was always fine on the same frame

Every reported white overlay had a correctly coloured dispel ring beside it, on the same frame at the same moment. That asymmetry turns out to be the most useful clue in the whole investigation, and it is not about colour handling at all — it is the two things' *position* in `initializeFrame`.

One pcall wrapped the entire slot-birth pass, in this order: the mouse setters, `_acceptSlot` (which builds and styles the ring), `_bindNativeSlot` (which binds it), and **last**, the consumer's `onInit` — the overlay's carrier create-and-bind. A throw anywhere in that sequence skipped straight past the hook. The button came out with its ring built and bound, and the overlay's carriers never created at all.

Ring correct, overlay white, every time. The hook does not have to be *refused* to be skipped; it only has to be downstream of something that threw. It also matches the dump that started this — widget present, carriers absent — because a hook that never ran leaves exactly that: the widget is recreated later by the tainted painter, the carriers are not, since only the hook builds them.

The hook now runs in its own guarded call after the pass, still inside the same `securecallfunction` window (the engine applies its restrictions only after the whole callback *returns*, and a pcall boundary is error handling rather than a context change).

## The fixes

**The retry gate was comparing `nil` to `nil`, so nothing was ever retried.** `DF.dispelCurveGen` was only ever created inside `InvalidateDispelColorCurve`, whose only callers are options-page callbacks and a debug command — so on any session where nobody edited a dispel colour it stayed `nil` all session. `BindDispelCarriers` stamps `_dfDispelCurveGen` only on success, so a failed bind left it `nil`, and the gate `btn._dfDispelCurveGen ~= DF.dispelCurveGen` evaluated `nil ~= nil`, which is false. A carrier that failed to bind was never retried again. Seeded to `0` at load, which makes the existing gate work with no other change.

This also explains why the bug kept vanishing under investigation: `/df debug dispelids` calls the invalidator, which bumps the generation — **running the diagnostic healed the slot** on the next out-of-combat pass.

**A slot whose secure init was refused was never rebuilt.** The client creates these buttons lazily on the first dispellable debuff, i.e. mid-combat, so the init hook runs while the button subtree carries `DenyTaintedAccessWhenAurasAreSecret`, and creating the gradient's dim host is refused exactly like a setter. The container pcalls that hook, so the refusal was swallowed silently. The recovery gate then asked only whether the art was *reachable* — which out of combat it is — so it never fired. It now tests completeness as well, via the bind result rather than the carrier list, because the carrier list is stamped *before* the bind is attempted and so reads as complete on a failed bind.

**The colour curve was built with a whole-table fallback instead of a per-key one.** `db.dispelColors` has no defaults entry and the Colors page only ever writes the five dispellable types, so the moment it existed it shadowed the complete palette and the point at index 0 was dropped. That matters more than it looks: the engine lets the curve override the map *unconditionally* — `if options.customDispelColorCurve then color = ... end`, with no test on the map result — so a curve with a hole discards a correct map lookup. A holed curve is worse than no curve, and the earlier fix introduced exactly that for auras with no dispel type. Now mirrors the map: per-key fallback for all seven types, plus an explicit anchor at index 0.

**Nothing invalidated the palette on profile switch or import.** The curve and map are process-lifetime caches that do not follow the active profile, and the generation never moved, so a switched-to profile rendered the previous profile's dispel colours with no re-bind ever scheduled. Both paths now invalidate. A second, drifted copy of the invalidation contract on the Indicators page nilled the curve by hand, left the map cached and never bumped the generation — it calls the one owner now.

## Two crash fixes found on the way

Switching the debuff filter to All Debuffs inside a key threw twice and left the debuff row empty. Both are the same fault: every entry in `handle.buttons` belongs to the client since addons stopped creating aura buttons, and the client can reclaim a slot's subtree at any point, after which setters throw *"attempt to access forbidden object"*.

These were the only two loops in the file touching those buttons without a guard — the layout call threw from the *middle* of its loop, so every button after the forbidden one was left unpositioned, which is the reported empty row. The teardown loop threw likewise, leaving the remaining slots' animation drivers ticking against torn-down textures. Note the per-button restyle loop three lines below the layout call was already guarded, as was the binding loop directly below the teardown one; these two were the gaps.

## Diagnostics

The dump could report a missing thing as no thing, in four separate places. Absent regions now print `ABSENT` rather than no line; the carrier line prints unconditionally with `rel=NO CARRIER`; `bind=` reads the button's own stamp instead of a global keyed by slot key alone (which was last-writer-wins across the whole roster, and is how five carrier-less frames all reported `ok x3`); and a new `declares:` line states what the slot was *supposed* to build so a missing carrier is visible as a mismatch rather than a gap.

A birth-time refusal is now also reported on the `DISPEL` log category and stamped on the button, so one paste names the exact refused call even from a client that had that category switched off at the time. The container's own init warning shared a one-shot latch with the restyle loop, so whichever failed first permanently silenced the other; they have separate latches now.

## Also included

The party, arena and separated-header strides are pixel-snapped. Reported as the Resource Bar Offset Y differing between test mode and a live party; measured with both dumps, the hosts carried a per-frame ±0.2px fraction in live and 0.000 in test. Blizzard's headers lay children out by repeated offset, so a fractional spacing accumulates rather than rounding away once. The grouped raid handler has snapped this all along; the party and arena headers pushed the raw value, and the separated-header updater rewrote raw what its creator had snapped — born on the grid, walking off it on the next settings change.

## Verification

`luac -p` clean, and `_ENV` global reads identical to this base, on all seven changed files. All files kept their CRLF endings, verified by CR count equalling total line count and matching the base's convention.

**Not confirmed in game, and the reason is itself a finding.** Every repro attempt so far has been destroyed by the act of investigating it — a reload rebuilds the slot out of combat, and the diagnostic command bumps the generation that the broken retry gate needed. The defects here are closed by construction and traced in code, not watched failing and then watched working. No changelog entries, for that reason.

## The guarantee: never white, not even once

Everything above makes the overlay *recover*. It does not stop the first white frame, and that is not good enough — so the last commit removes the possibility rather than shortening it.

Recovery runs out of combat, necessarily: rebuilding a carrier needs the slot subtree the client locks while auras are secret, which is the reason the bind failed in the first place. A slot born broken mid-fight therefore stays broken for that fight no matter what we retry. The only thing under our control in that window is whether the failure is *visible*.

These carriers are our textures with the engine's colour. Between creating one and binding it, nothing colours it, so it renders at the default vertex colour — white — across whatever it covers. For the gradient that is the whole frame. Birth handed each dim host the user's configured alpha immediately, which is right for cosmetics and exactly wrong for visibility: it made an unbound carrier maximally visible.

All four carriers now start at alpha 0 and are revealed only on the bind's success branch. **A refused bind costs the overlay for that fight instead of painting the frame white**, and the recovery still repairs it at the next out-of-combat pass.

The alpha has to live on the dim hosts rather than the textures: `AddDispelTypeTexture` claims `SecretAspect.Alpha` and `.Shown` on the texture at bind time, after which neither is ours to write. The dim hosts are plain frames of ours and are never restricted, so they are the only lever that still works on exactly the slot that needs it.

Applied to all four rather than just the frame-sized gradient — one rule with no exceptions beats sparing the ring and badge, and a half-revealed overlay would be its own confusing state.

This is the shape the debuff-icon dispel ring has always had, which is why that lane has never produced this symptom: its gate is `not slot._boundAuraBorder`, a positive test for "did this ever bind" that retries every pass until it succeeds, and its stamps land after the pcall — with a comment already on that code explaining why setting them up front would mark a failed bind as bound. The overlay had neither property.

## Known limits

Test mode cannot reproduce any of this — the preview takes the legacy widget path and never binds a carrier, so it is structurally incapable of showing the failure. Against the rule that previews run the live pathway, that is the gap that let these ship, and it is not addressed here.

`DEBUFF_TYPE_NONE_COLOR` is resolved client-side and is not in the interface source, so what `PreserveAsset` paints for an aura with no dispel type is still unverified.


## Added after review: the stylers are now the fourth success-gated writer

A review pass over this PR constructed one residual white path. The born-dark contract had three alpha writers and only the reveal asked about the bind: the four slot stylers (main wash, edge strips, ring, badge) raised their dim hosts on region existence alone. The chain: combat-born slot, bind fails (frame stays dark — this PR working), out of combat the recovery re-init runs and the bind fails *again* on a deterministic refusal, the stale latch has not tripped yet (it needs two consecutive failures), the style pass runs — and revealed every unbound white texture at the configured opacity.

`SlotBindConfirmed` gates all four now: `_dfDispelCurveGen` is stamped only after a successful bind, cleared by `ResetSlotArt` with the art it describes, so "equal to the live generation" means the carriers being revealed are the ones the engine currently owns. The stylers assert dark on the failure side rather than skipping the write, so a slot that was revealed and then failed a palette re-bind goes back to dark instead of keeping stale alpha. Every alpha raiser on the slot lane is now success-gated.
