### PR TITLE
Debug console audit: the log level that never filtered, and 34 categories checked for what silence means

### DIFF
--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -6268,4 +6268,9 @@ do
     end
 end
 
-DF:Debug(DBG, "Factory (native AD bridge) loaded")
+-- ☠ (Removed) a file-scope `DF:Debug(DBG, "Factory (native AD bridge) loaded")`. It could
+-- never print: DebugConsole:Init binds debugDb from ADDON_LOADED, long after every file
+-- has been parsed, so a log call at chunk level is a guaranteed no-op -- it allocated its
+-- argument and returned nothing, in every session this addon has ever run. The same trap
+-- is documented in Core.lua's migration trace, which buffers until the console exists.
+-- Anything that genuinely needs to report at load must use that buffer, not a bare call.

--- a/DandersFrames/ClickCasting/Bindings.lua
+++ b/DandersFrames/ClickCasting/Bindings.lua
@@ -2785,6 +2785,13 @@ function CC:BuildUnifiedMacroMap()
                 }
                 
                 DF:Debug("CLICK", "Item: %s\n%s", tostring(keyString), tostring(macroText))
+            else
+                -- ★ "A binding that shows in the list and does nothing is worse than one
+                -- that says why" -- this file's own words, at a sibling failure elsewhere.
+                -- Both macro-build failures dropped the key from the map in silence, so it
+                -- looked configured in the UI and was simply dead in play.
+                DF:DebugWarn("CLICK", "Item %s dropped: BuildMacroTextForBinding returned nothing",
+                    tostring(keyString))
             end
         else
             -- Normal spell/macro binding - try to build combined macro
@@ -2799,6 +2806,12 @@ function CC:BuildUnifiedMacroMap()
                 }
                 
                 DF:Debug("CLICK", "Macro: %s\n%s", tostring(keyString), tostring(macroText))
+            else
+                -- Same silent drop as the item branch above. Named separately so the log
+                -- says which half failed: no macro text at all, or text with no template
+                -- binding to attach it to.
+                DF:DebugWarn("CLICK", "Macro %s dropped: macroText=%s templateBinding=%s",
+                    tostring(keyString), tostring(macroText ~= nil), tostring(templateBinding ~= nil))
             end
         end
     end

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -1042,7 +1042,11 @@ DF.IsTexturePresent = textureKnown
 local function warnMissingTexture(path)
     if not path or _df_warnedMissingTexture[path] then return end
     _df_warnedMissingTexture[path] = true
-    if DF.Debug then DF:Debug("TEXTURE", "Missing texture '%s' — using stock fallback", tostring(path)) end
+    -- ☠ WARN, not INFO. A missing texture is significant enough that the next lines print
+    -- it to chat, yet the log entry sat at INFO -- so anyone who raised the log level to
+    -- cut chatter lost the only line this category has. TEXTURE has exactly one call site;
+    -- filtering it out by severity left the category permanently empty.
+    if DF.DebugWarn then DF:DebugWarn("TEXTURE", "Missing texture '%s' — using stock fallback", tostring(path)) end
 
     local shown = tostring(path)
     -- Ours: show just the filename, and say plainly that it is not coming back.

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -7896,7 +7896,9 @@ DF._MainEventDispatcher = function(self, event, arg1)
             end
         end
         
-        DF:Debug("ROLE", "PLAYER_REGEN_DISABLED (entering combat)")
+        -- ☠ (Removed) a bare "entering combat" constant. UpdateAllRoleIcons on the next
+        -- line logs "inCombat=true" itself, with more information and from the code that
+        -- actually acts on it.
         -- Update role icons (in case hideInCombat is enabled)
         if DF.UpdateAllRoleIcons then
             DF:UpdateAllRoleIcons()

--- a/DandersFrames/Core.lua
+++ b/DandersFrames/Core.lua
@@ -30,12 +30,23 @@ function DF:RegisterLocaleRefresh(fn)
     DF._localeRefreshers[#DF._localeRefreshers + 1] = fn
 end
 function DF:RunLocaleRefreshers()
+    -- ★ SCRIPT had no success path at all -- three ERROR calls across the addon and nothing
+    -- else -- so a session where every refresher worked and one where this never ran
+    -- produced the same empty category. Silence is only worth reading as "healthy" if
+    -- something says so. One line at the end with the failure count gives the category a
+    -- heartbeat without adding per-refresher chatter.
+    local failed = 0
     for i = 1, #DF._localeRefreshers do
         local ok, err = pcall(DF._localeRefreshers[i])
-        if not ok and DF.DebugError then
-            DF:DebugError("SCRIPT", "LocaleRefresh failed: %s", tostring(err))
+        if not ok then
+            failed = failed + 1
+            if DF.DebugError then
+                DF:DebugError("SCRIPT", "LocaleRefresh failed: %s", tostring(err))
+            end
         end
     end
+    DF:Debug("SCRIPT", "RunLocaleRefreshers: %d refresher(s), %d failed",
+        #DF._localeRefreshers, failed)
 end
 
 -- Locale warnings: silent by default (see Locales/enUS.lua for rationale).

--- a/DandersFrames/Core/AutoProfiles.lua
+++ b/DandersFrames/Core/AutoProfiles.lua
@@ -1838,7 +1838,12 @@ function AutoProfilesUI:HandleRuntimeWrite(key, value)
             -- a metatable); sets without one are the real table by reference.
             isOverridden = overlaySet ~= nil and getmetatable(overlaySet) ~= nil
         end
-        DF:Debug("AUTOPROFILE", "HandleRuntimeWrite: pinned key %s — overridden=%s, wrote to real table", key, tostring(isOverridden))
+        -- Same correction as the table-key branch below: the write at :1825 is inside
+        -- `if pf and pf.sets and pf.sets[setIndex]`, so claiming it unconditionally
+        -- misreported the exact case worth seeing -- a pinned set that is not there.
+        DF:Debug("AUTOPROFILE", "HandleRuntimeWrite: pinned key %s — overridden=%s, wrote=%s",
+            key, tostring(isOverridden),
+            tostring(pf ~= nil and pf.sets ~= nil and pf.sets[setIndex] ~= nil))
         return isOverridden
     end
 
@@ -1857,7 +1862,13 @@ function AutoProfilesUI:HandleRuntimeWrite(key, value)
         -- overlay view (see ApplyRuntimeProfile); everything else reads through.
         local overlayTbl = DF.raidOverrides[tableName]
         local isOverridden = type(overlayTbl) == "table" and rawget(overlayTbl, index) ~= nil
-        DF:Debug("AUTOPROFILE", "HandleRuntimeWrite: table key %s — overridden=%s, wrote to real table", key, tostring(isOverridden))
+        -- ☠ REPORT THE WRITE, DO NOT ASSERT IT. This said "wrote to real table"
+        -- unconditionally, while the write above sits inside `if type(tbl) == "table"` --
+        -- so on the one path worth debugging, the table being absent, the log claimed a
+        -- write that never happened. A line that lies about its failure case is worse
+        -- than no line: it sends the reader straight past the fault.
+        DF:Debug("AUTOPROFILE", "HandleRuntimeWrite: table key %s — overridden=%s, wrote=%s",
+            key, tostring(isOverridden), tostring(type(tbl) == "table"))
         return isOverridden
     end
 

--- a/DandersFrames/Core/Profile.lua
+++ b/DandersFrames/Core/Profile.lua
@@ -447,6 +447,13 @@ function DF:SetProfile(name)
     -- the new profile directly with no stale overlay
     DF:FullProfileRefresh()
 
+    -- ★ THE COMPLETION MARKER. PROFILE logged the START of a switch and nothing else, with
+    -- eleven one-time migrations and a full refresh running in between -- so a log showing
+    -- "cleared runtime state before switching" and then nothing was indistinguishable from
+    -- a switch that half-applied and threw. That is precisely the failure worth catching
+    -- here, and it was the one state the category could not describe.
+    DF:Debug("PROFILE", "SetProfile: switch to %s complete", tostring(name))
+
     DF:Say(format(L["Switched to profile: %s"], name))
 
     -- If the new profile has a different enable-flag state, prompt to reload
@@ -1162,6 +1169,28 @@ function DF:ValidateImportString(str)
     end
     
     return nil, "Invalid format"
+end
+
+-- ★ ONE LINE FOR TWELVE SILENT REJECTIONS. ValidateImportString bails with a distinct
+-- reason in twelve places -- Invalid encoding, Decompression failed, Deserialization
+-- failed, Missing required libraries, Legacy format, Corrupt data and the rest -- and
+-- logged none of them. "My import string doesn't work" therefore produced a completely
+-- empty log, while the function had the exact reason in hand and handed it only to the UI.
+--
+-- Wrapped rather than edited at each return: twelve separate edits to add the same line is
+-- twelve chances to drift, and a future thirteenth return would miss it. The wrapper cannot
+-- be bypassed and needs no maintenance.
+--
+-- Length is included because the common causes are a truncated paste and a string mangled
+-- by a chat client, and both show up as a plausible-looking prefix with the wrong size.
+local ValidateImportStringInner = DF.ValidateImportString
+function DF:ValidateImportString(str)
+    local data, err = ValidateImportStringInner(self, str)
+    if not data then
+        DF:DebugWarn("PROFILE", "import rejected: %s (length=%s)",
+            tostring(err), type(str) == "string" and #str or "not a string")
+    end
+    return data, err
 end
 
 -- Get version info from validated import data

--- a/DandersFrames/Debug/DebugConsole.lua
+++ b/DandersFrames/Debug/DebugConsole.lua
@@ -54,7 +54,12 @@ local CATEGORY_GROUPS = {
             { key = "HEALTH",     desc = "Health bar value writes, including Reduced Max Health" },
             { key = "FLATRAID",   desc = "Flat raid layout and sorting", noisy = true },
             { key = "FRAMESORT",  desc = "FrameSort addon integration" },
-            { key = "SECURESORT", desc = "Spec cache, inspect queue and the raid geometry calculators", noisy = true },
+            -- ⚠ NOT noisy. Most of this subsystem was deleted as unreachable; of the
+            -- survivors only two call sites are reachable in live play at all, so it was
+            -- hidden by default for a firehose that no longer exists -- and a defaulted-off
+            -- category with nothing in it is the worst outcome for whoever ticks it hoping
+            -- for a trace.
+            { key = "SECURESORT", desc = "Spec cache, inspect queue and the raid geometry calculators" },
             -- noisy: driven by UNIT_IN_RANGE_UPDATE per unit, and fans out to pinned
             -- and boss frames — a moving raid produces a steady stream.
             { key = "RANGE",      desc = "Range fading checks and cache decisions", noisy = true },
@@ -385,6 +390,27 @@ local function sanitizeLogMessage(msg)
 end
 
 function DebugConsole:Log(level, category, fmt, ...)
+    -- ☠☠ MINIMUM LOG LEVEL NOW DROPS THE LINE, IT DOES NOT JUST HIDE IT.
+    -- This used to be a VIEW filter only: CollectFilteredLines applied logLevel when
+    -- rendering the console and the export, while every INFO line was still formatted,
+    -- sanitised, stored and counted against maxLines. So "Errors Only" cost exactly as
+    -- much as "Info (All)" and gave exactly as little buffer -- the setting that looks
+    -- like the spam control was the one thing that could not control spam. A tester who
+    -- set it and then reproduced a bug still had their trace evicted by INFO chatter they
+    -- had explicitly asked not to see.
+    --
+    -- Filtering here instead makes it a real lever: no format, no pcall, no string, no
+    -- eviction. Combined with the per-category tickboxes it is the honest way to keep a
+    -- long capture readable, and it is reversible -- raise the level, reproduce again.
+    --
+    -- ⚠ The trade, stated: a line dropped here is GONE, not hidden, so raising the level
+    -- mid-session cannot recover earlier INFO. That is the same bargain as unticking a
+    -- category, and it is what "minimum log level" sitting directly above "max log
+    -- entries" reads as -- both are buffer controls.
+    local minLevel = SEVERITY[(debugDb and debugDb.logLevel) or "INFO"]
+    local thisLevel = SEVERITY[level]
+    if minLevel and thisLevel and thisLevel.level < minLevel.level then return end
+
     -- Format the message. If any format arg is a secret-tainted value, the
     -- resulting string inherits the taint and cannot be safely concatenated
     -- later. sanitizeLogMessage replaces tainted messages with a placeholder.

--- a/DandersFrames/Features/Dispel.lua
+++ b/DandersFrames/Features/Dispel.lua
@@ -1312,6 +1312,11 @@ end
 -- own copy lives in AuraUtil (dispelIconAtlas), so ours was a duplicate that could
 -- drift. See BadgeCarrierOptions and the badge block in DispelSlotSecureInit.
 local warnedTintBind = false
+-- ☠ TWO LATCHES, TWO FAULTS. These shared one flag: the recovery path's re-init throw and
+-- the steady-state StyleOneSlot throw. Different causes, different fixes -- and because
+-- the re-init one fires first (it runs inside the recovery branch), a single early
+-- recovery failure blinded every later styling error for the whole session.
+local warnedSlotReinit = false
 local warnedSlotStyle = false
 
 -- Slot plan from settings.
@@ -2148,8 +2153,8 @@ local function StyleDispelSlots(frame, db, h, slots)
                 -- it is the likeliest place to throw: the art was just found forbidden.
                 if info.roles then
                     local okInit, errInit = pcall(DispelSlotSecureInit, btn, info, db, frame)
-                    if not okInit and not warnedSlotStyle then
-                        warnedSlotStyle = true
+                    if not okInit and not warnedSlotReinit then
+                        warnedSlotReinit = true
                         if DF.DebugWarn then
                             DF:DebugWarn("DISPEL", "slot re-init %s failed: %s",
                                 tostring(info.key), tostring(errInit))

--- a/DandersFrames/Features/FlatRaidFrames.lua
+++ b/DandersFrames/Features/FlatRaidFrames.lua
@@ -809,7 +809,8 @@ end
 -- it expands symmetrically from its center point
 function FlatRaidFrames:ResizeInnerContainer()
     if not self.innerContainer or not self.header then return end
-    DF:Debug("FLATRAID", "ResizeInnerContainer: recalculating")
+    -- (Removed) an entry trace. This function logs its RESULT further down, which is the
+    -- part worth having; announcing that it had started added nothing.
     
     local db = GetRaidDB()
     if not db then return end
@@ -895,7 +896,8 @@ function FlatRaidFrames:UpdateContainerSize()
         math.floor(oldW + 0.5), math.floor(oldH + 0.5),
         math.floor(containerWidth + 0.5), math.floor(containerHeight + 0.5),
         tostring(db.raidUseGroups))
-    DebugPrint("Container size:", containerWidth, "x", containerHeight)
+    -- (Removed) a restatement: the line directly above already reports both dimensions,
+    -- rounded, alongside the grouped/flat mode that produced them.
 end
 
 -- ============================================================
@@ -924,7 +926,14 @@ function FlatRaidFrames:UpdateSorting()
     end
 
     -- FrameSort integration: yield sorting to FrameSort when active
-    if DF:IsFrameSortActive() then return end
+    -- ★ SAY SO. Handing sorting to another addon is a top-tier "my sorting stopped working"
+    -- cause, and it returned in silence one line above the "UpdateSorting: starting"
+    -- heartbeat -- so the log showed neither a start nor a reason, which reads as this
+    -- function never having been called.
+    if DF:IsFrameSortActive() then
+        DF:Debug("FLATRAID", "UpdateSorting: yielding to FrameSort, not sorting here")
+        return
+    end
 
     DF:Debug("FLATRAID", "UpdateSorting: starting")
 
@@ -1285,8 +1294,17 @@ function FlatRaidFrames:Initialize()
     
     self:CreateFrames()
     self.initialized = true
-    
-    DebugPrint("Initialization complete")
+
+    -- ☠ THIS SAID "Initialization complete" UNCONDITIONALLY. CreateFrames can bail for
+    -- several reasons and leave self.header nil, and `initialized` is set regardless -- so
+    -- the log asserted success on exactly the runs that failed, and the flag then stopped
+    -- anything from retrying. A line reporting an outcome it never checked is worse than no
+    -- line: it closes the investigation at the point it should open it.
+    if self.header then
+        DebugPrint("Initialization complete")
+    else
+        DebugPrint("WARNING: initialization finished with NO HEADER - CreateFrames bailed, flat raid will not render")
+    end
 end
 
 function FlatRaidFrames:Reinitialize()

--- a/DandersFrames/Features/FrameSort.lua
+++ b/DandersFrames/Features/FrameSort.lua
@@ -103,7 +103,7 @@ local function SortPartyFrames(units)
     local nameList = UnitsToNameList(units)
     if nameList == "" then return false end
 
-    DF:Debug("FRAMESORT", "Sorting party frames:", nameList)
+    DF:Debug("FRAMESORT", "Sorting party frames: %s", nameList)
 
     DF.partyHeader:SetAttribute("nameList", nameList)
     DF.partyHeader:SetAttribute("sortMethod", "NAMELIST")
@@ -124,7 +124,7 @@ local function SortFlatRaidFrames(units)
     local nameList = UnitsToNameList(units)
     if nameList == "" then return false end
 
-    DF:Debug("FRAMESORT", "Sorting flat raid frames:", nameList)
+    DF:Debug("FRAMESORT", "Sorting flat raid frames: %s", nameList)
 
     -- Set nameList FIRST, then clear group attrs (issue #543)
     header:SetAttribute("nameList", nameList)
@@ -184,7 +184,7 @@ local function SortGroupedRaidFrames(units)
             local nameList = tconcat(groupNamesBuf, ",")
 
             if nameList ~= "" then
-                DF:Debug("FRAMESORT", "Sorting raid group", groupIndex, ":", nameList)
+                DF:Debug("FRAMESORT", "Sorting raid group %d: %s", groupIndex, nameList)
                 -- Set nameList FIRST, then clear group attrs (issue #543)
                 header:SetAttribute("nameList", nameList)
                 header:SetAttribute("sortMethod", "NAMELIST")
@@ -250,7 +250,7 @@ local function SortArenaFrames(units)
     end
 
     local nameList = tconcat(namesBuf, ",")
-    DF:Debug("FRAMESORT", "Sorting arena frames:", nameList)
+    DF:Debug("FRAMESORT", "Sorting arena frames: %s", nameList)
 
     DF.arenaHeader:SetAttribute("nameList", nameList)
     DF.arenaHeader:SetAttribute("sortMethod", "NAMELIST")

--- a/DandersFrames/Features/PinnedFrames.lua
+++ b/DandersFrames/Features/PinnedFrames.lua
@@ -2775,6 +2775,15 @@ function PinnedFrames:PruneOrphanedSets()
             --    everything. Header/container hides are combat-protected; in
             --    lockdown the tracking is left intact too, so the pendingPrune
             --    re-run at regen repeats the full teardown.
+            -- ★ THE ORPHAN CASE, AND IT USED TO BE COMPLETELY SILENT. This whole function
+            -- exists for "a pinned frame stuck on screen after leaving a raid", and it
+            -- logged nothing at all -- not when it found an orphan, not when combat stopped
+            -- it from hiding one. So the exact report it was written to answer produced no
+            -- evidence that it had even run, let alone what it did.
+            if self.headers[i] or self.containers[i] or self.labels[i] then
+                DF:Debug("PINNED", "prune: set %d has no config in this mode%s - hiding and untracking",
+                    i, inCombat and " (in combat: hide deferred, tracking kept)" or "")
+            end
             if self.headers[i] then
                 if inCombat then
                     self.pendingPrune = true
@@ -3239,26 +3248,38 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
             return  -- Reinitialize handles everything
         end
         
+        -- ★ EVERY DEFERRAL IN THIS FILE WARNS AND NOTHING LOGGED THE RESUME. Six sites say
+        -- "in combat, deferring"; none of the drains below said anything, so a log ending
+        -- at "deferring" could not tell you whether the work ever happened -- which is the
+        -- difference between "combat delayed it" and "it never came back", and those get
+        -- reported identically. One line per drain closes it.
         -- Process pending initialization after combat
         if PinnedFrames.pendingInitialize then
             PinnedFrames.pendingInitialize = nil
+            DF:Debug("PINNED", "regen: resuming deferred Initialize")
             PinnedFrames:Initialize()
             PinnedFrames:ProcessAllSets()
         end
-        
+
         -- Process pending updates after combat
         if PinnedFrames.pendingNameListUpdate then
+            local n = 0
             for setIndex, _ in pairs(PinnedFrames.pendingNameListUpdate) do
+                n = n + 1
                 PinnedFrames:UpdateHeaderNameList(setIndex)
             end
             PinnedFrames.pendingNameListUpdate = nil
+            DF:Debug("PINNED", "regen: resumed %d deferred name-list update(s)", n)
         end
-        
+
         if PinnedFrames.pendingVisibilityUpdate then
+            local n = 0
             for setIndex, enabled in pairs(PinnedFrames.pendingVisibilityUpdate) do
+                n = n + 1
                 PinnedFrames:SetEnabled(setIndex, enabled)
             end
             PinnedFrames.pendingVisibilityUpdate = nil
+            DF:Debug("PINNED", "regen: resumed %d deferred visibility change(s)", n)
         end
 
         -- Replay a prune whose container/header hides were blocked by combat
@@ -3266,6 +3287,7 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
         -- After the SetEnabled replays above, so the re-run sees final state.
         if PinnedFrames.pendingPrune then
             PinnedFrames.pendingPrune = nil
+            DF:Debug("PINNED", "regen: replaying deferred prune")
             PinnedFrames:PruneOrphanedSets()
         end
 
@@ -3273,10 +3295,13 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, ...)
         -- in combat. Skipped harmlessly when pendingReinitialize already ran above
         -- (it returns early and re-applies every set's layout via ProcessAllSets).
         if PinnedFrames.pendingLayoutUpdate then
+            local n = 0
             for idx in pairs(PinnedFrames.pendingLayoutUpdate) do
+                n = n + 1
                 PinnedFrames:ApplyLayoutSettings(idx)
             end
             PinnedFrames.pendingLayoutUpdate = nil
+            DF:Debug("PINNED", "regen: resumed %d deferred layout update(s)", n)
         end
 
         -- Reset slot allocator + reapply layout now that we're out of combat.

--- a/DandersFrames/Features/Range.lua
+++ b/DandersFrames/Features/Range.lua
@@ -361,20 +361,26 @@ local function UpdateRangeSpell()
         if IsPlayerSpell(userSpellID) then
             currentFriendlySpell = userSpellID
             currentHostileSpell = userSpellID
+            DF:Debug("RANGE", "spell from user override: %d", userSpellID)
         else
             -- User spell not known (maybe changed spec/talents) - clear so auto-detect runs next call
             currentFriendlySpell = nil
             currentHostileSpell = nil
+            -- Worth a WARN: the user picked this deliberately and it is silently not being
+            -- used, which reads to them as the setting being ignored.
+            DF:DebugWarn("RANGE", "user range spell %d is not known to this character - auto-detect will run instead", userSpellID)
         end
         return
     end
-    
+
     -- Try spec-specific spells (validated with IsPlayerSpell)
     if specID and specSpells[specID] then
         local spells = specSpells[specID]
         currentFriendlySpell = spells.friendly and IsPlayerSpell(spells.friendly) and spells.friendly or nil
         currentHostileSpell = spells.hostile and IsPlayerSpell(spells.hostile) and spells.hostile or nil
         if currentFriendlySpell or currentHostileSpell then
+            DF:Debug("RANGE", "spell from spec %s: friendly=%s hostile=%s",
+                tostring(specID), tostring(currentFriendlySpell), tostring(currentHostileSpell))
             return
         end
     end
@@ -384,12 +390,23 @@ local function UpdateRangeSpell()
         local spells = classFallbacks[playerClass]
         currentFriendlySpell = spells.friendly and IsPlayerSpell(spells.friendly) and spells.friendly or nil
         currentHostileSpell = spells.hostile and IsPlayerSpell(spells.hostile) and spells.hostile or nil
+        DF:Debug("RANGE", "spell from class fallback: friendly=%s hostile=%s",
+            tostring(currentFriendlySpell), tostring(currentHostileSpell))
         return
     end
-    
-    -- Ultimate fallback
+
+    -- ☠ THE SILENT DEGRADE, AND IT WAS THE WHOLE CATEGORY'S BLIND SPOT. With no spell on
+    -- either side, range checking drops to CheckInteractDistance / always-in-range for the
+    -- rest of the session: fading either stops working or sticks on, which is the most
+    -- common real complaint about this module. It resolved to nil and said nothing, so the
+    -- log was indistinguishable from a healthy session that simply had no range
+    -- transitions -- RANGE only ever logged transitions, so empty meant both "fine" and
+    -- "dead". Every outcome above reports now, so the first line after enabling the
+    -- category answers "which spell did it pick", instead of leaving it to be inferred.
     currentFriendlySpell = nil
     currentHostileSpell = nil
+    DF:DebugWarn("RANGE", "no range spell for class %s (spec %s) - falling back to interact distance",
+        tostring(playerClass), tostring(specID))
 end
 
 -- ============================================================

--- a/DandersFrames/Features/SecureSort.lua
+++ b/DandersFrames/Features/SecureSort.lua
@@ -1241,4 +1241,6 @@ specScanFrame:SetScript("OnEvent", function()
     end)
 end)
 
-DebugPrint("SecureSort.lua loaded (geometry calculators + spec cache)")
+-- (Removed) a file-scope load line. Never printed in any session: chunk-level logging
+-- runs before the console exists. Doubly pointless here since it announced a file that
+-- is mostly deleted.

--- a/DandersFrames/FilterRegistry/Registry.lua
+++ b/DandersFrames/FilterRegistry/Registry.lua
@@ -869,6 +869,19 @@ function R:ResolveSelection(selection, showAll)
     local anySel = (selection.presets and next(selection.presets))
         or (selection.customs and next(selection.customs))
     if not anySel and not selection.uncategorised then
+        -- ☠ THE FAIL-OPEN, AND IT IS THIS CATEGORY'S MOST CONSEQUENTIAL BRANCH. "Nothing
+        -- selected" resolves to SHOW EVERYTHING -- the v4->v5 "all buffs until I toggle
+        -- something" signature -- and it logged nothing at its source. It was visible only
+        -- second-hand, as include=none in a container dump, and only for some rows. FILTER
+        -- meanwhile had one INFO in the whole addon (a one-shot migration replay), so the
+        -- category was effectively failure-only and this was the failure it was missing.
+        -- ⚠ Latched on the selection table: this sits on the render path, so an unlatched
+        -- line would fire per row per frame. The table is rebuilt when the selection
+        -- changes, so a genuine re-occurrence still reports.
+        if not selection._dfFailOpenLogged then
+            selection._dfFailOpenLogged = true
+            DF:DebugWarn("FILTER", "ResolveSelection: nothing selected - falling back to SHOW ALL")
+        end
         return { kind = "all" } -- nothing selected: safe fallback
     end
 

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -94,7 +94,13 @@ AuraContainer._ownTestPreview = true
 
 -- One-time-per-process warning latches so a guarded failure (curve bug, border
 -- taint, native dispel reject) logs ONCE, not once per button.
-local warnedCurve, warnedBorder, warnedNativeDispel = false, false, false
+local warnedCurve, warnedBorder = false, false
+-- ☠ ONE LATCH PER FAILURE, NOT PER SUBSYSTEM. warnedNativeDispel was shared between the
+-- dispel BORDER bind and the dispel TEXT bind -- two different calls with two different
+-- causes -- so whichever failed first silenced the other for the rest of the session.
+-- Same defect as the warnedRestyle/warnedInitFrame split below; found by audit, not by a
+-- report, because that is the nature of it: the second failure never spoke.
+local warnedDispelBorder, warnedDispelText = false, false
 -- (warnedMouse was a third latch here with no warning behind it — removed.)
 local warnedRestyle, warnedRefresh = false, false
 local warnedCreate = false
@@ -102,7 +108,10 @@ local warnedCreate = false
 -- because applyGroupTuning runs per frame per settings change; one line is enough
 -- to name the offending consumer.
 local warnedFilterString = false
-local warnedPandemic = false
+-- ☠ THREE SITES, THREE LATCHES. One `warnedPandemic` covered the border apply, the
+-- region add and the cover add -- so a single early failure in any one of them hid the
+-- other two for the session. Same split, same reasoning, as the dispel pair above.
+local warnedPandemicBorder, warnedPandemicRegion, warnedPandemicCover = false, false, false
 
 -- Animations SAFE to run on an OVERLAY-mode border (Aura Designer). These render
 -- entirely on DF-owned child regions of the border (edge alpha ticks + DF_DASH's
@@ -1703,8 +1712,8 @@ local function styleButton_regions(slot, config)
                     end
                     DF.Border:Apply(slot.dfPandemicBorder, bs)
                 end)
-                if not ok and not warnedPandemic then
-                    warnedPandemic = true
+                if not ok and not warnedPandemicBorder then
+                    warnedPandemicBorder = true
                     DF:DebugWarn(DBG, "pandemic border apply failed: %s", tostring(err))
                 end
             end
@@ -1962,17 +1971,20 @@ local function bindNative(slot, config)
     -- wrong before.
     --
     -- The stamp lands AFTER the pcall, not before: a bind-once flag set up front latches
-    -- a FAILED bind permanently, and warnedPandemic is one-shot per session, so the
+    -- a FAILED bind permanently, and the warn latch is one-shot per session, so the
     -- second failure would be silent too. (Same fix the duration-text and dispel binds
-    -- already carry.) A client older than PTR 8 has no AddPandemicRegion, so the gate
+    -- already carry.) ★ The latch is now warnedPandemicRegion, one of three -- this
+    -- comment said `warnedPandemic`, a single flag shared with the border and cover
+    -- sites, which meant the "second failure is silent" it warns about was ALSO true
+    -- across the three of them. Split; the reasoning here was right and under-applied. A client older than PTR 8 has no AddPandemicRegion, so the gate
     -- simply never matches and the feature is absent rather than erroring — the region
     -- is never created either, since the factory/rows only emit a spec when it exists.
     if slot.dfPandemicHolder and slot.AddPandemicRegion and not slot._boundPandemic then
         local ok, err = pcall(slot.AddPandemicRegion, slot, slot.dfPandemicHolder)
         if ok then
             slot._boundPandemic = true
-        elseif not warnedPandemic then
-            warnedPandemic = true
+        elseif not warnedPandemicRegion then
+            warnedPandemicRegion = true
             DF:DebugWarn(DBG, "AddPandemicRegion failed (build still ok): %s", tostring(err))
         end
     end
@@ -2013,8 +2025,8 @@ local function bindNative(slot, config)
             local ok, err = pcall(slot.AddPandemicRegion, slot, cover)
             if ok then
                 slot._boundPandemicCover = true
-            elseif not warnedPandemic then
-                warnedPandemic = true
+            elseif not warnedPandemicCover then
+                warnedPandemicCover = true
                 DF:DebugWarn(DBG, "AddPandemicRegion (cover) failed: %s", tostring(err))
             end
         end
@@ -2070,8 +2082,8 @@ local function bindNative(slot, config)
             if ok then
                 slot._boundAuraBorder = true
                 slot._dfDispelCurveGen = DF.dispelCurveGen
-            elseif not warnedNativeDispel then
-                warnedNativeDispel = true
+            elseif not warnedDispelBorder then
+                warnedDispelBorder = true
                 DF:DebugWarn(DBG, "SetAuraBorder failed (build still ok): %s", tostring(err))
             end
         end
@@ -2102,8 +2114,8 @@ local function bindNative(slot, config)
                     slot:SetAuraSymbol(slot.dfSymbol, opts)
                 end
             end)
-            if not ok and not warnedNativeDispel then
-                warnedNativeDispel = true
+            if not ok and not warnedDispelText then
+                warnedDispelText = true
                 DF:DebugWarn(DBG, "SetDispelTypeText failed (build still ok): %s", tostring(err))
             end
         end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5519,6 +5519,9 @@ function Handle:_applyIdentityGate()
     -- skipped when you CAN assist, not when you cannot -- so this is not the same
     -- condition in a different hat. It is driven by "is identity data trustworthy right
     -- now", which is what BOTH directions actually turn on.
+    -- Collected across both blocks and emitted once at the end; see the note in the park
+    -- block for why these were two lines and why one is better.
+    local parkFlip, hideFlip
     local newParked = (hide or self._idGateUntrusted) and true or nil
     if self._idGateParked ~= newParked then
         local prevParked = self._idGateParked
@@ -5526,9 +5529,14 @@ function Handle:_applyIdentityGate()
         -- each gated group's maxFrameCount, so it has to be set before the call — which is
         -- why this cannot simply latch on success.
         self._idGateParked = newParked
-        GateLog("park %s unit=%s why=%s",
-            newParked and "ON (gated groups -> 0)" or "OFF (gated groups restored)",
-            tostring(self.config and self.config.unit), tostring(why or "-"))
+        -- ☠ LOG DEFERRED TO THE JOINT LINE BELOW. park and hide are computed from the
+        -- SAME probe and flip together on a HELPFUL pool, so this emitted two lines per
+        -- unit per transition carrying the same unit and the same why. The sweep walks
+        -- every handle and every slot handle, and its triggers are global -- one
+        -- PLAYER_ENTERING_WORLD re-sweeps at 0s, 2s and 6s -- so a 40-unit raid produced
+        -- hundreds of lines from a single zone-in, in a category that defaults ON. One
+        -- line per transition says strictly more, because it shows both halves together.
+        parkFlip = newParked and "ON" or "OFF"
         -- ApplyTuning is the LIVE setter path and reads _idGateParked, so this is one
         -- call rather than a rebuild.
         local ok = true
@@ -5547,7 +5555,13 @@ function Handle:_applyIdentityGate()
             -- sweep recomputes the verdict from live conditions each time, so it converges
             -- on whatever is true then rather than on what was true when it broke.
             self._idGateParked = prevParked
-            GateLog("PARK APPLY FAILED unit=%s (combat=%s) — reverted, retries on next sweep",
+            -- Cleared so the joint line cannot claim a flip that was just undone.
+            parkFlip = nil
+            -- ⚠ WARN, not the INFO GateLog path: this is a hard failure that re-fires
+            -- every sweep until it clears, and at INFO it was invisible to anyone with
+            -- the log level raised -- i.e. to anyone filtering out the chatter it is
+            -- buried in.
+            DF:DebugWarn("IDGATE", "PARK APPLY FAILED unit=%s (combat=%s) - reverted, retries on next sweep",
                 tostring(self.config and self.config.unit),
                 tostring(InCombatLockdown and InCombatLockdown() or false))
         end
@@ -5555,11 +5569,7 @@ function Handle:_applyIdentityGate()
 
     local newHidden = hide or nil
     if self._idGateHidden ~= newHidden then
-        GateLog("hide %s unit=%s why=%s (vuln=%s srcRel=%s)",
-            newHidden and "ON" or "OFF",
-            tostring(self.config and self.config.unit), tostring(why or "-"),
-            tostring(self._idGateVulnerable or false),
-            tostring(self._idGateSourceRelative or false))
+        hideFlip = newHidden and "ON" or "OFF"
         self._idGateHidden = newHidden
         -- ⚠ TRANSITION ONLY. The sweep runs on every target change / roster event /
         -- loading screen; applying visibility unconditionally made every pass a
@@ -5568,6 +5578,19 @@ function Handle:_applyIdentityGate()
         -- A stable verdict now touches nothing. The rebuilt-onto-non-vulnerable
         -- case still clears its stale flag: that IS a transition.
         self:_applyVisibility()
+    end
+
+    -- ★ ONE LINE PER GATE TRANSITION, carrying both halves. Reads
+    --   gate unit=party2 why=- park=OFF hide=OFF (vuln=true srcRel=true)
+    -- where a dash in a slot means that half did not flip on this pass -- which is itself
+    -- worth seeing, because park and hide flipping apart is the interesting case and used
+    -- to be indistinguishable from two ordinary lines that happened to arrive together.
+    if parkFlip or hideFlip then
+        GateLog("gate unit=%s why=%s park=%s hide=%s (vuln=%s srcRel=%s)",
+            tostring(self.config and self.config.unit), tostring(why or "-"),
+            parkFlip or "-", hideFlip or "-",
+            tostring(self._idGateVulnerable or false),
+            tostring(self._idGateSourceRelative or false))
     end
 end
 

--- a/DandersFrames/Frames/Bars.lua
+++ b/DandersFrames/Frames/Bars.lua
@@ -2870,6 +2870,18 @@ function DF:UpdateRoleIcon(frame, source, roleOverride)
 
     if not role or role == "NONE" then
         frame.roleIcon:Hide()
+        -- ☠ THE LATCH HAS TO BE WRITTEN HERE TOO, OR IT GOES STALE AND SWALLOWS THE RETURN
+        -- EDGE. This return bypassed the edge-trigger below, so a unit whose role dropped
+        -- to NONE and later resolved back to the SAME role compared equal against a latch
+        -- still holding the pre-drop state: no transition, no line, and the icon
+        -- reappearing with no record of having gone. Exactly the bug class the edge-trigger
+        -- was added to prevent, on the reverse edge.
+        if frame.dfLastRoleShown ~= false or frame.dfLastRole ~= role then
+            DF:Debug("ROLE", "%s: role=%s show=false (no role assigned)",
+                tostring(frame.unit), tostring(role))
+            frame.dfLastRoleShown = false
+            frame.dfLastRole = role
+        end
         return
     end
     

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -3621,7 +3621,11 @@ function DF:UpdateRaidGroupOrderAttributes()
         handler:SetAttribute("groupdisplaypos" .. groupNum, displayPos)
     end
     
-    if DF:DebugActive("HEADERS") then
+    -- ☠ The guard must name the category the LINE uses. This asked DebugActive("HEADERS")
+    -- and then logged to ROSTER, so enabling ROSTER alone -- the obvious choice for a
+    -- group-order problem -- produced nothing, and the line appeared only for someone who
+    -- happened to have HEADERS switched on as well.
+    if DF:DebugActive("ROSTER") then
         local orderStr = table.concat(effectiveOrder, ",")
         DF:Debug("ROSTER", "UpdateRaidGroupOrderAttributes: group display order: %s", orderStr)
     end

--- a/DandersFrames/Frames/Headers.lua
+++ b/DandersFrames/Frames/Headers.lua
@@ -5015,13 +5015,22 @@ function DF:UpdateHeaderVisibility(skipRaidReposition)
 end
 
 function DF:UpdateRaidHeaderVisibility(skipReposition)
+    -- ★ THE THREE SILENT EXITS, AND THEY ARE THE THREE STATES USERS REPORT. The entry log
+    -- sat BELOW all of them, so "my raid frames didn't come back" produced no line at all
+    -- on every path that could actually cause it -- the log looked as though the function
+    -- had never been called. Each reason is now distinguishable from the others and from
+    -- a normal run.
     if InCombatLockdown() then
         DF.pendingRaidHeaderVisibility = true
+        DF:Debug("VISIBILITY", "UpdateRaidHeaderVisibility: in combat, deferred to regen")
         return
     end
 
     -- Guard against infinite recursion: SetEnabled(false) calls back here
-    if DF._updatingRaidHeaderVisibility then return end
+    if DF._updatingRaidHeaderVisibility then
+        DF:Debug("VISIBILITY", "UpdateRaidHeaderVisibility: re-entered while running, dropped")
+        return
+    end
     DF._updatingRaidHeaderVisibility = true
 
     DF:Debug("VISIBILITY", "UpdateRaidHeaderVisibility: skipReposition=%s", tostring(skipReposition))
@@ -5031,6 +5040,7 @@ function DF:UpdateRaidHeaderVisibility(skipReposition)
     -- calls to UpdateRaidHeaderVisibility are permanently blocked until ReloadUI.
     if DF.testMode or DF.raidTestMode then
         DF._updatingRaidHeaderVisibility = nil
+        DF:Debug("VISIBILITY", "UpdateRaidHeaderVisibility: test mode active, live frames left hidden")
         return
     end
 

--- a/DandersFrames/Frames/Pets.lua
+++ b/DandersFrames/Frames/Pets.lua
@@ -540,12 +540,34 @@ function DF:SetPetFrameVisible(frame, visible)
         if not InCombatLockdown() then
             local owner = frame.ownerFrame
             if owner then
-                pcall(frame.SetFrameStrata, frame, owner:GetFrameStrata())
-                pcall(frame.SetFrameLevel, frame, owner:GetFrameLevel() + 15)
+                -- ★ These pcalls were swallowing their result entirely. A refused strata or
+                -- level write is exactly the z-order fault this block exists to prevent --
+                -- the pet rendering under a neighbouring health bar -- and it degraded
+                -- silently and permanently, because nothing re-runs this on its own.
+                local okS = pcall(frame.SetFrameStrata, frame, owner:GetFrameStrata())
+                local okL = pcall(frame.SetFrameLevel, frame, owner:GetFrameLevel() + 15)
+                if not (okS and okL) and not frame._dfPetLayerWarned then
+                    frame._dfPetLayerWarned = true
+                    DF:DebugWarn("PET", "SetPetFrameVisible: %s layering refused (strata=%s level=%s) - pet may render under a neighbour",
+                        frame.unit or "?", tostring(okS), tostring(okL))
+                end
             end
             frame:Show()
+            -- Cleared on the successful out-of-combat show, so the next fight can report
+            -- again. A session-long latch would say "this happened once" when the useful
+            -- fact is "this happens every pull".
+            frame._dfPetLockdownWarned = nil
         else
-            DF:Debug("PET", "SetPetFrameVisible: %s wants SHOW but InCombatLockdown - using alpha only", frame.unit or "?")
+            -- ☠ LATCHED PER FRAME. This is the combat branch of a function called from every
+            -- owner UNIT_HEALTH and UNIT_FLAGS and from every pet UNIT_HEALTH, so ten pets
+            -- taking damage emitted dozens of identical lines per second -- into a category
+            -- that defaults ON, evicting whatever the console was opened to capture. The
+            -- frame write beside it was already guarded for exactly this reason and the log
+            -- line was not. The state is per frame and static for the fight, so one says it.
+            if not frame._dfPetLockdownWarned then
+                frame._dfPetLockdownWarned = true
+                DF:Debug("PET", "SetPetFrameVisible: %s wants SHOW but InCombatLockdown - using alpha only", frame.unit or "?")
+            end
         end
     else
         -- Mark as hidden and set alpha to 0

--- a/DandersFrames/Locales/enUS.lua
+++ b/DandersFrames/Locales/enUS.lua
@@ -1261,6 +1261,7 @@ L["Medium Health (50%)"] = true
 L["Minimal"] = true
 L["Minimap"] = true
 L["Minimum Log Level"] = true
+L["Lines below this level are not recorded at all, so raising it keeps a long capture readable and stops chatter evicting the part you need. Lowering it again only affects what is logged from that point on."] = true
 L["Missing Buff Alpha"] = true
 L["Missing Buffs"] = true
 L["Missing Health"] = true

--- a/DandersFrames/TextDesigner/Migration.lua
+++ b/DandersFrames/TextDesigner/Migration.lua
@@ -472,4 +472,6 @@ function DF:RestoreMigratedHealthText()
     end
 end
 
-DF:Debug("TD", "Migration module loaded (channel=%s)", tostring(DF.RELEASE_CHANNEL))
+-- (Removed) a file-scope load line -- same guaranteed no-op as the one in
+-- TextDesigner.lua. The migration OUTCOMES below are the useful signal and they log
+-- from a real runtime path.

--- a/DandersFrames/TextDesigner/Render.lua
+++ b/DandersFrames/TextDesigner/Render.lua
@@ -460,17 +460,19 @@ end
 -- Renders a single elem on a frame. Called per-element from UpdateFrame.
 -- source is a DataSource (Live or Mock).
 local function updateOne(frame, elem, source, globalDefaults, enabledById)
-    -- ☠ GUARDED, and this is the most load-bearing guard in the file. This is the
-    -- per-ELEMENT entry point, and TD renders are driven from DF:UpdateHealthFast —
-    -- per unit per health tick in combat. Unguarded, the three tostring() calls
-    -- allocated on every element of every frame on every tick. DF:Debug drops the
-    -- line, but the CALLER builds the arguments before it can, and `TD` is a
-    -- `noisy` category so it ships DISABLED — i.e. this was pure waste for
-    -- essentially every user. Same idiom as the guard in UpdateTextDesigner below.
-    if DF:DebugActive("TD") then
-        DF:Debug("TD", "updateOne: id=%s type=%s enabled=%s",
-            tostring(elem.id), tostring(elem.contentType), tostring(elem.enabled))
-    end
+    -- ☠ (Removed) a per-ELEMENT entry trace logging id/type/enabled. It was the largest
+    -- single source of log volume in the addon and reported nothing the element's own
+    -- config does not already say -- an entry marker, never an outcome.
+    --
+    -- Measured before removal: renders are driven from DF:UpdateHealthFast, so per unit
+    -- per health tick, and one render emitted 2 + E lines for E elements. A 20-frame raid
+    -- at three elements each is 100 lines per render and thousands per second sustained --
+    -- the 10,000-line buffer overwrote itself in under two seconds, so enabling TD
+    -- destroyed the trace it was enabled to capture.
+    --
+    -- The guard was right and is not the lesson; the line was. Render:UpdateFrame already
+    -- reports the unit and element COUNT once per frame, and the outcome detail lives
+    -- further down this function where it earns its cost.
     if not elem.enabled then
         local existing = frame._tdFontStrings and frame._tdFontStrings[elem.id]
         if existing then existing:Hide() end
@@ -833,7 +835,11 @@ end
 -- same frame collapse into a single render carrying the UNION of their hints.
 function DF:UpdateTextDesigner(frame, hint)
     if not frame then
-        DF:Debug("TD", "UpdateTextDesigner: no frame")
+        -- ☠ Named for THIS function. Both this and RenderTextDesignerNow emitted the
+        -- identical string, so the log could not say which of the two was called with no
+        -- frame -- the coalescing wrapper or the render itself, which are reached from
+        -- different callers and mean different things.
+        DF:Debug("TD", "UpdateTextDesigner (coalescing entry): no frame")
         return
     end
     hint = hint or "all"

--- a/DandersFrames/TextDesigner/Resolver.lua
+++ b/DandersFrames/TextDesigner/Resolver.lua
@@ -354,12 +354,11 @@ RESOLVERS.group = function(elem, source)
         end
         return ""
     end
-    -- Guarded: the tostring() args are evaluated by the CALLER, so an unguarded
-    -- DF:Debug allocated two strings per call even with the trace off.
-    if DF:DebugActive("TD") then
-        DF:Debug("TD", "group resolver: elem id=%s items=%d separator=%q",
-            tostring(elem.id), #elem.groupItems, tostring(elem.groupSeparator or " / "))
-    end
+    -- ☠ (Removed) an ENTRY line reporting id/items/separator. Two lines per group element
+    -- per render, and this was the half that restated config. Its useful half -- how many
+    -- items survived -- is now folded into the single outcome line at the end of this
+    -- function, which reports items AND parts together so a DROP is visible on one line
+    -- instead of requiring the reader to diff two.
     local MS = getMS()
     local parts = groupParts
     for pi = #parts, 1, -1 do parts[pi] = nil end
@@ -413,8 +412,12 @@ RESOLVERS.group = function(elem, source)
             end
         end
     end
+    -- ★ ONE line per group element, carrying both counts. `parts < items` is the whole
+    -- diagnostic -- items were dropped -- and it used to require reading this line against
+    -- an entry line further up. Stated directly, and the entry line is gone.
     if DF:DebugActive("TD") then
-        DF:Debug("TD", "group resolver: parts collected=%d", #parts)
+        DF:Debug("TD", "group resolver: elem id=%s items=%d parts=%d",
+            tostring(elem.id), #elem.groupItems, #parts)
     end
     -- IMPORTANT: cannot use table.concat() here — it throws on secret-tainted
     -- entries ("invalid value (secret) at index N in table for 'concat'").

--- a/DandersFrames/TextDesigner/TextDesigner.lua
+++ b/DandersFrames/TextDesigner/TextDesigner.lua
@@ -38,4 +38,7 @@ function DF.TextDesigner:EnsureDB(db)
     return db.textDesigner
 end
 
-DF:Debug("TD", "TextDesigner module loaded (channel=%s)", tostring(DF.RELEASE_CHANNEL))
+-- (Removed) a file-scope load line. Chunk-level Debug calls run before
+-- DebugConsole:Init binds debugDb from ADDON_LOADED, so they are guaranteed no-ops --
+-- this one still built its argument first. Use Core.lua's migration-trace buffer if
+-- something genuinely needs to report at load.

--- a/DandersFrames_Options/Features/Search.lua
+++ b/DandersFrames_Options/Features/Search.lua
@@ -960,7 +960,16 @@ function Search:ScrollToSection(tabName, sectionName)
         end
         if flashTarget then break end
     end
-    if not flashTarget then return end
+    -- ★ THE FAILURE THAT ACTUALLY HAPPENS. SEARCH's only other log call guards a load-order
+    -- slip that cannot occur in a shipped build, while THIS -- the section name no longer
+    -- resolving because it was renamed or moved into a group -- is the real "I clicked a
+    -- search result and nothing happened": the jump scrolls nowhere and never flashes, in
+    -- silence. Naming both halves makes it a one-line fix instead of a hunt.
+    if not flashTarget then
+        DF:DebugWarn("SEARCH", "ScrollToSection: %q not found on tab %q - jump did nothing",
+            tostring(sectionName), tostring(tabName))
+        return
+    end
 
     -- Put the section at the TOP of the viewport.
     --

--- a/DandersFrames_Options/GUI/Pages/Modules.lua
+++ b/DandersFrames_Options/GUI/Pages/Modules.lua
@@ -1946,9 +1946,14 @@ function DF._SetupGUIPagesPart5(GUI, CreateCategory, CreateSubTab, BuildPage, L,
             ["WARN"]  = L["Warnings + Errors"],
             ["ERROR"] = L["Errors Only"],
         }
-        AddToSection(GUI:CreateDropdown(self.child, L["Minimum Log Level"], logLevelOptions, debugProxy, "logLevel", function()
+        local logLevelDrop = GUI:CreateDropdown(self.child, L["Minimum Log Level"], logLevelOptions, debugProxy, "logLevel", function()
             if DF.DebugConsole then DF.DebugConsole:RefreshDisplay() end
-        end), 55, 1)
+        end)
+        -- ☠ The control DROPS lines below the chosen level now rather than hiding them, so
+        -- it is a real buffer lever and the tooltip has to say so. Read as a view filter it
+        -- would be set, a bug reproduced, and the missing detail treated as a bug of its own.
+        logLevelDrop.tooltip = L["Lines below this level are not recorded at all, so raising it keeps a long capture readable and stops chatter evicting the part you need. Lowering it again only affects what is logged from that point on."]
+        AddToSection(logLevelDrop, 55, 1)
 
         AddToSection(GUI:CreateSlider(self.child, L["Max Log Entries"], 100, 10000, 100, debugProxy, "maxLines", function()
             if DF.DebugConsole then

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -1684,15 +1684,16 @@ function GUI:CreateCheckbox(parent, label, dbTable, dbKey, callback, customGet, 
             container:UpdateOverrideIndicators(val)
         end
         
+        -- ☠ (Removed) three "calling X" entry traces, one immediately above each call.
+        -- Pure narration: the click itself is already logged above with its dbKey and
+        -- value, and the third restated DF:UpdateAll, which logs its own marker one line
+        -- later. Three log lines to say what the next statement says.
         if callback then 
-            DF:Debug("GUI", "checkbox OnClick: calling callback")
             callback() 
         end
         if parent.RefreshStates then 
-            DF:Debug("GUI", "checkbox OnClick: calling RefreshStates")
             parent:RefreshStates() 
         end
-        DF:Debug("GUI", "checkbox OnClick: calling DF:UpdateAll")
         DF:UpdateAll()
     end)
     


### PR DESCRIPTION
## What this is

A full audit of the debug console — all 34 declared categories, checked for four things: does silence mean "healthy" or "this never ran"; is anything on a hot enough path to evict the trace it was enabled to capture; does any line say something that is not true; and which failure paths report nothing at all.

It started from a concrete failure. Chasing a dispel bug with `DISPEL` and `AURACONTAINER` both enabled produced **zero entries**, and there was no way to tell whether that meant the subsystem was healthy, the code never ran, or the category was broken. That turned out to be a pattern rather than an oddity.

Nothing here changes behaviour outside logging, with one exception noted below.

## The setting that could not do its job

`DebugConsole:Log` formatted, sanitised, stored and counted **every** line regardless of `logLevel`. The setting was applied only in `CollectFilteredLines`, which renders the console and the export.

So "Errors Only" cost exactly as much as "Info (All)" and bought exactly as much buffer — the control that looks like the spam control was the one thing that could not control spam. Someone who set it, reproduced a bug and sent the log still had their trace evicted by INFO they had explicitly asked not to see.

The level is checked at write time now: below the threshold there is no format, no `pcall`, no string, no entry, no eviction.

⚠ **The trade, stated rather than buried:** a dropped line is gone, not hidden, so raising the level mid-session cannot recover earlier INFO. That is the same bargain as unticking a category, and it is what "Minimum Log Level" sitting directly above "Max Log Entries" reads as — both are buffer controls. The tooltip now says so, because read as a view filter this setting would generate a second bug report about the missing detail.

## Categories that could not evict what they were opened to capture

**Text Designer** was the worst by an order of magnitude. Renders are driven from `DF:UpdateHealthFast` — per unit, per health tick — and each emitted `2 + E` lines for E elements. A 20-frame raid at three elements each is 100 lines per render and thousands per second sustained: **the 10,000-line buffer overwrote itself in under two seconds.** Enabling TD reliably destroyed the trace it was enabled for. The per-element line logged id, type and enabled — all of it the element's own config, none of it an outcome — while the per-frame line above it already reports the unit and the element count. Removed. The group resolver's two lines are folded into one carrying both counts, so `parts < items` (items were dropped) reads on a single line instead of requiring the reader to diff two.

**The identity gate** emitted two lines per unit per transition, park and hide, computed from the same probe and carrying the same unit and reason. Its sweep walks every handle and every slot handle and its triggers are global — including a `PLAYER_ENTERING_WORLD` that re-sweeps at 0s, 2s and 6s — so a 40-unit raid produced hundreds of lines from one zone-in. Now one line per transition, and it says *more*: a dash marks a half that did not flip, which is the interesting case and used to be indistinguishable from two ordinary lines arriving together.

**Pet frames** logged from the combat branch of a function called on every owner `UNIT_HEALTH`/`UNIT_FLAGS` and every pet `UNIT_HEALTH` — dozens of identical lines per second with ten pets taking damage, in a category that defaults on. Latched per frame and cleared on the next successful out-of-combat show, so it still reports once per fight rather than once per session. The frame write beside it was already guarded for exactly this reason; only the log was missed.

**Secure sort** was the inverse: marked noisy and hidden by default, while most of that subsystem has been deleted as unreachable and only two of its call sites are reachable in live play. A hidden category with nothing in it is the worst outcome for whoever ticks it hoping for a trace. Unmarked.

## Lines that were never going to print

Four `DF:Debug` calls at file scope, in the Aura Designer factory, the Text Designer, its migration module and the secure-sort file. `DebugConsole:Init` binds its database from `ADDON_LOADED`, long after every file has been parsed, so a chunk-level log call is a guaranteed no-op that still builds its argument. None of them has produced a line in any session.

⚠ Removing the Text Designer one drops `tostring` from that file's `_ENV` reads — the deleted line was its only user. That is the single expected globals delta in this branch.

## Latches that hid the second failure

A session-wide `warned*` flag covering two or more unrelated failures means whichever fires first permanently silences the rest. Five instances, all the same shape:

- the dispel border bind and the dispel text bind shared one flag
- the pandemic border, region and cover binds shared one between **three** sites
- the dispel slot re-init and the slot style pass shared one — and because re-init runs inside the recovery path it fires first, so a single early recovery failure blinded every later styling error for the session

The pandemic case is the telling one: the comment beside it already explained why a bind-once flag must not latch a *failed* bind, and the warn flag it referenced was shared three ways — so the "second failure would be silent" it warned about was true across all three. Right reasoning, under-applied.

## Messages that were not true

- Two runtime-write lines claimed "wrote to real table" unconditionally while both writes sit inside guards, so on the one path worth debugging — the table absent — the log asserted a write that never happened.
- Flat raid said "Initialization complete" unconditionally; frame creation can bail and leave no header, and the initialised flag is set either way, so the log asserted success on exactly the runs that failed and the flag then stopped anything retrying.
- A group-order line was guarded on one category and logged to another, so enabling the obvious category produced nothing.
- Two different functions emitted the identical "no frame" string, so the log could not say which was called.
- Four sort lines passed their payload as a vararg to a format string with no specifier, so `string.format` discarded it — the name list is the entire diagnostic value of that category, and the per-group line lost its index too, giving eight identical entries.

## Failure paths that reported nothing

The most valuable class, because each is a state a user has reported or would.

**Pinned frames** — the orphan-pruning function had *zero* logging of any kind. It exists for "a pinned frame stuck on screen after leaving a raid" and could neither confirm it had run nor say what it found. And every deferral in that file warned without any drain logging the resume, so a log ending at "deferring" could not distinguish "combat delayed it and it completed" from "it never came back" — two outcomes reported identically and diagnosed very differently. All five drains now report.

**Header visibility** — the entry log sat *below* all three early exits, so "my raid frames didn't come back" produced no line on any path that could actually cause it. Combat deferral, re-entrancy drop and test-mode hold are now distinguishable from each other and from a normal run.

**Range** — logged transitions only, so an empty log meant both "healthy, nobody crossed the boundary" and "no spell was ever resolved and fading is dead". Spell selection reported none of its five outcomes; all do now, and the ultimate fallback — no spell either side, which silently degrades to interact distance for the rest of the session — is a warning, as is a rejected user override, since that was chosen deliberately and ignored without a word.

**Profile import** — validation bails with a distinct reason in twelve places and logged none of them, so "my import string doesn't work" produced an empty log while the function had the reason in hand and gave it only to the UI. Wrapped once rather than edited at twelve returns: twelve identical edits is twelve chances to drift, and a thirteenth return would miss it.

**Profile switching** logged a start and nothing else, with eleven one-time migrations and a full refresh in between — so "cleared runtime state" followed by silence was indistinguishable from a switch that half-applied and threw.

**Filter resolution** — its fail-open turns "nothing selected" into *show everything*, which is the v4-to-v5 "all buffs until I toggle something" signature, and it was silent at source; visible only second-hand in a container dump, and only for some rows.

**Click-casting** dropped a binding from the macro map in silence on both build-failure paths, leaving a key visible in the UI that does nothing. That file already argues the point at a sibling failure: *a binding that shows in the list and does nothing is worse than one that says why.* The two siblings never got it.

**Settings search** was instrumented at the one failure that cannot occur in a shipped build while the one that actually happens — a section name no longer resolving after a rename — was silent, which is the real "I clicked a search result and nothing happened".

## One behavioural fix found on the way

Role icons: the no-role-assigned early return hides the icon and returns **without writing the edge latch**, so a unit whose role dropped and later resolved back to the *same* role compared equal against a latch still holding the pre-drop state — no transition, no line, and the icon reappearing with no record. Exactly the bug class the edge-trigger exists to prevent, on the reverse edge.

## Verification

`luac -p` clean and `_ENV` global reads identical to this base on all 25 changed files, with the single documented `tostring` delta above. Every file kept its CRLF endings, verified by CR count equalling line count.

**Not confirmed in game.** This is a logging change, so confirmation is cheap: enable debug logging, play normally, and the categories that were silent should speak while the Text Designer and identity gate should be dramatically quieter. No changelog entries — nothing here is user-facing except the log level tooltip.

## Deliberately not attempted

Two findings are left open rather than guessed at. Auto-profile writes fire per slider tick while a runtime overlay is active, but fixing that means changing *when* the overlay reports rather than only its logging. And the spec cache — the melee/ranged split — has no logging at all; it deserves its own change rather than being folded into an audit.
