### PR TITLE
Tracker bugs: the identity-gate recovery that spent its only edge, plus four self-contained fixes

### DIFF
--- a/DandersFrames/AuraDesigner/Engine.lua
+++ b/DandersFrames/AuraDesigner/Engine.lua
@@ -107,28 +107,12 @@ function Engine:ForceRefreshAllFrames()
     -- Refresh the test previews too when the editor is used with test mode open.
     if (DF.testMode or DF.raidTestMode) and DF.UpdateAllTestAuraDesigner then
         DF:UpdateAllTestAuraDesigner()
-
-        -- ☠ AND RE-MEASURE INDICATOR INFO, which the line above had just invalidated.
-        -- Test mode's Indicator Info caches a rect per element and only rebuilds from
-        -- DF:RefreshTestFrames / DF:UpdateRaidTestFrames -- neither of which is on any
-        -- Aura Designer path. So every editor action that reaches this function moved,
-        -- created or destroyed indicators behind a region list that nobody rebuilt:
-        -- switching the designer preset with test mode open left the new preset's
-        -- indicators unhoverable until Indicator Info was toggled off and on, and the
-        -- elements it had NOT touched kept their marks throughout, which is what made
-        -- it read as "only the defensive icon has info" (Krathe, 2026-08-21).
-        -- ★ HERE rather than at the ~20 call sites: this is the single chokepoint every
-        -- one of them already funnels through, and a fix per site is a fix for the
-        -- sites someone happened to look at.
-        -- Deferred one tick for the reason the test-mode refresh defers its own call:
-        -- the containers were rebuilt on THIS tick and an anchor-derived rect is 0
-        -- until the layout settles, so measuring now would find nothing. (The settle
-        -- retry would recover it, but starting from a measurable pass is cheaper and
-        -- keeps the marks from blinking.)
-        if DF.UpdateTestLabels and C_Timer and C_Timer.After then
-            C_Timer.After(0, function()
-                if DF.UpdateTestLabels then DF:UpdateTestLabels() end
-            end)
-        end
+        -- ⚠ NO Indicator Info rebuild here, deliberately. One was added at this line
+        -- and it fixed only the editor's own actions: the designer PRESET bar changes
+        -- every indicator on screen without going through this function at all, so the
+        -- marks stayed stale exactly where they were first reported. The rebuild now
+        -- hangs off Factory:SyncFrame / Factory:ClearFrame — the mutation itself, which
+        -- every path reaches by definition. Do not re-add a caller-side hook here; it
+        -- would double-fire the one below and still not cover anything new.
     end
 end

--- a/DandersFrames/AuraDesigner/Engine.lua
+++ b/DandersFrames/AuraDesigner/Engine.lua
@@ -107,5 +107,28 @@ function Engine:ForceRefreshAllFrames()
     -- Refresh the test previews too when the editor is used with test mode open.
     if (DF.testMode or DF.raidTestMode) and DF.UpdateAllTestAuraDesigner then
         DF:UpdateAllTestAuraDesigner()
+
+        -- ☠ AND RE-MEASURE INDICATOR INFO, which the line above had just invalidated.
+        -- Test mode's Indicator Info caches a rect per element and only rebuilds from
+        -- DF:RefreshTestFrames / DF:UpdateRaidTestFrames -- neither of which is on any
+        -- Aura Designer path. So every editor action that reaches this function moved,
+        -- created or destroyed indicators behind a region list that nobody rebuilt:
+        -- switching the designer preset with test mode open left the new preset's
+        -- indicators unhoverable until Indicator Info was toggled off and on, and the
+        -- elements it had NOT touched kept their marks throughout, which is what made
+        -- it read as "only the defensive icon has info" (Krathe, 2026-08-21).
+        -- ★ HERE rather than at the ~20 call sites: this is the single chokepoint every
+        -- one of them already funnels through, and a fix per site is a fix for the
+        -- sites someone happened to look at.
+        -- Deferred one tick for the reason the test-mode refresh defers its own call:
+        -- the containers were rebuilt on THIS tick and an anchor-derived rect is 0
+        -- until the layout settles, so measuring now would find nothing. (The settle
+        -- retry would recover it, but starting from a measurable pass is cheaper and
+        -- keeps the marks from blinking.)
+        if DF.UpdateTestLabels and C_Timer and C_Timer.After then
+            C_Timer.After(0, function()
+                if DF.UpdateTestLabels then DF:UpdateTestLabels() end
+            end)
+        end
     end
 end

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -5923,6 +5923,15 @@ function Factory:SyncFrame(frame)
     -- framealpha / nametext / healthtext: intentionally NOT synced. No read-free,
     -- combat-safe port exists (see file-foot notes) — their GUI controls get the
     -- "Blizzard limitation" overlay in P4.7.
+
+    -- Test mode's Indicator Info measures these placements and caches a rect per one,
+    -- so a sync that moved, created or destroyed any of them has just invalidated its
+    -- region list. Called HERE rather than from whatever asked for the sync: this is
+    -- the mutation itself, so no caller can forget it (TL:Invalidate carries the full
+    -- reasoning, and coalesces the per-frame calls into one pass).
+    -- ⚠ dfIsTestFrame FIRST: this function is per-UNIT_AURA hot on live frames, and
+    -- that field read is the whole cost there.
+    if frame.dfIsTestFrame and DF.InvalidateTestLabels then DF:InvalidateTestLabels() end
 end
 
 -- ============================================================
@@ -6112,6 +6121,11 @@ function Factory:ClearFrame(frame)
     -- Sound: reconcile to config with AD now off -> unregisters every applied-sound handle
     -- (combat-deferred to regen inside SyncSound). No leaked registrations.
     self:SyncSound(frame)
+
+    -- The teardown half of the pair in SyncFrame: everything Indicator Info had a rect
+    -- for is gone, and a mark left pointing at a destroyed placement is worse than no
+    -- mark. Same guard, same reasoning.
+    if frame.dfIsTestFrame and DF.InvalidateTestLabels then DF:InvalidateTestLabels() end
 end
 
 -- ============================================================

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -3876,13 +3876,17 @@ end
 
 -- Style a FRAME-LEVEL missing badge as a flat TINT fill (healthbar / background colour-when-
 -- missing). The fill covers the whole window (== the region). Colour/blend from config.
-local function styleTintMissingBadge(h, r, g, b, blend)
+-- `clampTo` (optional): anchor the fill to THAT region instead of to the whole badge.
+-- The health-bar consumer passes the real bar's fill texture so a missing-mode tint
+-- covers current health only, exactly as the present-mode cover does; the background
+-- consumer passes nothing, because a background has no fill to track.
+local function styleTintMissingBadge(h, r, g, b, blend, clampTo)
     local badge = h.GetBadgeFrame and h:GetBadgeFrame()
     if not badge then return end
     if not badge.dfADFill then badge.dfADFill = badge:CreateTexture(nil, "ARTWORK") end
     badge.dfADFill:SetColorTexture(r, g, b, blend)
     badge.dfADFill:ClearAllPoints()
-    badge.dfADFill:SetAllPoints(badge)
+    badge.dfADFill:SetAllPoints(clampTo or badge)
     badge.dfADFill:Show()
 end
 
@@ -5086,20 +5090,39 @@ local function syncHealthbarTint(hb, frame, healthBar, spec, key, cfg, map, mine
         -- Missing stays single-winner: a non-winner SWM config renders nothing and its
         -- stale entry (if any) falls to the keep-set sweep.
         if not asMissing then return false, false end
-        -- SHOW-WHEN-MISSING: a flat tint over the health-bar region while the buff is ABSENT.
+        -- SHOW-WHEN-MISSING: a tint over the health-bar region while the buff is ABSENT.
         -- Window/badge sized read-free from the frame's CONFIGURED size (the live rect is
         -- secret on 12.1); single-anchored to the health bar's TOPLEFT so it covers the region
-        -- (config-size approximation — precise region + z-order are P4.7 polish). The filled
-        -- mirror is a present-only concept, so nil the feed ref while in missing mode.
+        -- (config-size approximation — precise region + z-order are P4.7 polish).
+        --
+        -- ☠ THIS BRANCH USED TO IGNORE "Tint Entire Bar" ENTIRELY. It always painted the
+        -- badge's full rect, so an effect configured as Tint + entire-bar UNTICKED covered
+        -- the missing-health region too, and the frame read as permanently full: "the
+        -- preview shows it correctly, but the actual frame will not" (Eef, 2026-08-19,
+        -- attonement-missing recolour). The preview was right because the preview renders
+        -- the PRESENT-mode shape — a divergence in RENDERING, which is the one thing a
+        -- preview may never do.
+        -- The old note said "the filled mirror is a present-only concept". True of the
+        -- MIRROR, which needed a feed; false of what replaced it. The cover is a plain
+        -- texture anchored to the real bar's fill region, so it needs no aura and no feed
+        -- and works exactly as well with nothing present — see buildHealthFillConfig.
+        -- Same `wholeBar` expression as the present path below, so the two modes cannot
+        -- disagree about what the checkbox means (replace mode always tracks the fill).
         local r, g, b, a = readADColor(colorCfg)
         local mode = slower(cfg.mode or "replace")
+        local wholeBar = (mode == "tint") and (cfg.tintWholeBar and true or false) or false
         local blend = (mode == "replace") and a or healthbarBlend(mode, cfg.blend, a)
         local fdb = (DF.GetFrameDB and DF:GetFrameDB(frame)) or {}
         local mw, mh = tonumber(fdb.frameWidth) or 100, tonumber(fdb.frameHeight) or 20
-        local coSig = tconcat({ "miss", tostring(r), tostring(g), tostring(b), tostring(blend), tostring(mw), tostring(mh) }, "|")
+        local clampTo = (not wholeBar) and healthBar.GetStatusBarTexture
+            and healthBar:GetStatusBarTexture() or nil
+        -- clampTo joins the signature: toggling the checkbox has to restyle, and a health
+        -- TEXTURE swap replaces the fill region and would strand a create-once anchor.
+        local coSig = tconcat({ "miss", tostring(r), tostring(g), tostring(b), tostring(blend),
+            tostring(mw), tostring(mh), tostring(wholeBar), tostring(clampTo) }, "|")
         local before = hb[key]
         syncFrameLevelMissing(hb, key, map, frame, healthBar, healthBar, mw, mh, 1, coSig,
-            function(handle) styleTintMissingBadge(handle, r, g, b, blend) end, filt)
+            function(handle) styleTintMissingBadge(handle, r, g, b, blend, clampTo) end, filt)
         -- syncFrameLevelMissing replaces the entry TABLE on create/recreate.
         return true, hb[key] ~= before
     end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -3611,14 +3611,20 @@ end
 -- next frame) = the immediate refresh, OOC only (Show re-arms the parse, same op class
 -- as enable). In combat: mark-only best-effort — combat aura events are frequent, so the
 -- flags get picked up on the next one.
+-- ★ RETURNS WHETHER A REAL RE-PARSE HAPPENED, and the distinction is the whole point.
+-- Only the Hide/Show bounce makes the engine re-read candidateFilters; UpdateAllAuras
+-- repaints from the candidate set it ALREADY has, which is exactly the set that is wrong
+-- when a pool has fallen open. Callers that only want "nudge the display" can keep
+-- ignoring the result; the identity gate's recovery must not (see _noteGateRecovery).
 function NativeBackend:refresh()
     local c = self.container
-    if not c then return end
+    if not c then return false end
     if not InCombatLockdown() then
-        pcall(function() c:Hide(); c:Show() end)
+        return pcall(function() c:Hide(); c:Show() end)
     elseif type(c.UpdateAllAuras) == "function" then
         pcall(function() c:UpdateAllAuras() end)
     end
+    return false
 end
 
 -- The container is OURS (per-consumer): teardown is disable, drop its buttons, hide, release
@@ -5239,19 +5245,58 @@ local function GateLog(fmt, ...)
     DF:Debug("IDGATE", fmt, ...)
 end
 
+-- ☠☠☠ THE RECOVERY EDGE IS THE ONLY THING THAT RE-PARSES A FAIL-OPEN POOL, AND IT FIRES
+-- EXACTLY ONCE. `_idGateAssist` used to be stamped BEFORE the re-parse was attempted and
+-- unconditionally, so a recovery that could not actually re-parse still burned the edge:
+-- `was == false` was never true again, and the pool stayed fail-open for the rest of the
+-- session. That is the "AD effects just stop working, reload fixes it" class -- five
+-- separate reports, 2026-08-19/21 (Ruben x2, Beans, Immozaan, hEaLtReEPhD, and Krathe's
+-- own "icons got stuck and AD effects stopped working").
+--
+-- ★ THE TRIGGER IS SUSTAINED COMBAT, NOT ANY PARTICULAR CONTENT. Only the Hide/Show
+-- bounce re-reads candidateFilters, and NativeBackend:refresh cannot bounce a container
+-- in combat -- it falls back to UpdateAllAuras, which repaints from the candidate set it
+-- already has, i.e. precisely the stale set. So the edge is lost whenever trust recovers
+-- BEFORE the pull ends, and every one of the triggers can do that: a death and a rez, a
+-- cinematic, a vehicle, phasing, a disconnect.
+-- ⚠ Do NOT narrow this to keys. Raid is at least as good a repro and arguably better --
+-- a battle rez is a false->true assist edge landing squarely mid-fight, boss cinematics
+-- and platform phases fire without dropping combat, and encounters run far longer than a
+-- dungeon pull, so there is more time for a flip to happen inside one. (First written as
+-- "an M+ bug"; corrected after Krathe reported it in raid, 2026-08-21. The mechanism
+-- never had a dungeon term in it -- only the example did.) What it is NOT is a
+-- world/overworld bug: out there you are usually out of combat when trust returns, the
+-- bounce runs, and nobody ever sees this.
+-- A backend that does not exist yet -- a container whose build was deferred to combat end
+-- -- burned the edge the same way, in any content.
+--
+-- ★ Now the edge is consumed only when a real re-parse lands. Otherwise the verdict stays
+-- false, so the NEXT gate pass sees the same false->true transition and tries again, and a
+-- combat-end retry is queued so it does not have to wait for one. Both halves matter: the
+-- retry guarantees the recovery, the un-consumed verdict makes it idempotent.
 function Handle:_noteGateRecovery(can)
     local was = self._idGateAssist
-    self._idGateAssist = can and true or false
-    if was == false and self._idGateAssist then
+    local now = can and true or false
+    if was == false and now then
         GateLog("recovered unit=%s - re-parsing (pool was fail-open)",
             tostring(self.config and self.config.unit))
-        self:Refresh()
+        if not self:Refresh() then
+            -- Deliberately NOT stamping _idGateAssist, and not clearing the cinematic
+            -- latch: neither may advance past a re-parse that did not happen.
+            self._pendingGateReparse = true
+            self:_registerRegen()
+            GateLog("recovery unit=%s could not re-parse (combat/no backend) - "
+                .. "edge held, retry queued for combat end",
+                tostring(self.config and self.config.unit))
+            return
+        end
         -- AFTER the bounce, deliberately: the whole point of the cinematic latch
         -- is that the frames reappear already re-parsed, not one frame before.
         -- skipReparse: the Refresh above IS that bounce; the latch clear would
         -- otherwise run a second one on the same edge.
         self:_setCineLatch(nil, true)
     end
+    self._idGateAssist = now
 end
 
 -- ★ THE BOARDING WINDOW. `UnitCanAssist` does not flip the instant you take control of
@@ -5812,13 +5857,19 @@ end
 -- dirty-mark (processed on the next OnUpdate while visible) — the real refresh. Use on
 -- a dynamic-unit consumer (target/focus/mouseover) when the underlying unit changes but
 -- the token does not. Falls back to an out-of-combat Hide/Show bounce if absent.
+-- Returns true only when the backend performed a genuine re-parse. A missing backend
+-- (build deferred to combat end) and the in-combat repaint both answer false.
 function Handle:Refresh()
-    if not self.backend then return end
-    local ok, err = pcall(function() self.backend:refresh() end)
-    if not ok and not warnedRefresh then
-        warnedRefresh = true
-        DF:DebugWarn(DBG, "Refresh bounce failed: %s", tostring(err))
+    if not self.backend then return false end
+    local ok, res = pcall(function() return self.backend:refresh() end)
+    if not ok then
+        if not warnedRefresh then
+            warnedRefresh = true
+            DF:DebugWarn(DBG, "Refresh bounce failed: %s", tostring(res))
+        end
+        return false
     end
+    return res and true or false
 end
 
 -- AUTO-REFRESH for dynamic-unit containers. Since there's no callable Refresh(), a
@@ -6126,6 +6177,25 @@ function Handle:_registerRegen()
                     pcall(function() h:_teardownContainer() end)
                     pcall(function() h:_releaseParked() end)
                 elseif not h._destroyed then
+                    -- ☠☠ DID A REBUILD ACTUALLY HAPPEN? The tune/restyle flushes below used
+                    -- to ask `op ~= "rebuild"`, i.e. whether one was REQUESTED. The two
+                    -- differ on exactly one path and that path dropped everything:
+                    --
+                    -- A parent-driven link skips its own rebuild (see the note below). Its
+                    -- flags were still consumed at the top of this loop, so `op == "rebuild"`
+                    -- suppressed the tuning and the restyle as well -- and since the rebuild
+                    -- was skipped, NOTHING re-declared the unit or the enabled state that the
+                    -- rebuild was standing in for either. Four deferred actions, all silently
+                    -- discarded, with nothing left to re-queue them.
+                    --
+                    -- ☠ AND "rebuild" IS NOT A RARE OP FOR A NESTED LINK. _queueOp upgrades
+                    -- ANY two different lesser ops to it, so an ordinary combat in which a
+                    -- link is both retargeted (roster churn) and re-enabled arrives here as
+                    -- "rebuild" -- the container then keeps driving the PREVIOUS unit for the
+                    -- rest of the session, which is what an effect stuck on the wrong people,
+                    -- frozen, with its duration no longer counting, looks like from the
+                    -- outside. A reload is the only thing that rebuilds it.
+                    local rebuilt = false
                     if op then
                         pcall(function()
                             if op == "rebuild" then
@@ -6139,7 +6209,19 @@ function Handle:_registerRegen()
                                 -- matches so no sync heals it. With no backend there is nothing
                                 -- a duplicate could be stranded FROM, so the escape cannot
                                 -- reintroduce the race — do not re-tighten it.
-                                if not skipNested(h) or not h.backend then h:_rebuild() end
+                                if not skipNested(h) or not h.backend then
+                                    h:_rebuild()
+                                    rebuilt = true
+                                elseif h.backend then
+                                    -- Skipped: the parent owns the recreate. Apply IN PLACE the
+                                    -- two things a rebuild would have re-declared from config,
+                                    -- because the upgrade folded them in and there is no longer
+                                    -- any record of which of them was queued. Both are
+                                    -- idempotent, so applying both is safe and cheaper than
+                                    -- tracking the pair through the upgrade.
+                                    h.backend:setUnit(h.config.unit)
+                                    h.backend:setEnabled(h.config.enabled ~= false)
+                                end
                             elseif op == "retarget" then
                                 if h.backend then h.backend:setUnit(h.config.unit) end
                             elseif op == "enable" then
@@ -6150,17 +6232,38 @@ function Handle:_registerRegen()
                     -- Combat-deferred in-place tuning (ApplyTuning hit in lockdown):
                     -- flush via the in-place mutate, NOT a recreate — the deferred
                     -- change costs no flicker/leak either. A rebuild redeclares the
-                    -- groups from the already-swapped config, so only non-rebuild
-                    -- paths need the explicit flush. Tuning runs BEFORE restyle
+                    -- groups from the already-swapped config, so only a rebuild that
+                    -- REALLY RAN makes this redundant. Tuning runs BEFORE restyle
                     -- (population first, cosmetics second).
-                    if tune and op ~= "rebuild" and h.backend and h.backend.applyGroupTuning then
+                    if tune and not rebuilt and h.backend and h.backend.applyGroupTuning then
                         pcall(function() h.backend:applyGroupTuning() end)
                     end
                     -- Combat-deferred cosmetic restyle (ApplyStyle hit in lockdown). A
-                    -- rebuild already styles fresh buttons from the updated config, so
-                    -- only non-rebuild paths need the explicit OOC re-apply.
-                    if restyle and op ~= "rebuild" then
+                    -- rebuild that ran already styles fresh buttons from the updated
+                    -- config; one that was skipped styled nothing.
+                    if restyle and not rebuilt then
                         pcall(function() h:ApplyStyle() end)
+                    end
+                    -- ☠ THE GATE RECOVERY THAT COULD NOT RUN IN COMBAT. Out of lockdown the
+                    -- bounce is available again, so this is the first moment the pool can
+                    -- actually be re-parsed. LAST, after any rebuild/tuning/restyle above:
+                    -- a rebuild parses fresh and clears the debt by itself, and re-parsing
+                    -- before a restyle would only be undone by it.
+                    -- The flag is cleared only on success, so a bounce that still fails
+                    -- leaves the verdict un-consumed and the next gate pass retries.
+                    if h._pendingGateReparse then
+                        if rebuilt then
+                            h._pendingGateReparse = nil
+                            h._idGateAssist = true
+                        else
+                            local done = false
+                            pcall(function() done = h:Refresh() end)
+                            if done then
+                                h._pendingGateReparse = nil
+                                h._idGateAssist = true
+                                pcall(function() h:_setCineLatch(nil, true) end)
+                            end
+                        end
                     end
                 end
             end
@@ -7248,7 +7351,19 @@ function SlotHandle:_noteGateRecovery(can)
         return
     end
     local c = self.owner and self.owner.container
-    if not c or self._lastCandidateFilters == nil then return end
+    -- ☠ NO CONTAINER = NO REPLAY QUEUED, so the edge must NOT be spent. Unlike the two
+    -- branches below, this one leaves nothing behind that will finish the job: the
+    -- verdict would read recovered while the candidate filters were never re-pushed, and
+    -- the false->true transition never comes again. Hold it and the next gate pass
+    -- retries. (The no-filters case below is safe to consume -- a slot that has never had
+    -- a gated selection pushed has nothing stale to re-parse.)
+    -- Same failure the Handle twin shipped; see Handle:_noteGateRecovery for the full
+    -- account of why one spent edge is permanent.
+    if not c then
+        self._idGateAssist = was
+        return
+    end
+    if self._lastCandidateFilters == nil then return end
     GateLog("slot recovered key=%s unit=%s - re-parsing (pool was fail-open)",
         tostring(self.key), tostring(self.owner and self.owner.unit))
     -- ☠ No native tuning setter runs in lockdown (see ApplyTuning). Queue the standard

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5295,6 +5295,10 @@ function Handle:_noteGateRecovery(can)
         -- skipReparse: the Refresh above IS that bounce; the latch clear would
         -- otherwise run a second one on the same edge.
         self:_setCineLatch(nil, true)
+        -- A pass can recover BEFORE the combat-end drain gets its turn. Clear the
+        -- retry debt too, or the drain would run a spurious bounce next regen on a
+        -- pool this pass just re-parsed.
+        self._pendingGateReparse = nil
     end
     self._idGateAssist = now
 end
@@ -6277,16 +6281,27 @@ function Handle:_registerRegen()
                     -- before a restyle would only be undone by it.
                     -- The flag is cleared only on success, so a bounce that still fails
                     -- leaves the verdict un-consumed and the next gate pass retries.
+                    -- ☠ THE DRAIN PAYS THE RE-PARSE DEBT BUT NEVER STAMPS THE VERDICT.
+                    -- It used to set _idGateAssist = true here, and that reintroduced the
+                    -- spent-edge bug on one corner (2026-08-21 review): if trust dropped
+                    -- AGAIN during the same combat, this bounce re-parsed an untrusted
+                    -- unit -- a fail-open parse, invisible only because the hide
+                    -- actuation covers it -- and the stamped true meant the REAL
+                    -- recovery, when trust returned, saw no false->true edge and never
+                    -- re-parsed. The anchor then un-hid an unfiltered pool.
+                    -- Leaving the verdict false costs one redundant bounce: the next
+                    -- gate pass (the 5s backstop at worst) sees the same edge out of
+                    -- combat, bounces instantly, and stamps through the normal flow --
+                    -- which re-asks the probes first, so a still-untrusted unit stays
+                    -- parked instead of being declared recovered by a timer.
                     if h._pendingGateReparse then
                         if rebuilt then
                             h._pendingGateReparse = nil
-                            h._idGateAssist = true
                         else
                             local done = false
                             pcall(function() done = h:Refresh() end)
                             if done then
                                 h._pendingGateReparse = nil
-                                h._idGateAssist = true
                                 pcall(function() h:_setCineLatch(nil, true) end)
                             end
                         end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -5374,11 +5374,37 @@ local function IdentityUnavailable(unit)
     end
     return nil
 end
+-- ☠☠ PROBE THE POOL SWAP, NOT THE PASSENGER FLAG. This asked UnitUsingVehicle, which is
+-- true for ANY vehicle association -- including riding an encounter's transport or
+-- platform entity, where your action bars, your unit token and YOUR AURA POOL all stay
+-- yours. Field-caught 2026-08-21 (Krathe, raid): the player was flagged self-vehicle for
+-- 5m38s of a fight (14:49:18 park -> 14:54:56 recover) while healing normally -- casting
+-- the whole time, so the bars were provably never swapped -- and every gated pool on the
+-- OWN frame parked for the duration: "my PoM was not showing on myself but was showing
+-- on other players". The backstop ticker re-probed every 5s throughout and UsingVehicle
+-- kept answering true, so this was the verdict being wrong, not an edge being missed.
+--
+-- ★ The signal the gate actually cares about is "does this frame's pool belong to the
+-- vehicle right now", and the client's own compact frames answer that with
+-- UnitHasVehicleUI (BlizzardInterfaceCode: CompactUnitFrame's shouldTargetVehicle) --
+-- the frame retargets to the vehicle unit exactly and only when that is true. No swap,
+-- no mismatch, nothing to distrust.
+--
+-- ⚠ THE TRADE, taken knowingly: the pre-seat boarding window this probe was added for
+-- (UsingVehicle true before HasVehicleUI lands) is now covered by the on-the-spot
+-- UNIT_ENTERING/ENTERED_VEHICLE sweeps instead of by the probe itself -- worst case is
+-- one dispatch of a real vehicle's swapped pool rendering before the ENTERED sweep
+-- parks it. The gate's stated fail-safe direction is SHOW; five minutes of your own
+-- tracked buffs hidden in a raid fight is the wrong side of that rule, one garbage
+-- frame on a genuine vehicle boarding is the right side.
 local function SelfIsUsingVehicle(unit)
     if not unit then return false end
     local okSame, same = pcall(UnitIsUnit, unit, "player")
     if not okSame or not same then return false end
-    local probe = UnitUsingVehicle or UnitInVehicle
+    -- Fallbacks kept for a client without the primary (belt-and-braces; all three are
+    -- ancient APIs) -- but never "UsingVehicle wins over HasVehicleUI": when the
+    -- precise signal exists it is the only one consulted.
+    local probe = UnitHasVehicleUI or UnitUsingVehicle or UnitInVehicle
     if not probe then return false end
     local ok, v = pcall(probe, "player")
     if not ok then return false end

--- a/DandersFrames/Frames/Pets.lua
+++ b/DandersFrames/Frames/Pets.lua
@@ -422,6 +422,24 @@ end
 -- PET FRAME EVENTS
 -- ============================================================
 
+-- Forward declaration: the recovery arms below need the update-AND-reposition pair,
+-- and RefreshPetFrame is defined near the bottom beside the other track entry points.
+-- Declared rather than duplicated -- showing a pet without repositioning it is the
+-- "right pet under the wrong teammate" bug that function's own header describes.
+local RefreshPetFrame
+
+-- ⚠ FILE SCOPE, not a closure inside the handler. OnPetFrameEvent runs for every pet
+-- and owner UNIT_HEALTH in the group; building a closure per call would allocate on
+-- the hottest path in this file for a helper that captures nothing.
+local function recoverIfHidden(frame)
+    if frame.dfPetHidden and UnitExists(frame.unit)
+        and not UnitIsDeadOrGhost(frame.ownerUnit) then
+        RefreshPetFrame(frame)
+        return true
+    end
+    return false
+end
+
 function DF:OnPetFrameEvent(frame, event, unit, ...)
     -- ☠ THE GATE. Every branch below can call SetPetFrameVisible(frame, true), and a
     -- frame belonging to a set that is NOT currently on screen doing that is exactly
@@ -450,6 +468,33 @@ function DF:OnPetFrameEvent(frame, event, unit, ...)
         return
     end
     
+    -- ☠☠ THE RECOVERY EDGE. Read this before touching either branch below.
+    --
+    -- UNIT_PET is a ONE-SHOT and it can arrive before the pet token is populated: the
+    -- branch above then takes its else-arm and HIDES, and no second UNIT_PET is coming
+    -- for that summon. Everything else here was hide-only -- the pet's own UNIT_FLAGS
+    -- could hide the frame and never show it, and its UNIT_HEALTH only repainted a
+    -- frame that was already visible -- so once the race was lost the ONLY route back
+    -- was an owner event, or the user toggling Pet Frames off and on. That is the
+    -- reported workaround, and the report is exactly this shape: "die, release,
+    -- resummon, pet frame missing; not 100% but more often than not" (moose,
+    -- 2026-08-20, delve). A race is precisely what "more often than not" looks like.
+    --
+    -- A gate needs a refresh on BOTH transitions and this one only had the hide half.
+    -- Every arm that can hide now has a matching show, so the pet's FIRST health or
+    -- flags event after it appears puts the frame back with no new registration and no
+    -- polling.
+    --
+    -- ⚠ EDGE-GATED ON dfPetHidden, so this costs one field read on the hot path. Pet
+    -- and owner UNIT_HEALTH fire constantly for every pet in the group; running a full
+    -- refresh on each would be a storm. The flag is set by SetPetFrameVisible itself,
+    -- so it is the frame's own record of which side of the gate it is on.
+    -- ★ Through RefreshPetFrame, not SetPetFrameVisible: a pet arriving outside a track
+    -- pass has to be REPOSITIONED as well as shown, or it appears under whichever
+    -- teammate it was last anchored to. Same reasoning as OnPetChanged's.
+    -- (recoverIfHidden is at file scope above -- a per-call closure here would allocate
+    -- on every UNIT_HEALTH.)
+
     -- Check for owner unit events (for death detection)
     if unit == frame.ownerUnit then
         if event == "UNIT_HEALTH" or event == "UNIT_FLAGS" then
@@ -457,8 +502,10 @@ function DF:OnPetFrameEvent(frame, event, unit, ...)
             if UnitIsDeadOrGhost(frame.ownerUnit) then
                 DF:SetPetFrameVisible(frame, false)
             else
-                -- Owner alive, check if pet exists
-                if UnitExists(frame.unit) then
+                -- Owner alive, check if pet exists. The hidden->shown crossing goes
+                -- through the full refresh (style, name, power, anchor); an
+                -- already-shown frame keeps the cheap health-only repaint it had.
+                if not recoverIfHidden(frame) and UnitExists(frame.unit) then
                     DF:SetPetFrameVisible(frame, true)
                     DF:UpdatePetHealth(frame)
                 end
@@ -466,20 +513,27 @@ function DF:OnPetFrameEvent(frame, event, unit, ...)
         end
         return
     end
-    
+
     -- Handle pet unit events
     if unit ~= frame.unit then return end
-    
+
     if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
-        DF:UpdatePetHealth(frame)
+        -- The pet's own first health tick after being summoned is what closes the
+        -- UNIT_PET race; before this it repainted a frame nobody had shown.
+        if not recoverIfHidden(frame) then
+            DF:UpdatePetHealth(frame)
+        end
     elseif event == "UNIT_POWER_UPDATE" or event == "UNIT_MAXPOWER" or event == "UNIT_DISPLAYPOWER" then
         DF:UpdatePetPower(frame)
     elseif event == "UNIT_NAME_UPDATE" then
         DF:UpdatePetName(frame)
     elseif event == "UNIT_FLAGS" then
-        -- Pet may have been dismissed or died
+        -- Pet may have been dismissed or died -- or may have just ARRIVED, which is
+        -- the half this branch was missing.
         if not UnitExists(frame.unit) then
             DF:SetPetFrameVisible(frame, false)
+        else
+            recoverIfHidden(frame)
         end
     end
 end
@@ -2148,7 +2202,9 @@ end
 -- case -- was SHOWN at whatever anchor it last held. That is the "right pet under the
 -- wrong teammate" symptom for anything that arrives here rather than through a track
 -- pass. Owner death and rez arrive as UNIT_HEALTH / UNIT_FLAGS and never reach here.
-local function RefreshPetFrame(frame)
+-- Assigns the forward-declared local above; a `local function` here would shadow it
+-- and leave the recovery arms in OnPetFrameEvent calling nil.
+function RefreshPetFrame(frame)
     if not frame then return end
     DF:UpdatePetFrame(frame)
     -- ⚠ NO combat early-return here, deliberately. PositionPetFrame owns the guard AND

--- a/DandersFrames/Frames/ReducedMaxHealth.lua
+++ b/DandersFrames/Frames/ReducedMaxHealth.lua
@@ -134,35 +134,73 @@ function DF:UpdateReducedMaxHealth(frame)
     bar:SetValue(pct)
     bar:Show()
 
-    if db.reducedMaxHealthClipHealthBar and frame.healthBar and tex and not pctIsSecret then
+    if db.reducedMaxHealthClipHealthBar and frame.healthBar and tex then
         -- Clip the health bar to the portion NOT covered by the reduced-max
         -- overlay: pin the three frame-side edges and anchor the full-health
         -- edge to the reduced texture's inner edge. Mirrors the orientation above.
-        -- SKIPPED on the secret path: clipping re-anchors the health bar to the
-        -- reduced bar's fill-texture geometry, which is driven by the secret value.
-        -- The overlay itself renders fine from the secret (above), but we don't clip
-        -- against secret-derived geometry unless it's proven taint-safe in-game.
-        frame.healthBar:ClearAllPoints()
-        if orientation == "HORIZONTAL_INV" then          -- reduced on left
-            frame.healthBar:SetPoint("TOPRIGHT", -padding, -padding)
-            frame.healthBar:SetPoint("BOTTOMRIGHT", -padding, padding)
-            frame.healthBar:SetPoint("TOPLEFT", tex, "TOPRIGHT")
-            frame.healthBar:SetPoint("BOTTOMLEFT", tex, "BOTTOMRIGHT")
-        elseif orientation == "VERTICAL" then            -- reduced on top
-            frame.healthBar:SetPoint("BOTTOMLEFT", padding, padding)
-            frame.healthBar:SetPoint("BOTTOMRIGHT", -padding, padding)
-            frame.healthBar:SetPoint("TOPLEFT", tex, "BOTTOMLEFT")
-            frame.healthBar:SetPoint("TOPRIGHT", tex, "BOTTOMRIGHT")
-        elseif orientation == "VERTICAL_INV" then        -- reduced on bottom
+        --
+        -- ☠☠ THIS USED TO BE SKIPPED ON THE SECRET PATH, WHICH IS THE ONLY PATH THAT
+        -- MATTERS. The note above says it plainly: in restricted content -- M+ and raid,
+        -- "exactly where max-HP reductions live" -- the percent comes back secret. So the
+        -- clip ran in test mode and nowhere else, and every consumer that reasons about
+        -- "the usable bar" was reasoning about a rect that is only correct in a preview:
+        --   * the dispel wash's "Show On Current Health Only" anchors to this bar
+        --     precisely so the reduced region is excluded (Features/Dispel.lua's
+        --     healthAnchor block, and the slot carrier's birth anchor). Unclipped, the
+        --     wash spans the taken-away max and reads as though the option were off --
+        --     "in game it looks like it does in test mode if you untick it" (Renegade,
+        --     2026-08-19).
+        --   * UpdateAbsorb's ATTACHED maths says "the bar physically ends there".
+        --     In a key it did not.
+        -- The original reason was caution, stated as caution: "we don't clip against
+        -- secret-derived geometry unless it's proven taint-safe in-game." It is the
+        -- established route -- ANCHORING derives geometry engine-side and reads nothing
+        -- in Lua, which is the same doctrine DispelSlotSecureInit relies on and the same
+        -- thing UpdateAbsorb already does to this very texture (Bars.lua's
+        -- healthFillTexture anchors, ungated and shipping). Anchoring is not a read.
+        -- ⚠ SELF-CORRECTING WHEN THE SECRET RESOLVES TO ZERO: an unmodified unit renders
+        -- an empty reverse-fill, so `tex` collapses onto the full-health edge and these
+        -- anchors give back the whole bar. That is why the numeric hide-test being
+        -- unavailable here does not strand a clipped bar.
+        -- ☠ GUARDED, AND THE FALLBACK RESTORES RATHER THAN LEAVES IT UNANCHORED. If the
+        -- client ever does refuse one of these, a half-applied ClearAllPoints would leave
+        -- the health bar with no points at all -- a worse outcome than the bug.
+        local clipped = pcall(function()
+            frame.healthBar:ClearAllPoints()
+            if orientation == "HORIZONTAL_INV" then          -- reduced on left
+                frame.healthBar:SetPoint("TOPRIGHT", -padding, -padding)
+                frame.healthBar:SetPoint("BOTTOMRIGHT", -padding, padding)
+                frame.healthBar:SetPoint("TOPLEFT", tex, "TOPRIGHT")
+                frame.healthBar:SetPoint("BOTTOMLEFT", tex, "BOTTOMRIGHT")
+            elseif orientation == "VERTICAL" then            -- reduced on top
+                frame.healthBar:SetPoint("BOTTOMLEFT", padding, padding)
+                frame.healthBar:SetPoint("BOTTOMRIGHT", -padding, padding)
+                frame.healthBar:SetPoint("TOPLEFT", tex, "BOTTOMLEFT")
+                frame.healthBar:SetPoint("TOPRIGHT", tex, "BOTTOMRIGHT")
+            elseif orientation == "VERTICAL_INV" then        -- reduced on bottom
+                frame.healthBar:SetPoint("TOPLEFT", padding, -padding)
+                frame.healthBar:SetPoint("TOPRIGHT", -padding, -padding)
+                frame.healthBar:SetPoint("BOTTOMLEFT", tex, "TOPLEFT")
+                frame.healthBar:SetPoint("BOTTOMRIGHT", tex, "TOPRIGHT")
+            else                                             -- HORIZONTAL: reduced on right
+                frame.healthBar:SetPoint("TOPLEFT", padding, -padding)
+                frame.healthBar:SetPoint("BOTTOMLEFT", padding, padding)
+                frame.healthBar:SetPoint("TOPRIGHT", tex, "TOPLEFT")
+                frame.healthBar:SetPoint("BOTTOMRIGHT", tex, "BOTTOMLEFT")
+            end
+        end)
+        if not clipped then
+            -- Re-pin the plain rect directly. RestoreHealthBarFromReducedMax is not
+            -- usable here: it early-returns unless dfReducedMaxHealthClipping is already
+            -- set, and this failed before setting it.
+            DF:DebugWarn("HEALTH", "ReducedMaxHealth: health-bar clip refused on unit=%s; "
+                .. "falling back to the unclipped rect", tostring(unit or "(test)"))
+            frame.healthBar:ClearAllPoints()
             frame.healthBar:SetPoint("TOPLEFT", padding, -padding)
-            frame.healthBar:SetPoint("TOPRIGHT", -padding, -padding)
-            frame.healthBar:SetPoint("BOTTOMLEFT", tex, "TOPLEFT")
-            frame.healthBar:SetPoint("BOTTOMRIGHT", tex, "TOPRIGHT")
-        else                                             -- HORIZONTAL: reduced on right
-            frame.healthBar:SetPoint("TOPLEFT", padding, -padding)
-            frame.healthBar:SetPoint("BOTTOMLEFT", padding, padding)
-            frame.healthBar:SetPoint("TOPRIGHT", tex, "TOPLEFT")
-            frame.healthBar:SetPoint("BOTTOMRIGHT", tex, "BOTTOMLEFT")
+            frame.healthBar:SetPoint("BOTTOMRIGHT", -padding, padding)
+            frame.dfReducedMaxHealthClipping = nil
+            frame.dfAbsorbState = nil
+            return
         end
         frame.dfReducedMaxHealthClipping = true
         -- ☠ THE ABSORB CACHE DEPENDS ON THE RECT WE JUST MOVED. UpdateAbsorb keeps a

--- a/DandersFrames_Options/AuraDesigner/UI/Groups.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Groups.lua
@@ -1233,7 +1233,12 @@ P.effectCardPool = effectCardPool
 -- the new Effects tab. Replaces the old per-aura view.
 -- ============================================================
 
-local FRAME_LEVEL_TYPE_KEYS = { "border", "healthbar", "background", "nametext", "healthtext", "sound" }
+-- ⚠ Captured from Options.lua rather than declared here. There were two copies of
+-- this list and one "does this record hold anything" test built on it; the cross-pool
+-- block asked a different, wrong question against the raw pool and shipped the "still
+-- In My Buffs after deleting it" bug. One list, one predicate.
+local FRAME_LEVEL_TYPE_KEYS = P.FRAME_LEVEL_TYPE_KEYS
+local AuraHoldsNoEffects = P.AuraHoldsNoEffects
 
 -- Remove an ad-hoc "#<id>" aura's config entry once it holds no effects at
 -- all (empty/absent indicators array AND no frame-level type keys). Ad-hoc
@@ -1252,10 +1257,7 @@ S.CleanupAdHocAura = function(auraName)
     local auras = CurrentAuraPool()
     local auraCfg = auras and auras[auraName]
     if type(auraCfg) ~= "table" then return end
-    if auraCfg.indicators and #auraCfg.indicators > 0 then return end
-    for _, typeKey in ipairs(FRAME_LEVEL_TYPE_KEYS) do
-        if auraCfg[typeKey] ~= nil then return end
-    end
+    if not AuraHoldsNoEffects(auraCfg) then return end
     auras[auraName] = nil
 end
 

--- a/DandersFrames_Options/AuraDesigner/UI/Options.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Options.lua
@@ -715,6 +715,27 @@ P.OtherPoolDisplayName = OtherPoolDisplayName
 -- comment was the only mention of one anywhere in the repo, and the DF.* export it
 -- justified had no readers either. The local below is live and used by
 -- CrossPoolTrackedIDs; only the export is gone.
+-- ☠ AN EMPTIED AURA RECORD IS NOT AN ABSENT ONE. Deleting an aura's last effect
+-- leaves its config table behind on purpose: S.CleanupAdHocAura prunes only the
+-- SYNTHETIC records (ad-hoc "#id" and filter-owned "@preset:"/"@custom:"), and its
+-- own comment says curated spells keep the linger deliberately. So "the pool holds a
+-- key for this spell" and "this spell renders anything" are different questions, and
+-- every consumer that means the second one has to ask it.
+-- ⚠ ONE list, captured from here by Groups.lua rather than restated there — two lists
+-- that agree today is how the next effect type gets added to only one of them.
+local FRAME_LEVEL_TYPE_KEYS = { "border", "healthbar", "background", "nametext", "healthtext", "sound" }
+P.FRAME_LEVEL_TYPE_KEYS = FRAME_LEVEL_TYPE_KEYS
+
+local function AuraHoldsNoEffects(auraCfg)
+    if type(auraCfg) ~= "table" then return true end
+    if auraCfg.indicators and #auraCfg.indicators > 0 then return false end
+    for _, typeKey in ipairs(FRAME_LEVEL_TYPE_KEYS) do
+        if auraCfg[typeKey] ~= nil then return false end
+    end
+    return true
+end
+P.AuraHoldsNoEffects = AuraHoldsNoEffects
+
 local function PoolTrackedIDs(adDB, which)
     local out = {}
     if type(adDB) ~= "table" then return out end
@@ -728,12 +749,25 @@ local function PoolTrackedIDs(adDB, which)
             for id in pairs(map) do out[id] = true end
         end
     end
+    -- ☠ RECORDS THAT RENDER NOTHING DO NOT COUNT. This accepted every table in the
+    -- pool, so an aura whose effects had all been deleted still blocked the spell in
+    -- the opposite pool -- permanently, since the record it was reading is one nothing
+    -- prunes. Field: "I added effects for Feather and Apotheosis to My Buffs, deleted
+    -- them, and Any Buffs still says they are In My Buffs" (Vindagor, 2026-08-19), with
+    -- the My Buffs pane visibly empty beside it. The question here is whether adding
+    -- the spell to the other pool would DOUBLE-RENDER it; an aura with no effects left
+    -- cannot render at all, so the honest answer is no.
+    -- ★ Fixed at the read, not by pruning on delete: pruning would change what a
+    -- curated record's linger means (S.CleanupAdHocAura's comment keeps it on purpose,
+    -- and a user who deletes an icon still owns that aura's priority and its type
+    -- configs), and it would leave every profile already carrying an emptied record
+    -- blocked until it was deleted again. This heals those on read.
     if which == "my" then
         if type(adDB.auras) == "table" then
             for specKey, specAuras in pairs(adDB.auras) do
                 if type(specAuras) == "table" then
                     for auraName, cfg in pairs(specAuras) do
-                        if type(cfg) == "table" then addIDs(specKey, auraName) end
+                        if not AuraHoldsNoEffects(cfg) then addIDs(specKey, auraName) end
                     end
                 end
             end
@@ -741,7 +775,7 @@ local function PoolTrackedIDs(adDB, which)
     else -- "other"
         if type(adDB.otherAuras) == "table" then
             for auraName, cfg in pairs(adDB.otherAuras) do
-                if type(cfg) == "table" then addIDs(nil, auraName) end
+                if not AuraHoldsNoEffects(cfg) then addIDs(nil, auraName) end
             end
         end
     end

--- a/DandersFrames_Options/TestMode/Labels.lua
+++ b/DandersFrames_Options/TestMode/Labels.lua
@@ -86,11 +86,13 @@ end
 -- substitute maths of its own, and this one does not: when the flow is unavailable the
 -- element simply goes unlabelled.
 -- ⚠ COST, stated because it scales with the raid preview: one probe box plus `count`
--- slot frames per labelled element per visible test frame — roughly 9 frames a frame,
--- so ~90 at the default 10-frame raid preview and ~360 at a 40-frame one. Pooled and
--- created once, never per pass, and only while the option is on; WoW never frees a
--- frame, so if that ceiling ever matters the fix is to probe fewer frames rather than
--- to rebuild them.
+-- slot frames per labelled element per visible test frame. The three fixed rows are
+-- ~9 frames a frame; the Aura Designer adds one probe per PLACEMENT on top, and since
+-- layout groups became measurable those are no longer one slot each — a group probes
+-- its own `_slotCount()`, so a design with a few multi-icon groups can double the
+-- per-frame figure. Pooled and created once, never per pass, and only while the option
+-- is on; WoW never frees a frame, so if that ceiling ever matters the fix is to probe
+-- fewer frames rather than to rebuild them.
 local function ensureProbe(frame, key, count)
     frame.dfTestLabelProbes = frame.dfTestLabelProbes or {}
     local p = frame.dfTestLabelProbes[key]
@@ -228,31 +230,51 @@ local function handleRect(frame, key, h)
     return windowRect(h)
 end
 
--- The Aura Designer has no single window: each placed indicator is its own handle in
--- the factory's `placed` store. Label the UNION of their rects, so the tag names the
--- system once instead of once per indicator.
-local function adUnionRect(frame)
+-- The Aura Designer has no single window: every placement is its own handle in the
+-- per-frame factory store, bucketed by family.
+-- ☠ ALL THREE ICON-BEARING FAMILIES, NOT JUST `placed`. This walked `placed` alone,
+-- so LAYOUT GROUPS — filter groups and member groups (store.fgroups, keyed "fgroup:"
+-- / "mgroup:") and debuff category groups (store.dgroups) — were invisible to the
+-- whole feature: unhoverable, and with `placed` empty the element read as switched
+-- OFF entirely, so a design built only from groups got no marks at all (Krathe,
+-- 2026-08-21). ⚠ Keep in sync with the Factory's own family list (SyncFrame's unit
+-- retarget loop, and AD_GATE_FAMILIES beside DebugDumpADGate).
+-- The frame-level families are deliberately NOT here: `healthbar` / `background` /
+-- `border` / `nametext` / `healthtext` tint or edge an existing element rather than
+-- placing an icon, so a region for one would span the whole health bar and swallow
+-- the rows drawn over it. They are Aura Designer output too, and if they ever want
+-- naming it has to be as a distinct element key, not folded in with the icons.
+local AD_FAMILIES = { "placed", "fgroups", "dgroups" }
+
+-- ☠ ONE REGION PER PLACEMENT, NOT ONE UNION OF THEM ALL. The union was written when
+-- every element was marked at once, where one box per system beat one per indicator.
+-- With only the hovered region marked that reasoning is gone and the union actively
+-- breaks the feature twice over: it draws brackets around the empty space BETWEEN
+-- scattered indicators, and because the hit test resolves smallest-region-wins, a
+-- union spanning the frame loses to every row nested inside it — so the thing under
+-- the cursor is named as the buff row rather than as the indicator sitting on it.
+-- Per-placement regions all carry the same key, so they all tag "Aura Designer" and
+-- exactly one is ever on screen; the difference is that it is the right one, tight
+-- around what the cursor is actually over.
+local function adRegions(frame, out)
     local store = frame.dfADFactory
-    local placed = store and store.placed
-    if type(placed) ~= "table" then return nil end
-    local l, r, t, b
-    local hosts = {}
+    if type(store) ~= "table" then return end
     local i = 0
-    for _, entry in pairs(placed) do
-        i = i + 1
-        -- Each placed indicator is its own single-slot handle; give each probe its own
-        -- key so they do not share (and overwrite) one measuring box.
-        local fl, fr, ft, fb, anchor = handleRect(frame, "ad" .. i, entry and entry.handle)
-        if fl then
-            l = (l and math.min(l, fl)) or fl
-            r = (r and math.max(r, fr)) or fr
-            t = (t and math.max(t, ft)) or ft
-            b = (b and math.min(b, fb)) or fb
-            if anchor then hosts[#hosts + 1] = anchor end
+    for _, family in ipairs(AD_FAMILIES) do
+        local bucket = store[family]
+        if type(bucket) == "table" then
+            for _, entry in pairs(bucket) do
+                i = i + 1
+                -- Give each placement its own probe key so they do not share (and
+                -- overwrite) one measuring box. Numbered across ALL families in one
+                -- run, so a group never collides with a placed indicator.
+                local l, r, t, b, anchor = handleRect(frame, "ad" .. i, entry and entry.handle)
+                if l and anchor then
+                    out[#out + 1] = { l = l, r = r, t = t, b = b, host = anchor, hosts = { anchor } }
+                end
+            end
         end
     end
-    if not l then return nil end
-    return l, r, t, b, hosts
 end
 
 -- Returns the rect AND the frame to anchor against. ☠ ANCHOR TO THE TARGET, never to
@@ -290,11 +312,17 @@ end
 -- over EMPTY SPACE, which a false positive here cannot produce.
 local function elementShown(frame, key)
     if key == "ad" then
-        -- The AD has no row frame: Factory:ClearFrame empties `placed`, so an empty
-        -- store IS the off state (and adUnionRect then finds no rect anyway).
+        -- The AD has no row frame: Factory:ClearFrame empties every family, so an
+        -- empty store IS the off state (and adRegions then finds no rect anyway).
+        -- ☠ ASKED OF ALL THREE FAMILIES. Asking only `placed` meant a design built
+        -- from layout groups alone answered "off" and never got a mark.
         local store = frame.dfADFactory
-        local placed = store and store.placed
-        return type(placed) == "table" and next(placed) ~= nil
+        if type(store) ~= "table" then return false end
+        for _, family in ipairs(AD_FAMILIES) do
+            local bucket = store[family]
+            if type(bucket) == "table" and next(bucket) ~= nil then return true end
+        end
+        return false
     end
     if key == "missing" then
         local s = frame.missingBuffStrip
@@ -317,13 +345,14 @@ local function elementShown(frame, key)
     return shown and true or false
 end
 
+-- Single-region elements only. The Aura Designer produces MANY regions per frame and
+-- goes through adRegions instead — which is also why the unit frame is no longer
+-- handed back as an anchor here: the union needed a shared parent to anchor against,
+-- a per-placement region anchors to the placement itself, and the standing warning
+-- (never register the unit frame as a tooltip host, or the parent walk makes every
+-- aura on the frame claim to be an indicator) stops being something to work around.
 local function targetOf(frame, key)
     if not elementShown(frame, key) then return nil end
-    if key == "ad" then
-        local l, r, t, b, hosts = adUnionRect(frame)
-        if not l then return nil end
-        return l, r, t, b, frame, hosts
-    end
     -- ☠ MISSING BUFF IS NOT ONE HANDLE. `frame.missingFactory` is a MAP of spell key
     -- -> handle, one cell per tracked buff, so passing it where a handle is expected
     -- found nothing and the element never labelled at all (field-reported). Its cells
@@ -687,24 +716,52 @@ local hoverRegions = {}   -- { frame, key, color, l, r, t, b, host, scale }
 -- It also stops the preview lying by omission: the defensive icon previews on a
 -- tank/healer slot and the missing-buff badge on another, so a single claimed frame
 -- left whole elements unhoverable with nothing to say why.
+local function addRegion(frame, target, reg)
+    for _, hf in ipairs(reg.hosts or {}) do
+        if hf ~= frame then regionOf[hf] = target.key end
+    end
+    local okScale, scale = pcall(reg.host.GetEffectiveScale, reg.host)
+    hoverRegions[#hoverRegions + 1] = {
+        frame = frame, key = target.key, color = target.color,
+        l = reg.l, r = reg.r, t = reg.t, b = reg.b, host = reg.host,
+        scale = (okScale and scale) or 1,
+    }
+end
+
+-- Returns whether anything on this frame is RENDERING BUT NOT YET MEASURABLE, which is
+-- what the settle retry needs to know. See TL:Update.
 local function scanFrame(frame)
     if not frame or not frame.GetLeft or not frame:GetLeft() or not frame:IsShown() then
-        return
+        return false
     end
+    local pending = false
     for _, target in ipairs(TARGETS) do
-        local l, r, t, b, host, hosts = targetOf(frame, target.key)
-        if l and host then
-            for _, hf in ipairs(hosts or {}) do
-                if hf ~= frame then regionOf[hf] = target.key end
+        local before = #hoverRegions
+        if target.key == "ad" then
+            -- Many regions, one per placement. Gathered into a scratch list rather
+            -- than appended directly so the "did this element produce anything"
+            -- test below reads the same for every key.
+            if elementShown(frame, target.key) then
+                local regs = {}
+                adRegions(frame, regs)
+                for _, reg in ipairs(regs) do addRegion(frame, target, reg) end
             end
-            local okScale, scale = pcall(host.GetEffectiveScale, host)
-            hoverRegions[#hoverRegions + 1] = {
-                frame = frame, key = target.key, color = target.color,
-                l = l, r = r, t = t, b = b, host = host,
-                scale = (okScale and scale) or 1,
-            }
+        else
+            local l, r, t, b, host, hosts = targetOf(frame, target.key)
+            if l and host then
+                addRegion(frame, target, { l = l, r = r, t = t, b = b, host = host, hosts = hosts })
+            end
+        end
+        -- ★ THE ELEMENT SAYS IT IS ON SCREEN AND YET MEASURED TO NOTHING. That is the
+        -- signal a container has been rebuilt this tick and has no rect yet — the
+        -- creation-tick rule — and it is the ONLY thing that distinguishes "not ready"
+        -- from "legitimately switched off". Both used to look identical here, which is
+        -- what let a partial pass declare itself finished.
+        if #hoverRegions == before and elementShown(frame, target.key) then
+            pending = true
         end
     end
+    return pending
 end
 
 -- Smallest containing region wins, so an Aura Designer indicator sitting inside the
@@ -817,9 +874,12 @@ end
 local function beginFadeOut(reg, linger)
     local w = widgetFor(reg)
     if not w then return end
-    -- Resurrect rather than duplicate if this region is already fading.
+    -- ☠ MATCHED BY WIDGET, NOT BY REGION. The pool is keyed (frame, element key) and
+    -- the Aura Designer now registers one region per placement, so several regions on
+    -- one frame legitimately share a single widget. Comparing region tables let the
+    -- same widget be queued twice and fought over.
     for _, f in ipairs(fadingOut) do
-        if f.reg == reg then f.wait = linger; f.state = "wait"; return end
+        if widgetFor(f.reg) == w then f.wait = linger; f.state = "wait"; return end
     end
     fadingOut[#fadingOut + 1] = {
         reg = reg, alpha = w.host:GetAlpha() or 1, wait = linger, state = "wait",
@@ -879,7 +939,13 @@ local function ensureHoverDriver()
             -- the option is on and only in test mode.
             local reg = regionUnderCursor()
             if reg ~= hoverShown then
-                if hoverShown then
+                local w = reg and widgetFor(reg)
+                -- ☠ NEVER FADE OUT THE WIDGET WE ARE ABOUT TO FADE IN. Crossing between
+                -- two Aura Designer placements on one frame moves between two regions
+                -- that SHARE a pooled widget: queuing the old one for fade-out would
+                -- drive the very widget the new one is raising, and the mark would sink
+                -- while the cursor sat on it. Same widget = a re-place, not a crossing.
+                if hoverShown and widgetFor(hoverShown) ~= w then
                     -- Crossing to another region ends the old one promptly; leaving to
                     -- nothing gets the hold.
                     beginFadeOut(hoverShown, reg and 0 or LINGER)
@@ -887,10 +953,9 @@ local function ensureHoverDriver()
                 if reg then
                     -- Pick up where a fade left off, so sweeping back onto a region
                     -- that is still visible does not restart it from transparent.
-                    local w = widgetFor(reg)
                     inAlpha = (w and w.host:IsShown() and w.host:GetAlpha()) or 0
                     for i = #fadingOut, 1, -1 do
-                        if fadingOut[i].reg == reg then table.remove(fadingOut, i) end
+                        if widgetFor(fadingOut[i].reg) == w then table.remove(fadingOut, i) end
                     end
                 end
                 hoverShown = reg
@@ -994,19 +1059,37 @@ function TL:Update(settling)
     for i = #hoverRegions, 1, -1 do hoverRegions[i] = nil end
     for k in pairs(regionOf) do regionOf[k] = nil end
 
+    local pending = false
     if poolWants(false) then
-        for i = 0, 4 do scanFrame(DF.testPartyFrames[i]) end
+        for i = 0, 4 do if scanFrame(DF.testPartyFrames[i]) then pending = true end end
     end
     if poolWants(true) then
-        for i = 1, 40 do scanFrame(DF.testRaidFrames[i]) end
+        for i = 1, 40 do if scanFrame(DF.testRaidFrames[i]) then pending = true end end
     end
 
-    if #hoverRegions > 0 then
-        settleLeft = 0
-        ensureHoverDriver():Show()
-    elseif settleLeft > 0 and (poolWants(false) or poolWants(true)) then
+    -- Drive whatever DID measure straight away; a partial answer beats a blank one
+    -- while the rest settles.
+    if #hoverRegions > 0 then ensureHoverDriver():Show() end
+
+    -- ☠☠ A PASS THAT FOUND *SOMETHING* IS NOT A PASS THAT FOUND *EVERYTHING*. This
+    -- stood the retry down the moment one region measured, and elements rebuilt on the
+    -- same tick were never scanned again: switch the Aura Designer preset with test
+    -- mode open and the defensive icon — untouched, still measurable — ended the budget
+    -- on pass one, so every indicator the new preset had just created stayed unlabelled
+    -- until Indicator Info was toggled off and on (Krathe, 2026-08-21). The `pending`
+    -- term is the fix: keep going while anything reports itself rendering and refuses
+    -- to measure. The empty-result term stays exactly as it was, because on a fresh
+    -- login the handles do not exist yet and nothing can report itself pending at all.
+    -- ⚠ An element that reports shown but can never measure burns the whole budget on
+    -- every settings change (~1.5s of cheap self-cancelling timers). That is the state
+    -- worth retrying into, and elementShown fails OPEN on a refused read, so the cost
+    -- is bounded and the alternative is dropping the case this exists for.
+    if (pending or #hoverRegions == 0)
+        and settleLeft > 0 and (poolWants(false) or poolWants(true)) then
         settleLeft = settleLeft - 1
         scheduleSettle()
+    else
+        settleLeft = 0
     end
 end
 

--- a/DandersFrames_Options/TestMode/Labels.lua
+++ b/DandersFrames_Options/TestMode/Labels.lua
@@ -1108,5 +1108,41 @@ function TL:Clear()
     for k in pairs(regionOf) do regionOf[k] = nil end
 end
 
+-- ============================================================
+-- INVALIDATION — the Aura Designer moved underneath us
+-- ============================================================
+-- ☠ HOOKED TO THE MUTATION, NOT TO ITS CALLERS. The region list is rebuilt from
+-- DF:RefreshTestFrames / DF:UpdateRaidTestFrames. Every TEST PANEL control reaches
+-- those -- tick "Buffs" and the mark appears, which is why the feature looked fine --
+-- and nothing on a DESIGNER PRESET path reaches them at all. Switching the preset
+-- therefore rebuilt every indicator behind a list nobody rebuilt: the new ones were
+-- unhoverable until Indicator Info was toggled off and on, while the elements the
+-- switch had not touched kept their marks throughout, which is what made it read as
+-- "only the defensive icon has info" (Krathe, 2026-08-21).
+-- ⚠ Hooking Engine:ForceRefreshAllFrames was tried first and fixed the editor's own
+-- actions only — the preset bar does not go through it. Chasing callers was the error,
+-- not the choice of caller.
+-- ★ The one thing true of EVERY path, present and future: if an indicator appeared,
+-- moved or vanished on a test frame, Factory:SyncFrame or Factory:ClearFrame ran on
+-- that frame. That is where this is called from, and it is why no caller has to know
+-- this feature exists.
+-- Coalesced onto a single next-tick pass: a refresh calls SyncFrame once per test
+-- frame (10 by default, 40 at most) and they all want the same one rebuild. The tick
+-- of delay is needed regardless — a container built this tick has no rect until the
+-- layout settles — and TL:Update's settle retry covers a tick not being enough.
+local invalidatePending = false
+function TL:Invalidate()
+    if invalidatePending then return end
+    if not labelsWanted() then return end
+    invalidatePending = true
+    C_Timer.After(0, function()
+        invalidatePending = false
+        -- Re-asked on arrival: test mode can end, or the option be switched off,
+        -- between the request and the pass.
+        if labelsWanted() then TL:Update() end
+    end)
+end
+
 function DF:UpdateTestLabels() TL:Update() end
 function DF:ClearTestLabels()  TL:Clear()  end
+function DF:InvalidateTestLabels() TL:Invalidate() end


### PR DESCRIPTION
## What this is

A round of tracker bug fixes: ten reports, six of which turned out to be one cause.

Independent of #242 and #244 — every commit cherry-picked onto this base with no conflict, so this can merge in any order relative to them.

## The one that mattered: Aura Designer effects dying mid-fight

Six reports with the same shape and different symptoms — icons frozen with the duration no longer counting, a health-bar recolour that vanishes, an effect stuck on the wrong three people, "hots just stop working". Which element dies differs per reporter because **the failure is per container, not per feature**.

`_noteGateRecovery` is the only thing that re-parses a pool that has fallen open, and it fires on a single `false→true` assist edge. It stamped `_idGateAssist` *before* attempting the re-parse, and unconditionally — so once that edge was spent, `was == false` was never true again for the life of that handle.

Then the re-parse it was spent on could not work:

* Only the Hide/Show bounce makes the engine re-read `candidateFilters`. `NativeBackend:refresh` cannot bounce a container in combat, so it falls back to `UpdateAllAuras` — which repaints from the candidate set it **already has**, i.e. exactly the stale set that needs replacing.
* `Handle:Refresh` returns early when there is no backend at all, which is the normal state of a container whose build was deferred to combat end.

Neither reported anything back, so both were indistinguishable from success. Verdict ≠ actuation, and the verdict is what got recorded.

**The trigger is sustained combat, not any particular content.** The edge is lost whenever trust recovers before the pull ends, and every trigger can do that: a death and a rez, a cinematic, a vehicle, phasing, a disconnect. Raid is at least as good a repro as a key and arguably better — a battle rez is a `false→true` assist edge landing squarely mid-fight, boss cinematics and platform phases fire without dropping combat, and encounters run longer. It is *not* a world bug: out there you are usually out of combat when trust returns, the bounce runs, and nobody sees it.

**The fix.** Both refresh paths now return whether a real re-parse happened. The edge is consumed only then; otherwise the verdict stays false so the next gate pass retries, **and** a combat-end retry is queued. Both halves matter — the retry guarantees the recovery, the un-consumed verdict makes it idempotent and covers a retry that also fails. The cinematic latch clears only on the same success, since its whole contract is that frames come back already re-parsed.

**The sibling.** `SlotHandle:_noteGateRecovery` was mostly right — it queues a replay in combat — but it stamped the verdict before an early return on a missing container, which queues nothing. Same spent edge, narrower path.

**Found on the way, same file, same shape.** The combat-end drain asked whether a rebuild had been *requested*, not whether one had *run*. A parent-driven link skips its own rebuild (correct — the parent recreates it), but its pending tuning and restyle were already consumed and then suppressed by `op ~= "rebuild"`, and the unit and enabled state the rebuild was standing in for were never re-declared. Four deferred actions dropped with nothing left to re-queue them. `_queueOp` upgrades *any* two different lesser ops to `"rebuild"`, so an ordinary combat where a link is both retargeted and re-enabled lands there.

## Four self-contained bugs

**My Buffs / Any Buffs exclusivity.** Deleting an aura's last effect leaves its config table in the pool on purpose — `CleanupAdHocAura` prunes only synthetic records and says curated ones keep the linger. `PoolTrackedIDs` did not allow for it, so an emptied record kept contributing its spell IDs to the opposite pool's blocked set forever, because nothing prunes the thing it was reading. Fixed at the read: an aura with no effects cannot double-render, so it cannot block. That also heals profiles already carrying an emptied record, which pruning-on-delete would not.

**Missing health hidden by a health-bar aura.** The show-when-missing branch never read `tintWholeBar` — it always painted the badge's full rect, so Tint + entire-bar-unticked + when-missing is a configuration where the checkbox is simply inert. The preview was right because it renders the *present*-mode shape: a divergence in rendering, which is the thing previews may never do.

**Dispel overlay vs reduced max HP.** "Show On Current Health Only" effectively was off. The clip that shrinks `frame.healthBar` to the portion that is still health was gated on `not pctIsSecret` — and the comment three lines above it says the percent comes back secret in restricted content, *exactly where max-HP reductions live*. So the clip ran in test mode and nowhere else. Anchoring resolves engine-side and reads nothing in Lua; it is the same route `DispelSlotSecureInit` rests on and the same thing `UpdateAbsorb` already does to that exact texture, ungated and shipping.

⚠ **This one needs verification before release.** It changes health-bar geometry for every frame in combat — a wider blast radius than the bug. Guarded, with the fallback re-pinning the plain rect rather than leaving the bar unanchored. It also means the attached-absorb maths ("the bar physically ends there") was wrong in the same content, for the same reason; nobody reported that separately.

**Pet frame missing after death.** `UNIT_PET` is a one-shot and can arrive before the pet token is populated; the handler then hides, and no second `UNIT_PET` is coming. Every other arm was hide-only — the pet's own `UNIT_FLAGS` could hide the frame and never show it — so the only route back was an owner event or toggling the feature. That is the workaround in the report, which is what identifies the dead paths. Every arm that can hide now has a matching show, edge-gated on the flag `SetPetFrameVisible` already maintains so the hot path costs one field read, and routed through `RefreshPetFrame` so a pet arriving outside a track pass is repositioned as well as shown.

## Indicator Info (test mode), from the same session

Two halves. Layout groups were invisible to the feature — it walked `store.placed` and not `fgroups`/`dgroups`, so groups were unhoverable and a design built only from groups read as switched off entirely. And no Aura Designer path rebuilt the region list, so switching a designer preset left every new indicator unhoverable until the option was toggled off and on. The rebuild now hangs off `Factory:SyncFrame`/`ClearFrame` — the mutation itself, which every path reaches by definition. Hooking a caller was tried first and covered the editor's own actions but not the preset bar.

The union-of-all-indicators region is now one region per placement: with only the hovered region marked, a union drew brackets around empty space and lost the smallest-region-wins hit test to every row nested inside it.

## Verification

`luac -p` clean and `_ENV` global reads identical to this base on all 8 changed files, with one intended delta (`+pcall` in `ReducedMaxHealth.lua`). All files uniformly CRLF, no BOM.

## Not confirmed in game

None of it. For the cluster specifically, **do not accept silence as evidence** — "it didn't happen this run" is weak for an intermittent bug. The gate now logs a held edge and its retry on `IDGATE`, so a raid night with that category on should show recoveries being deferred during pulls and completing at the end of each one, with a battle rez as a deliberate trigger. That is the positive evidence.

## One thing the cluster fix does not explain

One reporter states that `/reload` does **not** clear it and only a full relog does. This fix cannot account for that: a reload builds fresh handles with a fresh verdict, so a reload should clear it. Another reporter says a reload does fix theirs, which is consistent. That discriminator is unresolved, and until it is retested I would treat the relog-only case as possibly a second bug wearing the same symptoms rather than as covered here.

No changelog entries — those wait until the fixes are confirmed in game.


## Added after review: two follow-ups on the same gate

**The drain no longer stamps the verdict.** The combat-end retry used to set `_idGateAssist = true` after its successful bounce — a timer declaring a unit recovered without asking the probes. If trust had dropped *again* during the same combat, the real recovery later saw no false→true edge and never re-parsed: the same class this PR fixes, reintroduced on one corner. The drain now clears only the retry debt; the verdict stays false and the next gate pass stamps through the normal flow, which re-asks the probes first. Cost is one redundant bounce. The matching bookkeeping leak (a pass recovering before the drain left the debt set, causing a spurious bounce next regen) is closed too.

**The vehicle probe distrusts the pool swap, not the passenger flag.** Field-caught with full logging: a player was flagged `self-vehicle` for 5m38s of a raid fight — parked own-frame pools, "my PoM was not showing on myself but was showing on other players" — while healing normally the whole time, so the action bars were provably never swapped. `UnitUsingVehicle` is true for any vehicle association, including riding an encounter's transport entity where the aura pool never leaves the player; the log's 5-second backstop re-probed throughout and it answered true on every tick, so this was a wrong verdict, not a missed edge. The probe now consults `UnitHasVehicleUI` — the exact signal the client's own compact frames use to decide the unit swap — with the old APIs kept as fallbacks. The trade is one dispatch of a genuine vehicle's swapped pool before the `ENTERED_VEHICLE` sweep parks it; the gate's fail-safe direction is SHOW, and the log shows both sides (a legitimate two-second boarding park at 12:07, and the five-minute wrong one at 14:49).
