### PR TITLE
Debuff filters: restore the All Debuffs completeness warning as a conditional caution banner

### DIFF
--- a/DandersFrames_Options/FilterRegistry/UI/Options.lua
+++ b/DandersFrames_Options/FilterRegistry/UI/Options.lua
@@ -2780,8 +2780,15 @@ function DF.BuildFilterDesignerPage(guiRef, pageRef, dbRef)
         -- turned the top of the page gold AND displaced the tab's own explanation --
         -- a warning about one switch, four inches from that switch, evicting the copy
         -- that says what the whole tab is. That caution is now a banner of its own
-        -- directly under All Debuffs (see catCaution), beside the control it is about,
-        -- and nothing has to give up its slot for it.
+        -- directly under All Debuffs, beside the control it is about, and nothing has
+        -- to give up its slot for it.
+        -- ⚠ It lives on the DEBUFF BAR page, not here: GUI/Pages/Indicators.lua,
+        -- pageDebuffs, still named `catCaution`. This pointer used to say "see
+        -- catCaution" meaning the local a few hundred lines up, and cf70ac00 -- the
+        -- commit that moved the debuff half off this page -- deleted that local and
+        -- left the reference behind. The banner went with it: it came back as a
+        -- permanent grey caption on the new page, losing both its condition and its
+        -- tone, and stayed that way until 2026-08-21.
         --
         -- The rule that leaves behind: this banner says "here is how this tab works"
         -- and is always info; anything that says "this will silently miss things"

--- a/DandersFrames_Options/GUI/Pages/Indicators.lua
+++ b/DandersFrames_Options/GUI/Pages/Indicators.lua
@@ -774,8 +774,40 @@ function DF._SetupGUIPagesPart4(GUI, CreateCategory, CreateSubTab, BuildPage, L,
             -- category obviously misses things, so saying that adds nothing. What is
             -- surprising is that switching on every category still is not All
             -- Debuffs, because Blizzard tagged some debuffs with none of them.
-            filterGroup:AddWidget(GUI:CreateLabel(self.child,
-                "|cff888888" .. L["Only All Debuffs shows every debuff: all the categories combined still miss some debuffs."] .. "|r", 250), 45)
+            --
+            -- ☠ A CAUTION BANNER, CONDITIONAL — not a permanent grey caption. It was a
+            -- banner on the old shared Filters page (catCaution, gated on this same
+            -- switch) and became a static label when the debuff half moved here in
+            -- cf70ac00; that page still carries a "see catCaution" comment pointing at
+            -- the symbol the move deleted. Two things were lost with it:
+            --   * it was CONDITIONAL. All Debuffs is on by default and is the correct
+            --     setting, so a permanent caption warns the overwhelming majority of
+            --     users about a state they are not in -- and the reader who IS in it
+            --     gets no more emphasis than the reader who is not.
+            --   * it was a CAUTION TONE. The completeness gap is Blizzard's and cannot
+            --     be fixed from here: no combination of these tickboxes is complete.
+            --     That is a genuine "this will silently miss things", not a footnote,
+            --     and grey body text is the register this page uses for ordinary help.
+            -- ⚠ The page-banner slot is deliberately NOT where this goes. That was
+            -- tried and reverted on the old page: a warning about one switch, four
+            -- inches from it, displaced the tab's own explanation while it showed.
+            -- It belongs against the control that causes it.
+            --
+            -- ⚠ TEXT SET ONCE, AT CREATION, AND NEVER RE-SET. A banner whose
+            -- SetText/SetHTML is driven from a refresh can feed the refreshContent
+            -- loop that froze the GUI once before, so this one only ever gets hideOn.
+            -- Do not add a refreshContent to it.
+            local catCaution = GUI:CreateInfoBanner(self.child, {
+                tone = "caution",
+                text = L["Only All Debuffs shows every debuff: all the categories combined still miss some debuffs."],
+                minHeight = 30,
+            })
+            -- Shown only while All Debuffs is OFF — the state the warning is about, and
+            -- turning that switch back on is what it tells you to do. A hidden group
+            -- child collapses to nothing (LayoutChildren's entryVisible), so the rows
+            -- below close up rather than leaving a hole where it would have been.
+            catCaution.hideOn = function(d) return (d.directDebuffShowAll and true) or false end
+            filterGroup:AddWidget(catCaution, catCaution.layoutHeight or 45)
 
             -- Blizzard's fixed categories, in the order the old page listed them.
             local DEBUFF_CATEGORIES = {


### PR DESCRIPTION
## What this is

Restores the All Debuffs completeness warning as the conditional caution banner it used to be. Reported as: *"before we split buffs and debuffs out of the filters page we had a warning banner that would trigger if a user did not select All Debuffs. It used our banner system. It's somehow got lost."*

It did, and the history names the commit.

## What happened

`cf70ac00` (2026-08-10, "Aura filters: build them in the Filter Designer, pick them where they show") moved the debuff half off the shared Filters page. `catCaution` — a caution-toned `InfoBanner` placed directly under the All Debuffs switch and shown only while that switch was **off** — did not come with it. What arrived on the Debuff Bar page instead was a permanent grey `CreateLabel` carrying the same sentence.

The reference count is the whole story: **12 mentions of `catCaution` before that commit, 1 after** — and the survivor is a comment on the page it left, reading "see catCaution", pointing at a local the same commit deleted. It has been dangling since.

So it was *downgraded*, not deleted, which is why it stayed invisible for eleven days — the words were still on screen.

## Why the downgrade matters

Two properties were lost, and both are the point of the warning:

**It was conditional.** All Debuffs is on by default and is the correct setting, so a permanent caption warns the great majority of users about a state they are not in — and gives the one user who *is* in it no more emphasis than everyone else. The banner appears only when the switch is off, which is exactly when the incompleteness is real.

**It was a caution tone.** No combination of those tickboxes is complete: Blizzard tagged some debuffs with none of the categories and we cannot widen them. That is a genuine "this will silently miss things", not a footnote, and grey body text is the register that page uses for ordinary help.

## The restore

On the page that owns the control now (`GUI/Pages/Indicators.lua`, `pageDebuffs`), same locale string so there is no translation churn, gated by `hideOn` on `directDebuffShowAll`.

Mechanics verified rather than assumed:

* a hidden group child collapses to nothing (`LayoutChildren`'s `entryVisible`), so the category rows below close up instead of leaving a hole;
* `RelayoutHost` rewrites `entry.height` after the banner measures its wrapped text, so the fixed slot height passed at `AddWidget` time self-corrects;
* the hidden-at-birth case is handled by the factory's `deferredWhileHidden`/`OnShow` path — which matters here, because the default state hides it.

⚠ Text is set **once** at creation and never re-set, carried over from the original for the reason the original gave: a banner whose `SetText`/`SetHTML` runs from a refresh can feed the `refreshContent` loop that froze the GUI once before. There is no `refreshContent` on this banner and there must not be one.

The page-banner slot is deliberately not where this went. That was tried and reverted on the old page — a warning about one switch, four inches from it, turning the top of the page gold and displacing the tab's own explanation. It belongs against the control that causes it.

The dangling "see catCaution" comment is corrected rather than deleted: it now names the page the banner actually lives on and records that the move lost it.

## Verification

`luac -p` clean, `_ENV` global reads identical to this base on both files, CRLF preserved.

**Not confirmed in game.** Open Auras → Debuff Bar, untick All Debuffs: the gold caution should appear directly under the switch and vanish when it is re-ticked.

## Note on origin

This was cut for #245 but that PR merged about five minutes before the commit was ready, so it stands alone here. It is unrelated to everything in #242/#244/#245 and touches two files none of them did.
