### PR TITLE
AD group indicators fade out of range, and aura rows confirm their retarget re-parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (Aura Designer) Fix layout and filter group indicators staying at full brightness on out-of-range players when element-specific fading is on — placed indicators faded, groups next to them did not. (by Krathe)
+
 ## [5.3.1]
 
 ### New Features

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -2449,6 +2449,33 @@ local function rowTuningSig(cfg)
     }, "|")
 end
 
+-- ☠ CONFIRM THE RETARGET ACTUALLY RE-PARSED, AND SAY SO WHEN IT DID NOT.
+-- NativeBackend:setUnit already does a partition bounce out of combat, which is SUPPOSED to
+-- make the container drop the previous occupant's parse. Field evidence says it does not
+-- always land: a shaman's own Earth Shield stayed on a frame after "party3 -> party2", out
+-- of combat, with the log showing the three retargets and then nothing at all
+-- (2026-08-26 22:14). A buff nobody re-casts generates no UNIT_AURA on the new unit, so a
+-- missed re-parse has nothing to correct it and the icon sits there until a reload.
+--
+-- Handle:Refresh is the addon-callable re-parse and it RETURNS whether a genuine one
+-- happened, so this is a fix and an instrument at once: it forces the parse, and a "did NOT
+-- happen" line is the bounce having failed rather than an unexplained icon.
+-- ✅ Source-confirmed combat-safe (see the note on Handle:Refresh). No combat gate needed
+-- anyway — in combat the retarget itself defers to regen, so this cannot be reached there.
+-- ⚠ Cheap: the drives call this only on an ACTUAL unit change, never per pass.
+local function confirmRetarget(h, label, unit)
+    if not (h and h.Refresh) then return end
+    local ok, reparsed = pcall(h.Refresh, h)
+    if not ok then
+        DF:DebugWarn("AURAROW", "%s: retarget re-parse THREW on %s", label, tostring(unit))
+    elseif not reparsed then
+        DF:DebugWarn("AURAROW", "%s: retarget re-parse did NOT happen on %s - the row may "
+            .. "still be showing the previous occupant", label, tostring(unit))
+    else
+        DF:Debug("AURAROW", "%s: retarget re-parsed on %s", label, tostring(unit))
+    end
+end
+
 -- Drive the factory buff row for one frame. Creates the container lazily, hides the legacy
 -- icons (no double row), keeps it on the frame's unit, and applies setting changes. The
 -- container self-updates from UNIT_AURA, so there is no per-tick render here.
@@ -2493,6 +2520,7 @@ function DF:DriveBuffFactory(frame, db)
             InCombatLockdown() and " (in combat: row hidden until regen)" or "")
         h:SetUnit(frame.unit)
         frame.dfBuffFactoryHidden = InCombatLockdown() or nil
+        if not InCombatLockdown() then confirmRetarget(h, "buff", frame.unit) end
     elseif frame.dfBuffFactoryHidden and not InCombatLockdown() then
         DF:Debug("AURAROW", "buff: regen, unhiding row after deferred retarget")
         frame.dfBuffFactoryHidden = nil
@@ -2695,6 +2723,7 @@ function DF:DriveDebuffFactory(frame, db)
             InCombatLockdown() and " (in combat: row hidden until regen)" or "")
         h:SetUnit(frame.unit)
         frame.dfDebuffFactoryHidden = InCombatLockdown() or nil
+        if not InCombatLockdown() then confirmRetarget(h, "debuff", frame.unit) end
     elseif frame.dfDebuffFactoryHidden and not InCombatLockdown() then
         DF:Debug("AURAROW", "debuff: regen, unhiding row after deferred retarget")
         frame.dfDebuffFactoryHidden = nil
@@ -3002,6 +3031,7 @@ function DF:DriveDefensiveFactory(frame, db)
             InCombatLockdown() and " (in combat: row hidden until regen)" or "")
         h:SetUnit(frame.unit)
         frame.dfDefFactoryHidden = InCombatLockdown() or nil
+        if not InCombatLockdown() then confirmRetarget(h, "defensive", frame.unit) end
     elseif frame.dfDefFactoryHidden and not InCombatLockdown() then
         DF:Debug("AURAROW", "defensive: regen, unhiding row after deferred retarget")
         frame.dfDefFactoryHidden = nil

--- a/DandersFrames/Features/ElementAppearance.lua
+++ b/DandersFrames/Features/ElementAppearance.lua
@@ -1431,8 +1431,24 @@ end
 -- regions hangs off — its own anchor frame for a container, dfLevelHost for a
 -- collapsed slot — so fading it fades the indicator whole. Nil only if host creation
 -- failed, hence the guard. See SlotHandle:GetAlphaHost.
+-- ☠☠ "fgroups"/"dgroups" WERE MISSING FROM THIS LIST, AND THAT WAS THE WHOLE
+-- "AD groups don't fade out of range" bug (element mode, 2026-08-26). The Factory's own
+-- retarget list names all eight stores; this one named six. Group containers therefore
+-- had NO alpha writer at all in element mode — the frame is pinned at base there, so the
+-- cascade that covers them in whole-frame mode never runs, and nothing else touches them.
+-- Placed indicators kept fading (slot-owner anchor), which made it look like the old
+-- anchor fix had regressed. It had not: groups are a different pathway that never had the
+-- fade wired.
+-- ⚠ Krathe's differential located it — "my AD single PI is working, it's a group that
+-- doesn't fade" — after four wrong theories from me about the anchor path.
+-- ★ Group handles are ROW handles: entry.handle.button is nil, so the walk's existing
+-- callback routes them onto the fade branch (base-only in whole-frame mode, where the
+-- cascade already fades them — no squared fade, see [ad_oor_fade_two_layers]).
+-- ☠ If the Factory ever grows a ninth store, IT GOES IN BOTH LISTS — this one and the
+-- retarget walk at Factory.lua ~5464 — or its containers will silently skip either fades
+-- or unit reassignment.
 local AD_STORE_KEYS = { "healthbar", "background", "border", "placed",
-                        "nametext", "healthtext" }
+                        "nametext", "healthtext", "fgroups", "dgroups" }
 
 -- ☠ THE WRITE IS PROTECTED, AND A DENIED HOST IS REMEMBERED.
 -- GetAlphaHost is supposed to answer with a DF-owned frame, so in principle a tainted

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -6698,6 +6698,25 @@ local function ensureOwner(frame, unit)
     owner = { frame = frame, anchor = anchor, container = c, unit = unit, slots = {}, seq = 0 }
     frame.dfSlotOwner = owner
     AuraContainer.stats.slotOwners = (AuraContainer.stats.slotOwners or 0) + 1
+
+    -- ★ SEED THE APPEARANCE AT BIRTH — defensive, not a diagnosis.
+    -- In element-fade mode this anchor is the only thing that fades slot-backed Aura
+    -- Designer indicators, the pass that writes it runs on a range EDGE, and the owner is
+    -- stood up LAZILY on first slot acquisition. An anchor born while its unit is already
+    -- out of range would therefore start at full alpha with no further edge to correct it;
+    -- this call closes that ordering hole. Idempotent (the pass recomputes from db + the
+    -- frame's own range state) and effectively a no-op in whole-frame mode, where the
+    -- unit-frame cascade covers the anchor anyway.
+    --
+    -- ⚠ HONEST STATUS: this shipped mid-hunt as THE fix for "AD indicators don't fade out
+    -- of range" (2026-08-26) and it was NOT that bug — the field fault was group
+    -- containers being absent from ElementAppearance's AD_STORE_KEYS walk entirely, fixed
+    -- separately. The birth-order hole above is real but was never proven to be biting.
+    -- Kept because it is one cheap call at a rare event; if it is ever suspected of
+    -- misbehaving, deleting it outright is safe.
+    if DF.UpdateAuraDesignerAppearance then
+        pcall(DF.UpdateAuraDesignerAppearance, DF, frame)
+    end
     return owner
 end
 


### PR DESCRIPTION
Against **stable**. Independent of #254 apart from a trivial `CHANGELOG.md` overlap — both add an `[Unreleased]` section; whichever merges second resolves by keeping both bullets.

## AD group indicators fade out of range ✅ *confirmed in game*

With element-specific out-of-range fading, a layout/filter group's indicators sat at full brightness on a faded frame while a **placed** indicator beside them faded correctly.

The Factory keeps one container handle per enabled group in `store.fgroups` / `store.dgroups`; its own retarget walk names all eight of its stores. The alpha-fade walk's store list named **six** — groups were absent — so group containers had no alpha writer at all in element mode: the frame is pinned at base there, and the whole-frame cascade that masks the hole in the other mode never runs. That masking is also why whole-frame fading worked throughout, which made this look like a regression of the 22086f49 slot-anchor fix. It was not — that fix is intact, which is why placed indicators kept fading.

The fix is adding the two keys. Group handles are row handles, so the walk's existing callback routes them onto the fade branch — and base-only in whole-frame mode, where the cascade already fades them, so no squared fade. Verified no competing writer exists on a group wrapper. The comment at the key list now states the rule: a ninth Factory store goes in **both** lists, or its containers silently skip either fades or unit reassignment.

Credit where due: the differential that located this — "my single placed indicator fades, the group doesn't" — was Krathe's, after the anchor-path theories had all come up empty.

## Slot anchor seeded at birth — *defensive, honestly labelled*

The slot-owner anchor (the legal fade target for slot-backed indicators) is stood up lazily on first slot acquisition, and the pass that fades it runs on a range **edge** — so an anchor born while its unit is already out of range would start at full alpha with no further trigger. One idempotent appearance call at owner creation closes that ordering hole. ⚠ The comment states its honest status: this shipped mid-hunt as a diagnosis of the group bug above and was **not** that bug; the hole it covers is real but was never proven to bite, and deleting the call is safe if ever suspected.

## Aura rows: force and confirm the re-parse on a retarget — *built, not yet field-confirmed*

Field report: a shaman's own Earth Shield stayed on a frame (frozen, no duration) after the frame changed hands, uncleaable without a reload. The log's last entries were the three rows retargeting `party3 -> party2`, out of combat, then nothing — the backend's out-of-combat partition bounce on `SetUnit` is *supposed* to drop the previous occupant's parse, and the evidence says it did not land. A long-lived buff nobody re-casts fires no `UNIT_AURA` on the new unit, so nothing ever corrects it.

`Handle:Refresh` is the addon-callable re-parse and returns whether a genuine one happened, so the retarget path now forces it and logs a warning when it reports false — a fix and an instrument in one. Source-confirmed combat-safe; unreachable in combat anyway since the retarget itself defers to regen. Fires only on an actual unit change. Built after the reporter's stuck icon was gone, hence unconfirmed; no changelog entry until it is.

## Verification

`luac -p` clean on every changed file, CRLF intact. `Frames/AuraContainer.lua` and `Features/ElementAppearance.lua` are **byte-identical to the tested tree** on their non-debug content (the tested tree additionally carries locally-held diagnostic tooling, deliberately excluded here). Changelog entry included for the confirmed fix only.