### PR TITLE
(Auras) Fix claimed Boss/Priority/Role debuffs leaking into the debuff row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* (Auras) Fix a claimed Boss/Priority/Role debuff still rendering a second time in the debuff row's Crowd Control, Raid, Dispellable or Non-Player group whenever it also matched one of those categories. "Hide Duplicate Debuffs" only ever subtracted a category from the row's own Boss/Role/Priority record; a category an Aura Designer debuff group claimed outright had no such record to subtract from, so the other category records never learned to exclude it.
+
 ### Changes
 
 ## [5.3.0]

--- a/DandersFrames/Features/Auras.lua
+++ b/DandersFrames/Features/Auras.lua
@@ -357,12 +357,21 @@ local function BuildDirectDebuffFilters(db, claimed)
                                   candidateFilters = cfFor(true, extra),
                                   style = importantStyle }
     end
-    -- Subtract whichever important records were declared. Returns a FRESH table each
-    -- call because cfFor mutates and returns the table it is handed.
+    -- Subtract whichever important records were declared, AND whichever
+    -- categories an Aura Designer group has claimed — a claimed category has
+    -- no row record of its own to read back, so leaving it out here let a
+    -- claimed Boss/Priority debuff double-render through CC/Raid/Dispellable/
+    -- Non-Player. Fresh table each call: cfFor mutates and returns what it's
+    -- handed.
+    local excludeBoss = boss or (claimed and claimed.boss) or false
+    local excludeRole = role or (claimed and claimed.role) or false
+    local excludePriority = db.debuffFilterPriority or (claimed and claimed.priority) or false
     local function notImportant(extra)
         extra = extra or {}
-        if importantFlag then extra[importantFlag] = false end
-        if priorityDeclared then extra.isPriorityAura = false end
+        if excludeBoss and excludeRole then extra.isBossOrRoleAura = false
+        elseif excludeBoss then extra.isBossAura = false
+        elseif excludeRole then extra.isRoleAura = false end
+        if excludePriority then extra.isPriorityAura = false end
         return extra
     end
     if ccToken and not (claimed and claimed.crowdControl) then


### PR DESCRIPTION
`BuildDirectDebuffFilters`, category mode. When an Aura Designer debuff group
claims a category (Boss, Priority, etc.), the row correctly skips building
that category's own record — but the other four category records (CC, Raid,
Dispellable, Non-Player) never find out. Their exclusion list was built from
`importantFlag`/`priorityDeclared`, which only get set when *this row*
declares its own Boss/Role/Priority record. A fully claimed category has no
such record, so nothing tells the other four to leave it out.

Result: a debuff that's Boss- or Priority-flagged and *also* Dispellable, CC,
Raid-flagged, or mob-applied renders a second time on the bar, next to the AD
group already showing it. Hide Duplicate Debuffs doesn't hold for that case.
Show All mode isn't affected — it already subtracts straight from `claimed`
instead of reading back a declared record.

Fix: exclude boss/role/priority based on (checkbox on) OR (claimed), computed
independently instead of read back from what got declared. When nothing's
claimed this is identical to the old behavior, so unclaimed setups see no
change.

Checked every other read of `importantFlag`/`priorityDeclared` in the
function — nothing outside `notImportant()` touches them.

### Verified with `/df debug auras <unit>`

AD group claiming Boss + Priority, row has Role/CC/Dispellable checked.

Before:
```
group 2 [cc]: HARMFUL|CROWD_CONTROL|!DISPELLABLE
    isRoleAura = false
group 4 [dispel]: HARMFUL|DISPELLABLE
    isRoleAura = false
```

After:
```
group 2 [cc]: HARMFUL|CROWD_CONTROL|!DISPELLABLE
    isRoleAura = false
    isBossOrRoleAura = false
    isPriorityAura = false
group 4 [dispel]: HARMFUL|DISPELLABLE
    isRoleAura = false
    isBossOrRoleAura = false
    isPriorityAura = false
```

Same delta on `raid` and `nonplayer`. Boss/Priority are now excluded from
every group they're claimed in, not just the one that no longer exists.
