### PR TITLE
Border animations return: the frame-level border and the aura icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@
 
 * (Aura Designer) Border animations are back from the 12.1 lockdown — first on the frame-level border, and now on the aura icons themselves: placed icons and squares, aura bars, and filter, debuff and layout group icons can all animate their borders again, in combat included. Icons always start on an effect's settled loop; only the frame-level border plays the intro flash. (by Krathe)
 
-### Bug Fixes
-
-* (Aura Designer) Fix layout and filter group indicators staying at full brightness on out-of-range players when element-specific fading is on — placed indicators faded, groups next to them did not. (by Krathe)
-* (Dispel) "Only Dispellable by You" now follows your talents everywhere, live. A Shaman's poison dispel appears and disappears with Poison Cleansing Totem, a Priest without Improved Purify no longer sees diseases they cannot cure, and talent changes apply to the overlay and the debuff row without a reload. (by Krathe)
-* (Dispel) Fix a Dwarf's bleed dispel lighting up on other players' frames after roster changes — Stoneform only cleanses yourself, so bleeds now show as dispellable only on your own frame. (by Krathe)
-
 ## [5.3.1]
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # DandersFrames Changelog
 
+## [Unreleased]
+
+### New Features
+
+* (Aura Designer) Border animations are back from the 12.1 lockdown — first on the frame-level border, and now on the aura icons themselves: placed icons and squares, aura bars, and filter, debuff and layout group icons can all animate their borders again, in combat included. Icons always start on an effect's settled loop; only the frame-level border plays the intro flash. (by Krathe)
+
+### Bug Fixes
+
+* (Aura Designer) Fix layout and filter group indicators staying at full brightness on out-of-range players when element-specific fading is on — placed indicators faded, groups next to them did not. (by Krathe)
+* (Dispel) "Only Dispellable by You" now follows your talents everywhere, live. A Shaman's poison dispel appears and disappears with Poison Cleansing Totem, a Priest without Improved Purify no longer sees diseases they cannot cure, and talent changes apply to the overlay and the debuff row without a reload. (by Krathe)
+* (Dispel) Fix a Dwarf's bleed dispel lighting up on other players' frames after roster changes — Stoneform only cleanses yourself, so bleeds now show as dispellable only on your own frame. (by Krathe)
+
 ## [5.3.1]
 
 ### New Features

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -1041,6 +1041,10 @@ local function buildBorderConfig(unit, map, spec, filter, drawAbove, pandemicSpe
         candidateFilters = { includeSpellIDs = map },
         enabled = true,
         frameLevelOffset = (drawAbove ~= false) and 11 or 9,
+        -- Opt this container into the DF-owned border animations. The AuraContainer
+        -- ANIMATION FILTER honours the flag for OVERLAY mode only, which is what keeps
+        -- the reopening bounded to one ring per frame — see the comment there.
+        adBorderAnim = true,
         style = { border = { spec = spec, pandemicSpec = pandemicSpec } },
     }
 end
@@ -1070,9 +1074,10 @@ end
 -- live aura), mirroring the legacy Indicators:ApplyBorderToOverlay (module removed): canonical keys via BuildSpec (the
 -- border-key fold ran in SyncFrame), black default colour. Returns nil when the border
 -- resolves disabled (ShowBorder=false) — the caller then renders no container. Animations
--- are NO LONGER dropped here: the AuraContainer allowlist (SAFE_OVERLAY_ANIM) is the single
--- filter, keeping the DF-owned overlay animations and stripping the taint-prone LCG glows.
--- The GUI restricts the AD dropdown to the recoverable types, so only safe types reach here.
+-- are not dropped here: the AuraContainer ANIMATION FILTER is the single gate, and it keeps
+-- an overlay-mode animation whose type is in SAFE_OVERLAY_ANIM. Every type the GUI currently
+-- offers is in that set (the LCG glows it used to exclude no longer exist), so the allowlist
+-- now only defends against a stale or imported profile naming an effect we do not own.
 local function buildBorderSpec(frame, borderCfg)
     if not DF.Border then return nil end
     local spec = DF.Border:BuildSpec(borderCfg, "")
@@ -1179,6 +1184,22 @@ local function borderSpecSig(spec)
         end
     end
     return tconcat(parts, "|")
+end
+
+-- ☠ ANIMATION IS STRUCTURAL ON A CONTAINER BORDER, not cosmetic.
+-- The frame-level ring renders on an overlay-mode container slot, and its animation is a
+-- declarative AnimationGroup built inside the slot's SECURE init and never touched again
+-- (Frames/Border.lua, "DF_ORBIT, DECLARATIVE") — because a per-frame Lua driver is refused
+-- on a button subtree once auras are secret. Creation-frozen means a retune is impossible,
+-- so changing the effect, its speed, particle count, colour or inset has to hand over a
+-- FRESH button: this token rides the STRUCT signature, where a change forces a Rebuild.
+-- Same contract as the pandemic FLASH.
+-- ⚠ It also stays inside borderSpecSig (the cosmetic sig), which is harmless — a change
+-- moves both and the structural branch wins.
+local function borderAnimStructToken(spec)
+    local a = spec and spec.animation
+    if not a or not a.type or a.type == "NONE" then return "off" end
+    return subSig(a)
 end
 
 -- Pick the single highest-priority configured indicator of `typeKey` across all configured
@@ -4813,6 +4834,7 @@ local function syncBorderEntry(bd, frame, key, cfg, map, mine)
     -- The pandemic ring's PRESENCE joins the struct sig: its holder is created in the
     -- secure init, so enabling it must hand over a fresh button.
     local structSig = "da=" .. tostring(drawAbove) .. (pdSpec and "|pd" or "")
+        .. "|an=" .. borderAnimStructToken(spec)
     local tuningSig = placedTuningSig(map, filt)
     local coSig = borderSpecSig(spec) .. (pdSpec and ("|pd=" .. colSig(cfg.pandemicColor)) or "")
 
@@ -5626,7 +5648,8 @@ function Factory:SyncFrame(frame)
             -- relative to `frame` (the flat path's parent) at any chain length.
             local pdChain = pandemicBorderSpec(bestSpec, bestCfg)
             return syncConditionChain(bd, bestName, frame, frame.unit, chainLinks, filt,
-                "da=" .. tostring(drawAboveBD) .. (pdChain and "|pd" or ""),
+                "da=" .. tostring(drawAboveBD) .. (pdChain and "|pd" or "")
+                    .. "|an=" .. borderAnimStructToken(bestSpec),
                 borderSpecSig(bestSpec) .. (pdChain and ("|pd=" .. colSig(bestCfg.pandemicColor)) or ""),
                 function(map, f) return buildBorderConfig(frame.unit, map, bestSpec, f, drawAboveBD, pdChain) end,
                 function(h) h:ApplyStyle({ border = { spec = bestSpec, pandemicSpec = pdChain } }) end,

--- a/DandersFrames/AuraDesigner/Factory.lua
+++ b/DandersFrames/AuraDesigner/Factory.lua
@@ -1604,6 +1604,37 @@ local function placedBorderRawSig(indicator, borderOn)
     return tconcat(parts, ",")
 end
 
+-- ☠ ANIMATION IS STRUCTURAL ON EVERY CONTAINER BORDER, buttons included (2026-08-29,
+-- row-mode reopened) — same contract as borderAnimStructToken below, raw-config and
+-- alloc-free for the per-tick sig paths (FIX C). The declarative AnimationGroups are
+-- built once in the slot's secure init and can never be retuned on a live (restricted)
+-- button, so ANY animation key change must hand over fresh buttons via Rebuild.
+-- EMPTY when no animation is configured, so every pre-animation profile sigs
+-- byte-identically and nothing rebuilds on upgrade (the durationFmtKey removals
+-- document why that stability matters). The keys mirror what BuildSpec("") folds into
+-- spec.animation — colour included: it is baked into the anim textures at build.
+-- `t` is whichever table BuildSpec reads: the indicator (placed/bar) or the group's
+-- style table (filter/debuff groups via buildGroupBorderSpec).
+local function rawBorderAnimStructTok(t, borderOn)
+    if not borderOn then return "" end
+    local ty = t.BorderAnimationType
+    if not ty or ty == "NONE" then return "" end
+    return "|an=" .. tostring(ty)
+        .. "," .. tostring(t.BorderAnimationFrequency)
+        .. "," .. tostring(t.BorderAnimationParticles)
+        .. "," .. tostring(t.BorderAnimationLength)
+        .. "," .. tostring(t.BorderAnimationThickness)
+        .. "," .. tostring(t.BorderAnimationScale)
+        .. "," .. tostring(t.BorderAnimationInset)
+        .. "," .. tostring(t.BorderAnimationOffsetX)
+        .. "," .. tostring(t.BorderAnimationOffsetY)
+        .. "," .. tostring(t.BorderAnimationMask)
+        .. "," .. tostring(t.BorderAnimationSidesAxis)
+        .. "," .. tostring(t.BorderAnimationCornerLength)
+        .. "," .. tostring(t.BorderAnimationProcStart)
+        .. "," .. colSig(t.BorderAnimationColor)
+end
+
 -- Native stack-count TextStyle spec from the AD stack config keys (font/scale/outline/
 -- anchor/offset/colour). Read-free — the COUNT itself is filled secure-side by Blizzard's
 -- SetApplicationCount (no formatter — secret trap), shown at >1. defOX/defOY parameterize
@@ -2205,6 +2236,10 @@ local function placedStructSig(isSquare, hideIcon, showStacks, showDuration, bor
         -- create-once, so a type change (or the master toggle) rebuilds. Everything else
         -- about it hot-applies and rides placedCoSig. "" when off.
         .. "|pd=" .. pandemicStructKey(indicator)
+        -- Border animation: creation-frozen declarative groups — see rawBorderAnimStructTok.
+        -- (The keys also stay in placedBorderRawSig's cosmetic hash, harmlessly: a change
+        -- moves both sigs and the structural branch wins.)
+        .. rawBorderAnimStructTok(indicator, borderOn)
 end
 
 -- TUNING signature: the live-mutable half of what placedStructSig used to carry. The
@@ -2977,6 +3012,7 @@ local function barStructSig(indicator, borderOn, defs)
         .. "|fl=" .. tostring(resolveLevel(indicator, defs.level))
         .. "|fs=" .. tostring(resolveStrata(indicator, defs.strata) or "")
         .. "|pd=" .. pandemicStructKey(indicator)   -- see placedStructSig
+        .. rawBorderAnimStructTok(indicator, borderOn)   -- creation-frozen — see the helper
 end
 
 -- COSMETIC signature: size (width/height + match-frame + the fed frame size), anchor/offset/
@@ -3189,6 +3225,10 @@ local function groupStyleStructSig(group)
         -- style is absent, {}, or carries durationBarEnabled = false.
         .. "|" .. (s.durationBarEnabled == true and "bar" or "")
         -- (No pandemic entry — see buildFilterGroupStyle for why groups don't carry it yet.)
+        -- Border animation: the group border reads the SAME BorderAnimation* keys off the
+        -- group's style table (buildGroupBorderSpec -> buildPlacedBorderSpec(s)), and the
+        -- declarative groups are creation-frozen — see rawBorderAnimStructTok.
+        .. rawBorderAnimStructTok(s, s.ShowBorder == true)
 end
 
 -- EDITOR PREVIEW CONFIG for one SAMPLE slot of a filter/debuff group: the same

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -130,12 +130,12 @@ local warnedFilterString = false
 -- other two for the session. Same split, same reasoning, as the dispel pair above.
 local warnedPandemicBorder, warnedPandemicRegion, warnedPandemicCover = false, false, false
 
--- Animations SAFE to run on an OVERLAY-mode border (Aura Designer). These render
--- entirely on DF-owned child regions of the border (edge alpha ticks + DF_DASH's
--- own dash / sparkle / flipbook / overlay textures on our own frames), so they
--- never re-parent anything onto a Blizzard AuraButton and never taint.
--- Any type NOT in this set (a future/unknown type) is stripped. ROW mode always
--- strips (see below).
+-- Animations SAFE to run on a container border (Aura Designer) — overlay-mode
+-- frame borders AND row-mode aura buttons (the latter reopened 2026-08-29). These
+-- render entirely on DF-owned child regions of the border (edge alpha ticks +
+-- DF_DASH's own dash / sparkle / flipbook / overlay textures on our own frames),
+-- so they never re-parent anything onto a Blizzard AuraButton and never taint.
+-- Any type NOT in this set (a future/unknown type) is stripped.
 local SAFE_OVERLAY_ANIM = {
     DF_PULSATE     = true,
     DF_DASH        = true,
@@ -1468,22 +1468,32 @@ local function styleButton_regions(slot, config)
                 -- (Border.lua's sharedAnimDriver), so the failure mode is a stopped effect,
                 -- not a log flood — which is what makes this safe to reopen at all.
                 --
-                -- Reopened for OVERLAY mode only, and only when the container opted in:
-                --   * overlay = the whole-frame presence box (the Aura Designer's frame-level
-                --     border). One ring per frame, so the per-frame cost is bounded.
-                --   * ROW mode always strips. A row holds many icons and every group
-                --     allocates its buttons up front, so a looping effect would run on
-                --     buttons no aura is even using.
-                --   * config.adBorderAnim is the opt-in. The AD factory sets it on several
-                --     ROW containers too; those stay inert because of the isRow test above,
-                --     deliberately — widening to them is a separate, measured decision.
+                -- Reopened wherever the container opted in (config.adBorderAnim):
+                --   * overlay = the whole-frame presence box (the AD frame-level border) —
+                --     the first surface reopened (2026-08-27), proven in combat.
+                --   * ROW-mode buttons too (2026-08-29, Krathe's call — "make it work for
+                --     the actual aura buttons"). The old objection was that every group
+                --     pre-allocates its 10-button batch, so a looping effect runs on
+                --     buttons no aura is using. Under the DECLARATIVE regime that is the
+                --     FEATURE, not the cost: the anims are C-side AnimationGroups built
+                --     once in the secure init, they tick invisibly on hidden buttons for
+                --     pennies, and when the engine Shows a button its effect is already
+                --     running — presence-driven animation with zero addon reads. Intro
+                --     one-shots (DF Proc's burst) play at BUILD, not at aura-appear
+                --     (presence is secret; no OnShow script runs in the subtree), so
+                --     buttons show the steady loop only.
+                --   * ☠ Animation keys are STRUCTURAL for every opted-in consumer: the
+                --     groups are creation-frozen on a restricted button, so each factory
+                --     sig folds rawBorderAnimStructTok / borderAnimStructToken and a key
+                --     change hands over fresh buttons via Rebuild. A restyle with an
+                --     UNCHANGED spec is a no-op (Border.lua's dedupe counts _declAnims).
                 -- SAFE_OVERLAY_ANIM still filters the TYPE, so a stale profile naming an
                 -- effect we no longer own renders static rather than erroring.
                 -- DF-owned frames OFF the container — unit-frame border, missing-buff badge,
                 -- targeted-spell highlight — were never affected and keep animating.
                 if spec then
                     local animType = spec.animation and spec.animation.type
-                    if isRow or not config.adBorderAnim
+                    if not config.adBorderAnim
                         or not (animType and SAFE_OVERLAY_ANIM[animType]) then
                         spec.animation = nil
                     end

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -54,12 +54,21 @@ local addonName, DF = ...
 --      forwards the curve without the required `property`, and DurationTextBinding is private).
 --      Colour-by-time = discrete BUCKETS via the duration formatter (|c escapes) — P2.
 --      Stacks formatters are FORBIDDEN outright (secret trap — see bindNative).
---   6. Animation drivers do NOT run inside the button subtree: onUpdateMode=disabled
---      propagates, so an OnUpdate/AnimationGroup on a descendant is installed but never
---      ticks (verified in-game — SetScript/Play merely don't error). Host the driver
---      OUTSIDE the subtree (e.g. UIParent) and drive our own textures by reference — see
---      DF.Border ensureDriver (secretRect -> UIParent). Expiry-TRIGGERED anim is separately
---      dead (needs the sealed timer).
+--   6. ☠ CORRECTED 2026-08-27 — this said "an OnUpdate/AnimationGroup on a descendant is
+--      installed but never ticks", and the AnimationGroup half is FALSE. It is what kept
+--      animation retired here for six weeks, so read the split carefully:
+--        * SCRIPTS do not run in the button subtree. onUpdateMode=disabled, and
+--          ForbiddenAspect.UntrustedScriptExecution is documented as propagating to
+--          children. So host an OnUpdate driver OUTSIDE the subtree (e.g. UIParent) and
+--          drive our own textures by reference — DF.Border ensureDriver (secretRect).
+--        * A DECLARATIVE AnimationGroup is not a script and DOES run. Built and :Play()ed
+--          inside initializeFrame and never touched again, it animates C-side with zero Lua
+--          per frame — our own pandemic FLASH does exactly this, on a slot child.
+--      What the OUTSIDE-hosted driver still cannot do is WRITE into the subtree while auras
+--      are secret; that is the real constraint, and it is now guarded rather than assumed
+--      (Border.lua's driver drops a border whose tick is refused).
+--      Expiry-TRIGGERED anim remains separately dead (needs the sealed timer) — though an
+--      always-playing effect revealed by the duration-band formatter is not the same thing.
 --   7. Cannot read IsShown / spellId / expirationTime / dispelName / presence — all secret.
 --      Never branch on them. Filtering is Blizzard-side (filterString + candidateFilters).
 --   8. Group topology is add-only: no RemoveAuraGroup/Slot; a filterString change = recreate
@@ -1445,19 +1454,39 @@ local function styleButton_regions(slot, config)
                     if spec then spec.knownWidth, spec.knownHeight = sx, sy end
                 end
                 -- ANIMATION FILTER (single chokepoint for every container border).
-                -- 12.1 PTR-5 made AuraButtons blanket-forbidden while auras are secret
-                -- (combat / M+ / encounters / PvP): once forbidden, ANY API call on the
-                -- button OR its children errors from our tainted code — including the
-                -- render setters our OnUpdate border driver uses (SetVertexColor / Hide /
-                -- SetPoint). Every animated border here lives on a container-button child,
-                -- so any animation spams a per-frame forbidden error in exactly the content
-                -- these indicators are for. Animation is therefore stripped on ALL
-                -- container borders unconditionally (the recovery that once let AD placed /
-                -- overlay borders animate via config.adBorderAnim is gone). DF-owned frames
-                -- OFF the container — unit-frame border, missing-buff badge, targeted-spell
-                -- highlight — are not forbidden and keep animating through their own paths.
+                -- 12.1 PTR-5 made AuraButtons forbidden to tainted code while auras are
+                -- secret (combat / M+ / encounters / PvP), descendants included since
+                -- 12.1.0.69382 — and our border animations are an OnUpdate driver writing
+                -- SetVertexColor / Hide / SetPoint into those descendants every frame. That
+                -- is what made animation unsafe here, and it was stripped unconditionally.
+                --
+                -- ★ NARROWED 2026-08-27, and it is the DRIVER that was the problem, not
+                -- animation as such: a declarative AnimationGroup on a button child runs
+                -- fine (our own pandemic flash does, and two peer addons animate borders and
+                -- glows on container buttons the same way). The OnUpdate driver now DROPS a
+                -- border whose tick is refused instead of erroring every frame
+                -- (Border.lua's sharedAnimDriver), so the failure mode is a stopped effect,
+                -- not a log flood — which is what makes this safe to reopen at all.
+                --
+                -- Reopened for OVERLAY mode only, and only when the container opted in:
+                --   * overlay = the whole-frame presence box (the Aura Designer's frame-level
+                --     border). One ring per frame, so the per-frame cost is bounded.
+                --   * ROW mode always strips. A row holds many icons and every group
+                --     allocates its buttons up front, so a looping effect would run on
+                --     buttons no aura is even using.
+                --   * config.adBorderAnim is the opt-in. The AD factory sets it on several
+                --     ROW containers too; those stay inert because of the isRow test above,
+                --     deliberately — widening to them is a separate, measured decision.
+                -- SAFE_OVERLAY_ANIM still filters the TYPE, so a stale profile naming an
+                -- effect we no longer own renders static rather than erroring.
+                -- DF-owned frames OFF the container — unit-frame border, missing-buff badge,
+                -- targeted-spell highlight — were never affected and keep animating.
                 if spec then
-                    spec.animation = nil
+                    local animType = spec.animation and spec.animation.type
+                    if isRow or not config.adBorderAnim
+                        or not (animType and SAFE_OVERLAY_ANIM[animType]) then
+                        spec.animation = nil
+                    end
                     -- pp: the border renders inside the container's SetScale(scale)
                     -- subtree — Apply must snap thickness in that space, not
                     -- UIParent's (spec.renderScale, Border:SnapThickness). Factory

--- a/DandersFrames/Frames/AuraContainer.lua
+++ b/DandersFrames/Frames/AuraContainer.lua
@@ -1497,6 +1497,19 @@ local function styleButton_regions(slot, config)
                         or not (animType and SAFE_OVERLAY_ANIM[animType]) then
                         spec.animation = nil
                     end
+                    -- ☠ NO INTRO ON BUTTONS — forced, not user-configurable. The DF Proc /
+                    -- DF Flash intro one-shot plays at BUILD: timelines advance while a
+                    -- button is hidden and no OnShow script runs in the subtree, so on a
+                    -- pooled button it can only ever fire as a burst on every container
+                    -- rebuild that happens while an aura is up — config-edit noise on a
+                    -- whole row of icons, never an "aura appeared" cue. Buttons go
+                    -- straight to the settled loop (and skip building the intro objects).
+                    -- The GUI greys the Hide Intro Flash checkbox on button cards
+                    -- (introInert). The overlay frame border KEEPS its intro: one ring,
+                    -- and its rebuild-time burst is user-triggered edit feedback.
+                    if spec.animation and isRow then
+                        spec.animation.procStart = true
+                    end
                     -- pp: the border renders inside the container's SetScale(scale)
                     -- subtree — Apply must snap thickness in that space, not
                     -- UIParent's (spec.renderScale, Border:SnapThickness). Factory

--- a/DandersFrames/Frames/Border.lua
+++ b/DandersFrames/Frames/Border.lua
@@ -2058,7 +2058,7 @@ local function setupProcGlow(border, anim)
     -- anim.procStart = the "Hide Intro Flash" toggle (default nil/false plays it).
     local showIntro = not anim.procStart
     border._procStartElapsed = showIntro and 0 or PROC_START_DURATION
-    border._procGeomW = nil   -- tick re-applies loop spill + burst size
+    border._procGeomW, border._procGeomH = nil, nil   -- tick re-applies spill + burst size
     s:Show(); t:Show()
     s:SetAlpha(showIntro and 1 or 0)
     t:SetAlpha(showIntro and 0 or 1)
@@ -2081,13 +2081,24 @@ local function procTick(border, anim, dt)
     -- lands where the loop WOULD be at inset 0 and visibly jumps. (The non-secret
     -- fallback host:GetWidth() is already inset-adjusted.)
     if w and border._knownW then w = w - 2 * (anim.inset or 0) end
-    if host and w and w > 0 and border._procGeomW ~= w then
-        border._procGeomW = w
-        local off = floor(w * PROC_LOOP_SPILL + 0.5)
+    local h = border._knownH or (host and host:GetHeight())
+    if h and border._knownH then h = h - 2 * (anim.inset or 0) end
+    if host and w and w > 0 and h and h > 0
+        and (border._procGeomW ~= w or border._procGeomH ~= h) then
+        border._procGeomW, border._procGeomH = w, h
+        -- ☠ SPILL AND BURST ARE PER-AXIS, and both used to come from WIDTH alone.
+        -- That is invisible on a square aura icon — where this effect grew up — and
+        -- wrong on anything else: on a wide unit-frame border a width-derived vertical
+        -- spill made the glow several times the frame's height, and a square burst
+        -- ignored the frame's shape completely. Deriving each axis from its own
+        -- dimension keeps the glow the same shape as the thing it is glowing around,
+        -- and is a no-op wherever w == h.
+        local offX = floor(w * PROC_LOOP_SPILL + 0.5)
+        local offY = floor(h * PROC_LOOP_SPILL + 0.5)
         t:ClearAllPoints()
-        t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -off,  off)
-        t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  off, -off)
-        if s then s:SetSize(w * PROC_BURST_SCALE, w * PROC_BURST_SCALE) end
+        t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -offX,  offY)
+        t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  offX, -offY)
+        if s then s:SetSize(w * PROC_BURST_SCALE, h * PROC_BURST_SCALE) end
     end
     local period = border._procPeriod or 1
     border._procTimer = (border._procTimer + dt / period) % 1
@@ -2120,22 +2131,26 @@ end
 local function buildProcAnims(border, anim)
     local t, s, host = border.procTex, border.procStartTex, border._procHost
     if not (t and host) then return false end
-    local w = border._knownW
-    if not w then return false end
+    local w, h = border._knownW, border._knownH
+    if not (w and h) then return false end
     w = w - 2 * (anim.inset or 0)
-    if w <= 0 then return false end
+    h = h - 2 * (anim.inset or 0)
+    if w <= 0 or h <= 0 then return false end
     if not border._procAtlas then return false end
     -- Geometry is applied once here instead of per tick: every number is plain config.
+    -- Per-axis, for the reason spelled out in procTick — a width-derived spill turns a
+    -- wide frame's glow into a tall blob.
     t:SetAtlas(PROC_ATLAS)
-    local off = floor(w * PROC_LOOP_SPILL + 0.5)
+    local offX = floor(w * PROC_LOOP_SPILL + 0.5)
+    local offY = floor(h * PROC_LOOP_SPILL + 0.5)
     t:ClearAllPoints()
-    t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -off,  off)
-    t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  off, -off)
+    t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -offX,  offY)
+    t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  offX, -offY)
     local groups = border._declAnims or {}
     local showIntro = (not anim.procStart) and s and border._procStartAtlas
     if showIntro then
         s:SetAtlas(PROC_START_ATLAS)
-        s:SetSize(w * PROC_BURST_SCALE, w * PROC_BURST_SCALE)
+        s:SetSize(w * PROC_BURST_SCALE, h * PROC_BURST_SCALE)
         s:SetAlpha(1)
         local ag = s:CreateAnimationGroup()
         ag:SetToFinalAlpha(true)
@@ -2242,7 +2257,7 @@ local function setupFlashGlow(border, anim)
     -- anim.procStart = the "Hide Intro Flash" toggle (default nil/false plays it).
     local showIntro = not anim.procStart
     border._flashIntroElapsed = showIntro and 0 or FLASH_INTRO_DUR
-    border._flashGeomW = nil     -- tick sizes everything once the width is known
+    border._flashGeomW, border._flashGeomH = nil, nil   -- tick re-sizes once known
     border._flashSettled = nil
     spark:SetAlpha(0); inner:SetAlpha(0); innerOver:SetAlpha(0)
     outer:SetAlpha(showIntro and 0 or a); outerOver:SetAlpha(0)
@@ -2268,15 +2283,22 @@ local function flashTick(border, anim, dt)
     -- Inset entirely on container icons. (The non-secret fallback host:GetWidth()
     -- is already inset-adjusted.)
     if w and border._knownW then w = w - 2 * (anim.inset or 0) end
-    local F = border._flashF
-    if host and w and w > 0 and border._flashGeomW ~= w then
-        border._flashGeomW = w
-        F = w * FLASH_FRAME_SCALE
-        border._flashF = F
+    -- ☠ PER-AXIS, same correction as DF Proc: F used to be a single width-derived
+    -- number and every layer was sized (F, F), so on a wide unit-frame border the glow
+    -- was a big square that ignored the frame's shape. No-op wherever w == h, which is
+    -- every aura icon — the surface this effect was built for.
+    local h = border._knownH or (host and host:GetHeight())
+    if h and border._knownH then h = h - 2 * (anim.inset or 0) end
+    local Fw, Fh = border._flashFw, border._flashFh
+    if host and w and w > 0 and h and h > 0
+        and (border._flashGeomW ~= w or border._flashGeomH ~= h) then
+        border._flashGeomW, border._flashGeomH = w, h
+        Fw, Fh = w * FLASH_FRAME_SCALE, h * FLASH_FRAME_SCALE
+        border._flashFw, border._flashFh = Fw, Fh
         border._flashSettled = nil   -- re-park the steady glow at the new F
-        if ants then ants:SetSize(F * 0.85, F * 0.85) end
+        if ants then ants:SetSize(Fw * 0.85, Fh * 0.85) end
     end
-    if not F then return end   -- no width yet — nothing to draw against
+    if not (Fw and Fh) then return end   -- no size yet — nothing to draw against
     -- March the ants every frame (mid-crawl when they fade in).
     local period = border._flashPeriod or 0.5
     border._flashTimer = (border._flashTimer + dt / period) % 1
@@ -2300,13 +2322,14 @@ local function flashTick(border, anim, dt)
         -- its steady rect and never moves again; the inner expands F/2→F, its
         -- bright "over" pass fading as they land.
         local kg = min(k / 0.6, 1)
-        local outerS = F * (2 - kg)
-        outer:SetSize(outerS, outerS)
+        -- Sizes are a SCALE on each axis now, not one square number.
+        local outerK = 2 - kg
+        outer:SetSize(Fw * outerK, Fh * outerK)
         outer:SetAlpha(maxA)
         if outerOver then outerOver:SetAlpha(maxA * (1 - kg)) end
         if inner then
-            local innerS = F * (0.5 + 0.5 * kg)
-            inner:SetSize(innerS, innerS)
+            local innerK = 0.5 + 0.5 * kg
+            inner:SetSize(Fw * innerK, Fh * innerK)
             -- holds full until the glows land, then hands off over the last 40%
             local ia = k < 0.6 and 1 or (1 - (k - 0.6) / 0.4)
             inner:SetAlpha(maxA * ia)
@@ -2315,17 +2338,17 @@ local function flashTick(border, anim, dt)
         -- Spark flare over the top: grows F→1.5F while brightening, shrinks back
         -- fading — gone by 80%.
         if spark then
-            local sS, sA
+            local sK, sA
             if k < 0.4 then
                 local ks = k / 0.4
-                sS, sA = F * (1 + 0.5 * ks), ks
+                sK, sA = 1 + 0.5 * ks, ks
             elseif k < 0.8 then
                 local ks = (k - 0.4) / 0.4
-                sS, sA = F * (1.5 - 0.5 * ks), 1 - ks
+                sK, sA = 1.5 - 0.5 * ks, 1 - ks
             else
-                sS, sA = F, 0
+                sK, sA = 1, 0
             end
-            spark:SetSize(sS, sS)
+            spark:SetSize(Fw * sK, Fh * sK)
             spark:SetAlpha(maxA * sA)
         end
         -- Ants crawl in during the last 40%, taking over from the inner glow.
@@ -2336,7 +2359,7 @@ local function flashTick(border, anim, dt)
     border._flashIntroElapsed = FLASH_INTRO_DUR
     if not border._flashSettled then
         border._flashSettled = true
-        outer:SetSize(F, F)
+        outer:SetSize(Fw, Fh)
         outer:SetAlpha(maxA)
         if outerOver then outerOver:SetAlpha(0) end
         if spark then spark:SetAlpha(0) end
@@ -2384,24 +2407,27 @@ end
 local function buildFlashAnims(border, anim)
     local outer, ants, host = border.flashOuter, border.flashAnts, border._flashHost
     if not (outer and ants and host) then return false end
-    local w = border._knownW
-    if not w then return false end
+    local w, h = border._knownW, border._knownH
+    if not (w and h) then return false end
     w = w - 2 * (anim.inset or 0)
-    if w <= 0 then return false end
-    local F = w * FLASH_FRAME_SCALE
-    border._flashF = F
-    border._flashGeomW = w
+    h = h - 2 * (anim.inset or 0)
+    if w <= 0 or h <= 0 then return false end
+    -- Per-axis, matching flashTick — a single width-derived F made the glow a square
+    -- that ignored a wide frame's shape.
+    local Fw, Fh = w * FLASH_FRAME_SCALE, h * FLASH_FRAME_SCALE
+    border._flashFw, border._flashFh = Fw, Fh
+    border._flashGeomW, border._flashGeomH = w, h
     border._flashSettled = true
     local maxA = border._flashMaxA or 1
     local spark, inner = border.flashSpark, border.flashInner
     local innerOver, outerOver = border.flashInnerOver, border.flashOuterOver
     -- Steady sizes, set once.
-    outer:SetSize(F, F)
+    outer:SetSize(Fw, Fh)
     if outerOver then outerOver:ClearAllPoints(); outerOver:SetAllPoints(outer) end
-    if inner then inner:SetSize(F, F) end
+    if inner then inner:SetSize(Fw, Fh) end
     if innerOver then innerOver:ClearAllPoints(); innerOver:SetAllPoints(inner) end
-    if spark then spark:SetSize(F * 1.5, F * 1.5) end
-    ants:SetSize(F * 0.85, F * 0.85)
+    if spark then spark:SetSize(Fw * 1.5, Fh * 1.5) end
+    ants:SetSize(Fw * 0.85, Fh * 0.85)
     local groups = border._declAnims or {}
     playFlipBook(ants, FLASH_ANTS_ROWS, FLASH_ANTS_COLS, FLASH_ANTS_FRAMES,
                  FLASH_ANTS_PX, FLASH_ANTS_PX, border._flashPeriod or 0.5, groups)

--- a/DandersFrames/Frames/Border.lua
+++ b/DandersFrames/Frames/Border.lua
@@ -2093,12 +2093,24 @@ local function procTick(border, anim, dt)
         -- ignored the frame's shape completely. Deriving each axis from its own
         -- dimension keeps the glow the same shape as the thing it is glowing around,
         -- and is a no-op wherever w == h.
-        local offX = floor(w * PROC_LOOP_SPILL + 0.5)
-        local offY = floor(h * PROC_LOOP_SPILL + 0.5)
+        -- ★ SCALE multiplies the reach. The band's midline lands on the frame edge at
+        -- scale 1; there is no exact "on the border" beyond that, because the bright
+        -- band is a soft gradient baked into the art — so the residual is a knob, not a
+        -- constant. At scale 1 the loop rect is identical to the pre-slider render; the
+        -- burst is within 2px of it (it now sizes off the ROUNDED loop, which lands the
+        -- contract-onto-loop hand-off on our actual rect rather than the ideal one).
+        local sc = anim.scale or 1
+        local offX = floor(w * PROC_LOOP_SPILL * sc + 0.5)
+        local offY = floor(h * PROC_LOOP_SPILL * sc + 0.5)
         t:ClearAllPoints()
         t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -offX,  offY)
         t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  offX, -offY)
-        if s then s:SetSize(w * PROC_BURST_SCALE, h * PROC_BURST_SCALE) end
+        -- Burst sized off the LOOP rect so the intro still contracts exactly onto it
+        -- at any scale (the art's hand-off is loop-relative, not host-relative).
+        if s then
+            local k = PROC_BURST_SCALE / (1 + 2 * PROC_LOOP_SPILL)
+            s:SetSize((w + 2 * offX) * k, (h + 2 * offY) * k)
+        end
     end
     local period = border._procPeriod or 1
     border._procTimer = (border._procTimer + dt / period) % 1
@@ -2141,8 +2153,10 @@ local function buildProcAnims(border, anim)
     -- Per-axis, for the reason spelled out in procTick — a width-derived spill turns a
     -- wide frame's glow into a tall blob.
     t:SetAtlas(PROC_ATLAS)
-    local offX = floor(w * PROC_LOOP_SPILL + 0.5)
-    local offY = floor(h * PROC_LOOP_SPILL + 0.5)
+    -- Scale multiplies the reach, exactly as procTick does — see the note there.
+    local sc = anim.scale or 1
+    local offX = floor(w * PROC_LOOP_SPILL * sc + 0.5)
+    local offY = floor(h * PROC_LOOP_SPILL * sc + 0.5)
     t:ClearAllPoints()
     t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -offX,  offY)
     t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  offX, -offY)
@@ -2150,7 +2164,8 @@ local function buildProcAnims(border, anim)
     local showIntro = (not anim.procStart) and s and border._procStartAtlas
     if showIntro then
         s:SetAtlas(PROC_START_ATLAS)
-        s:SetSize(w * PROC_BURST_SCALE, h * PROC_BURST_SCALE)
+        local k = PROC_BURST_SCALE / (1 + 2 * PROC_LOOP_SPILL)
+        s:SetSize((w + 2 * offX) * k, (h + 2 * offY) * k)
         s:SetAlpha(1)
         local ag = s:CreateAnimationGroup()
         ag:SetToFinalAlpha(true)
@@ -2293,7 +2308,12 @@ local function flashTick(border, anim, dt)
     if host and w and w > 0 and h and h > 0
         and (border._flashGeomW ~= w or border._flashGeomH ~= h) then
         border._flashGeomW, border._flashGeomH = w, h
-        Fw, Fh = w * FLASH_FRAME_SCALE, h * FLASH_FRAME_SCALE
+        -- Scale multiplies the reach past the edge (the FLASH_FRAME_SCALE - 1 part),
+        -- not the whole frame — so scale 1 is byte-identical to the pre-slider render
+        -- and 0.5 halves the overhang rather than shrinking the glow inside the frame.
+        local sc = anim.scale or 1
+        local k = 1 + (FLASH_FRAME_SCALE - 1) * sc
+        Fw, Fh = w * k, h * k
         border._flashFw, border._flashFh = Fw, Fh
         border._flashSettled = nil   -- re-park the steady glow at the new F
         if ants then ants:SetSize(Fw * 0.85, Fh * 0.85) end
@@ -2412,9 +2432,10 @@ local function buildFlashAnims(border, anim)
     w = w - 2 * (anim.inset or 0)
     h = h - 2 * (anim.inset or 0)
     if w <= 0 or h <= 0 then return false end
-    -- Per-axis, matching flashTick — a single width-derived F made the glow a square
-    -- that ignored a wide frame's shape.
-    local Fw, Fh = w * FLASH_FRAME_SCALE, h * FLASH_FRAME_SCALE
+    -- Per-axis with the Scale knob on the overhang, exactly as flashTick does it.
+    local sc = anim.scale or 1
+    local k = 1 + (FLASH_FRAME_SCALE - 1) * sc
+    local Fw, Fh = w * k, h * k
     border._flashFw, border._flashFh = Fw, Fh
     border._flashGeomW, border._flashGeomH = w, h
     border._flashSettled = true

--- a/DandersFrames/Frames/Border.lua
+++ b/DandersFrames/Frames/Border.lua
@@ -1004,6 +1004,13 @@ end
 -- on a hidden texture is a harmless SetAlpha — same as the prior UIParent driver).
 local animRegistry = {}   -- [border] = { fn = fn, elapsed = number }
 local sharedAnimDriver
+-- ☠ FORWARD DECLARATION, not a stray local. The driver's OnUpdate below drops a border
+-- that refuses its tick, and unregisterAnimTick is defined AFTER it -- without this the
+-- closure would capture a nil GLOBAL and fail only at the moment it is needed. Same trap
+-- this file has been bitten by twice; see the header notes.
+local unregisterAnimTick
+-- One-time latch: a refused tick logs once, not once per frame per border.
+local warnedTickRefused = false
 local function ensureSharedAnimDriver()
     if sharedAnimDriver then return sharedAnimDriver end
     sharedAnimDriver = CreateFrame("Frame", nil, UIParent)
@@ -1015,7 +1022,37 @@ local function ensureSharedAnimDriver()
         for border, e in pairs(animRegistry) do
             if border._secretRect or border:IsShown() then
                 e.elapsed = e.elapsed + dt
-                e.fn(border, e.elapsed, dt)
+                if border._secretRect then
+                    -- ☠ A secretRect border's edge textures are DESCENDANTS of a Blizzard
+                    -- aura button, which refuses tainted writes while auras are secret
+                    -- (DenyTaintedAccessWhenAurasAreSecret, descendants included since
+                    -- 12.1.0.69382). A tick that writes into a refused subtree throws
+                    -- EVERY FRAME, in exactly the content these borders exist for -- which
+                    -- is why container animation was retired wholesale rather than guarded.
+                    --
+                    -- Guard rather than forbid: probe under pcall and DROP the border on the
+                    -- first refusal, so the cost of being wrong is one error and a stopped
+                    -- effect instead of a per-frame flood. Nothing re-arms it here; the next
+                    -- Apply does, via StartAnimation's dead-driver recovery (a DRIVER_ANIMS
+                    -- type whose registry entry has gone re-registers even though the spec
+                    -- hash is unchanged). So leaving an instance and restyling restores it.
+                    --
+                    -- ⚠ Deliberately NOT gated on CanBeAccessedInContext(): that answers for
+                    -- the object it is called on, and what we need to know is whether a WRITE
+                    -- to this border's own regions lands. Only the write answers that.
+                    if not pcall(e.fn, border, e.elapsed, dt) then
+                        unregisterAnimTick(border)
+                        if not warnedTickRefused then
+                            warnedTickRefused = true
+                            if DF.DebugWarn then
+                                DF:DebugWarn("AURACONTAINER",
+                                    "border animation tick refused on a restricted subtree - effect dropped until the next restyle")
+                            end
+                        end
+                    end
+                else
+                    e.fn(border, e.elapsed, dt)
+                end
             end
         end
     end)
@@ -1030,7 +1067,7 @@ local function registerAnimTick(border, fn, initialElapsed)
     e.fn = fn
     e.elapsed = initialElapsed or 0
 end
-local function unregisterAnimTick(border)
+function unregisterAnimTick(border)
     animRegistry[border] = nil
     -- ☠ Hide the driver once the last animated border goes. An OnUpdate on a
     -- shown frame runs every frame forever; emptying the registry alone left
@@ -1201,7 +1238,24 @@ local ORBIT_LAYER_SIZES = { 7, 6, 5, 4 }   -- four layers, outer→inner (LCG pa
 -- small aura icon and a large AD border.
 local ORBIT_BASE_PERIOD = 8
 
+-- Stop the declarative orbit groups (see "DF_ORBIT, DECLARATIVE" below). Guarded per
+-- group: these live on textures under a container button, and teardown runs at the
+-- moment those go restricted -- an unguarded throw here would unwind out of
+-- StopAnimation and skip the rest of its teardown, which is exactly the shape of bug
+-- #1079. Declared above hideOrbitParticles on purpose: a local referenced before its
+-- definition would be captured as a nil GLOBAL.
+local function stopOrbitAnims(border)
+    local groups = border._orbitAnims
+    if not groups then return end
+    for i = 1, #groups do
+        local ag = groups[i]
+        if ag then pcall(ag.Stop, ag) end
+    end
+    border._orbitAnims = nil
+end
+
 local function hideOrbitParticles(border)
+    stopOrbitAnims(border)
     if not border.orbitTex then return end
     for _, t in ipairs(border.orbitTex) do t:Hide() end
 end
@@ -1294,6 +1348,127 @@ local function orbitTick(border, anim, dt)
             end
         end
     end
+end
+
+-- ===== DF_ORBIT, DECLARATIVE (the same motion, driven C-side) =====
+--
+-- ☠ WHY THE SAME EFFECT EXISTS TWICE. orbitTick above walks the sparkles by SetPoint
+-- from Lua on every frame. On a CONTAINER-hosted border those textures are descendants
+-- of a Blizzard aura button, which refuses tainted writes while auras are secret -- so
+-- the tick is refused in exactly the content the effect exists for. That is not a
+-- theory: bug #1079 was a single SetAlpha on an edge texture throwing ~197 times on
+-- entering an instance. An OnUpdate driver cannot win there.
+--
+-- A declarative AnimationGroup is not a script and is never touched after creation, so
+-- it runs through the restriction untouched. Built and :Play()ed on the border's FIRST
+-- Apply -- which for a container border is inside initializeFrame, the secure context.
+--
+-- ★ IT IS THE SAME WALK, deliberately. Leg order and start corner match orbitTick
+-- exactly (up the left edge from BOTTOMLEFT, right along the top, down the right edge,
+-- left along the bottom), so a sparkle at perimeter position `pos` lands where the tick
+-- would put it, and layer k orbits in period*k seconds for the same shimmer stagger.
+-- Keep the two in step if either is edited.
+--
+-- ⚠ CREATION-FROZEN. Nothing here can be retuned afterwards without a tainted write
+-- into the button subtree, so for a container border every animation key is STRUCTURAL:
+-- the AD factory folds them into the border's struct signature and a change rebuilds the
+-- slot. Same contract as the pandemic FLASH.
+--
+-- ⚠ Geometry comes from _knownW/_knownH (plain config numbers fed by the caller), never
+-- from measuring the host -- a container button's rect is secret. No geometry, no
+-- declarative build: the caller falls back to the tick rather than guessing.
+
+-- Perimeter leg directions, in walk order: up, right, down, left.
+local ORBIT_LEG_DIRS = { { 0, 1 }, { 1, 0 }, { 0, -1 }, { -1, 0 } }
+local ORBIT_EPS = 0.0001
+
+-- Anchor a sparkle at perimeter position `pos` -- the exact branch orbitTick uses.
+local function orbitAnchor(t, host, pos, w, h)
+    local rightlim, bottomlim = h + w, h * 2 + w
+    t:ClearAllPoints()
+    if pos > bottomlim then
+        t:SetPoint("CENTER", host, "BOTTOMRIGHT", -pos + bottomlim, 0)
+    elseif pos > rightlim then
+        t:SetPoint("CENTER", host, "TOPRIGHT", 0, -pos + rightlim)
+    elseif pos > h then
+        t:SetPoint("CENTER", host, "TOPLEFT", pos - h, 0)
+    else
+        t:SetPoint("CENTER", host, "BOTTOMLEFT", 0, pos)
+    end
+end
+
+-- One full loop of ordered Translations starting from `pos`. The offsets sum to zero, so
+-- a REPEAT group returns the sparkle to its anchor each cycle and never drifts -- which
+-- is what makes the loop seamless without any Lua re-seeding it.
+local function buildOrbitLoop(ag, pos, w, h, period)
+    local perimeter = 2 * (w + h)
+    local legLen = { h, w, h, w }
+    -- Which leg `pos` sits in, and how far into it.
+    local leg, into = 1, pos % perimeter
+    for i = 1, 4 do
+        if into < legLen[i] then leg = i; break end
+        into = into - legLen[i]
+    end
+    local remaining, idx, skip, order = perimeter, leg, into, 0
+    while remaining > ORBIT_EPS do
+        -- skip is non-zero only on the first (partial) leg; every later leg is whole.
+        -- legLen entries are > 0 (the caller rejects a degenerate rect), so d is always
+        -- positive and the walk terminates.
+        local d = legLen[idx] - skip
+        skip = 0
+        if d > remaining then d = remaining end
+        if d > ORBIT_EPS then
+            order = order + 1
+            local dir = ORBIT_LEG_DIRS[idx]
+            local tr = ag:CreateAnimation("Translation")
+            tr:SetOffset(dir[1] * d, dir[2] * d)
+            tr:SetDuration(period * d / perimeter)
+            tr:SetOrder(order)
+            tr:SetSmoothing("NONE")   -- constant speed; easing would pulse at each corner
+        end
+        remaining = remaining - d
+        idx = idx % 4 + 1
+    end
+    return order
+end
+
+-- Returns true when the declarative orbit was built and started. False means "no usable
+-- geometry" and the caller should fall back to the OnUpdate tick.
+local function buildOrbitAnims(border, anim)
+    local host, tex = border._orbitHost, border.orbitTex
+    if not (host and tex) then return false end
+    local w, h = border._knownW, border._knownH
+    if not (w and h) then return false end
+    -- Same inset adjustment orbitTick applies: _knownW/H are the BORDER's raw size, and
+    -- the particles anchor to the animRect, which ensureAnimRect has already inset.
+    w = w - 2 * (anim.inset or 0)
+    h = h - 2 * (anim.inset or 0)
+    if w <= 0 or h <= 0 then return false end
+    local perimeter = 2 * (w + h)
+    local N = border._orbitN or 4
+    local space = perimeter / N
+    local basePeriod = border._orbitPeriod or ORBIT_BASE_PERIOD
+    local groups, idx = {}, 0
+    for k = 1, 4 do
+        -- Layer k takes period*k for one orbit -- the tick's dt/(period*k).
+        local period = basePeriod * k
+        for i = 1, N do
+            idx = idx + 1
+            local t = tex[idx]
+            if t then
+                local pos = (space * i) % perimeter
+                orbitAnchor(t, host, pos, w, h)
+                local ag = t:CreateAnimationGroup()
+                ag:SetLooping("REPEAT")
+                buildOrbitLoop(ag, pos, w, h, period)
+                ag:Play()
+                groups[#groups + 1] = ag
+            end
+        end
+    end
+    if #groups == 0 then return false end
+    border._orbitAnims = groups
+    return true
 end
 
 -- ===== DF_DASH (dashed / marching-ants border) =====
@@ -2067,8 +2242,12 @@ function Border:StartAnimation(border, spec)
     -- animation frozen until a real spec change forces a restart (the "move the
     -- frequency slider off 1 and back" symptom). When the driver is dead, fall
     -- through and restart instead of no-opping.
+    -- ⚠ A DECLARATIVE orbit counts as live too. It has no animRegistry entry by design
+    -- (nothing ticks it), so without _orbitAnims here the "driver is dead, restart" arm
+    -- would fire on EVERY re-apply and rebuild its animation groups from scratch — on a
+    -- container border that is also a tainted write into the button subtree.
     if border._animHash == newHash then
-        if not DRIVER_ANIMS[border.activeAnimation] or animRegistry[border] then
+        if not DRIVER_ANIMS[border.activeAnimation] or animRegistry[border] or border._orbitAnims then
             return
         end
     end
@@ -2119,6 +2298,17 @@ function Border:StartAnimation(border, spec)
     -- secret-rect reads).
     if anim.type == "DF_ORBIT" then
         setupOrbitParticles(border, anim)
+        -- ★ CONTAINER-HOSTED BORDERS TAKE THE DECLARATIVE PATH. Their textures sit under
+        -- a Blizzard aura button, so a per-frame Lua walk is refused the moment auras go
+        -- secret; C-side Translation groups are not. Everything else (unit-frame border,
+        -- targeted-spell highlight, missing-buff badge, the AD editor canvas) keeps the
+        -- tick, which retunes live while a slider is dragged.
+        -- ⚠ A false return means no usable geometry, not a failure to build — fall through
+        -- to the tick, which is what this border did before either way.
+        if border._secretRect and buildOrbitAnims(border, anim) then
+            border.activeAnimation = anim.type
+            return
+        end
         registerAnimTick(border, function(b, el, dt)
             orbitTick(b, anim, dt)
         end)

--- a/DandersFrames/Frames/Border.lua
+++ b/DandersFrames/Frames/Border.lua
@@ -1238,24 +1238,25 @@ local ORBIT_LAYER_SIZES = { 7, 6, 5, 4 }   -- four layers, outer→inner (LCG pa
 -- small aura icon and a large AD border.
 local ORBIT_BASE_PERIOD = 8
 
--- Stop the declarative orbit groups (see "DF_ORBIT, DECLARATIVE" below). Guarded per
--- group: these live on textures under a container button, and teardown runs at the
--- moment those go restricted -- an unguarded throw here would unwind out of
--- StopAnimation and skip the rest of its teardown, which is exactly the shape of bug
--- #1079. Declared above hideOrbitParticles on purpose: a local referenced before its
--- definition would be captured as a nil GLOBAL.
-local function stopOrbitAnims(border)
-    local groups = border._orbitAnims
+-- Stop every DECLARATIVE animation group this border owns, whichever effect built
+-- them (see "DECLARATIVE EFFECTS" below). One list for all of them: only one effect
+-- runs at a time, because StopAnimation always clears before a start.
+--
+-- Guarded per group: these live on regions under a container button, and teardown
+-- runs at the very moment those go restricted -- an unguarded throw here would unwind
+-- out of StopAnimation and skip the rest of its teardown, which is exactly the shape
+-- of bug #1079.
+local function stopDeclAnims(border)
+    local groups = border._declAnims
     if not groups then return end
     for i = 1, #groups do
         local ag = groups[i]
         if ag then pcall(ag.Stop, ag) end
     end
-    border._orbitAnims = nil
+    border._declAnims = nil
 end
 
 local function hideOrbitParticles(border)
-    stopOrbitAnims(border)
     if not border.orbitTex then return end
     for _, t in ipairs(border.orbitTex) do t:Hide() end
 end
@@ -1467,8 +1468,138 @@ local function buildOrbitAnims(border, anim)
         end
     end
     if #groups == 0 then return false end
-    border._orbitAnims = groups
+    border._declAnims = groups
     return true
+end
+
+-- ===== DECLARATIVE EFFECTS — shared machinery =====
+--
+-- Everything below builds C-side AnimationGroups for an effect that normally runs on
+-- the shared OnUpdate driver, for the one case where that driver cannot run: a border
+-- whose regions are descendants of a Blizzard aura button. Same rules throughout:
+-- built on the border's FIRST Apply (inside initializeFrame), never touched again,
+-- geometry from _knownW/_knownH rather than measured, and every group pushed onto
+-- border._declAnims so StopAnimation can stop them.
+--
+-- ★ THE MARCHING TRICK, used by DF Dash and DF Pixel. A per-edge CLIP frame is pinned
+-- to the edge; a MOVER fills it; the quads hang off the mover at fixed positions, some
+-- of them deliberately outside the clip; one Translation slides the mover by exactly
+-- one spacing and loops. Because the quads are spaced by that same distance, the state
+-- after one loop is identical to the state before it, so the snap-back is invisible and
+-- nothing has to re-seed positions in Lua. The clip is what lets a quad leave the edge
+-- and another enter without either being repositioned.
+local function ensureMarchEdge(store, key, parent)
+    local e = store[key]
+    if not e then
+        e = { quads = {} }
+        e.clip = CreateFrame("Frame", nil, parent)
+        e.clip:SetClipsChildren(true)
+        e.mover = CreateFrame("Frame", nil, e.clip)
+        e.mover:SetAllPoints(e.clip)
+        store[key] = e
+    end
+    e.clip:Show()
+    return e
+end
+
+-- One quad on the mover, created on demand. Surplus quads from a previous (larger)
+-- configuration are hidden by the caller.
+local function marchQuad(e, i)
+    local q = e.quads[i]
+    if not q then
+        q = e.mover:CreateTexture(nil, "OVERLAY")
+        e.quads[i] = q
+    end
+    q:Show()
+    return q
+end
+
+-- Slide `e.mover` by (dx, dy) over `duration` seconds, forever.
+local function playMarch(e, dx, dy, duration, groups)
+    local ag = e.mover:CreateAnimationGroup()
+    ag:SetLooping("REPEAT")
+    local tr = ag:CreateAnimation("Translation")
+    tr:SetOffset(dx, dy)
+    tr:SetDuration(duration)
+    tr:SetSmoothing("NONE")
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
+end
+
+-- Hold `region` at `from` then at `to`, forever — a hard on/off strobe rather than a
+-- fade. An Alpha animation whose from and to match simply holds that value for its
+-- duration, so two of them in order give a square wave with instant edges.
+local function playStrobe(region, from, to, halfPeriod, groups)
+    local ag = region:CreateAnimationGroup()
+    ag:SetLooping("REPEAT")
+    local on = ag:CreateAnimation("Alpha")
+    on:SetFromAlpha(from); on:SetToAlpha(from)
+    on:SetDuration(halfPeriod); on:SetOrder(1)
+    local off = ag:CreateAnimation("Alpha")
+    off:SetFromAlpha(to); off:SetToAlpha(to)
+    off:SetDuration(halfPeriod); off:SetOrder(2)
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
+end
+
+-- Fade `region` from `lo` up to `hi` and back, forever. IN_OUT smoothing gives the
+-- zero-slope endpoints the cosine wave in the pulsate tick produces, so each cycle
+-- blends into the next with no seam at the loop point.
+local function playFade(region, lo, hi, halfPeriod, groups)
+    local ag = region:CreateAnimationGroup()
+    ag:SetLooping("REPEAT")
+    local down = ag:CreateAnimation("Alpha")
+    down:SetFromAlpha(hi); down:SetToAlpha(lo)
+    down:SetDuration(halfPeriod); down:SetOrder(1); down:SetSmoothing("IN_OUT")
+    local up = ag:CreateAnimation("Alpha")
+    up:SetFromAlpha(lo); up:SetToAlpha(hi)
+    up:SetDuration(halfPeriod); up:SetOrder(2); up:SetSmoothing("IN_OUT")
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
+end
+
+-- A one-shot alpha ramp that STAYS where it lands (SetToFinalAlpha). Used to build the
+-- intro choreography of DF Proc / DF Flash out of pure alpha, with no Lua timeline.
+-- `hold` delays the ramp so several regions can hand off to each other in sequence.
+local function playAlphaOnce(region, from, to, hold, dur, groups)
+    local ag = region:CreateAnimationGroup()
+    ag:SetToFinalAlpha(true)
+    local order = 1
+    if hold and hold > 0 then
+        local wait = ag:CreateAnimation("Alpha")
+        wait:SetFromAlpha(from); wait:SetToAlpha(from)
+        wait:SetDuration(hold); wait:SetOrder(order)
+        order = order + 1
+    end
+    local ramp = ag:CreateAnimation("Alpha")
+    ramp:SetFromAlpha(from); ramp:SetToAlpha(to)
+    ramp:SetDuration(dur or 0.001); ramp:SetOrder(order)
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
+end
+
+-- A looping flipbook over a grid, the native equivalent of the hand-stepped
+-- SetTexCoord walks in DF Proc and DF Flash. frameW/frameH of 0 means "derive from the
+-- texture's own rect", which is what makes it work on an ATLAS sub-rect — the recipe
+-- LibCustomGlow uses on these very same Blizzard sheets.
+local function playFlipBook(region, rows, cols, frames, frameW, frameH, duration, groups)
+    local ag = region:CreateAnimationGroup()
+    ag:SetLooping("REPEAT")
+    local fb = ag:CreateAnimation("FlipBook")
+    fb:SetDuration(duration)
+    fb:SetOrder(1)
+    fb:SetFlipBookRows(rows)
+    fb:SetFlipBookColumns(cols)
+    fb:SetFlipBookFrames(frames)
+    fb:SetFlipBookFrameWidth(frameW or 0)
+    fb:SetFlipBookFrameHeight(frameH or 0)
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
 end
 
 -- ===== DF_DASH (dashed / marching-ants border) =====
@@ -1504,6 +1635,13 @@ local function ensureDashPool(border)
 end
 
 local function hideDashPool(border)
+    -- Declarative edges first: hiding the clip frame takes its mover and every dash
+    -- with it, so the quads need no individual pass.
+    if border._dashDecl then
+        for _, e in pairs(border._dashDecl) do
+            if e.clip then e.clip:Hide() end
+        end
+    end
     if not border.dashPool then return end
     for _, edge in pairs(border.dashPool) do
         for _, d in ipairs(edge) do d:Hide() end
@@ -1575,6 +1713,67 @@ local function drawDashes(border, offset, th, inset, r, g, b, a)
     drawDashEdgeV(border, pool.right,  true,  2 * width + height - offset, height, th, inset, r, g, b, a)
 end
 
+-- DF_DASH, DECLARATIVE. The tick above redraws every dash each frame by recomputing
+-- its clipped extent; here the clipping is done by a frame instead, and one Translation
+-- per edge slides a fixed set of dashes by exactly one pattern length.
+--
+-- ★ The seed phases reproduce the tick's cumulative perimeter offsets (bottom 0, left
+-- `width`, top `width+height`, right `2*width+height`), so the pattern stays continuous
+-- around the corners exactly as it does today. Direction matches too: clockwise on
+-- screen — up the left edge, right along the top, down the right, left along the bottom.
+--
+-- ⚠ Static dashes (frequency 0) are NOT built here: with nothing to march there is no
+-- animation to declare, and the tick path draws them once and stops. The caller checks.
+local function buildDashAnims(border, anim, th, inset, r, g, b, a, marchSpeed)
+    if not (marchSpeed and marchSpeed > 0) then return false end
+    local fw, fh = border._knownW, border._knownH
+    if not (fw and fh) then return false end
+    local width, height = fw - inset * 2, fh - inset * 2
+    if width <= 0 or height <= 0 then return false end
+    local P = DF_DASH_PATTERN
+    local dur = P / marchSpeed
+    border._dashDecl = border._dashDecl or {}
+    local store = border._dashDecl
+    local groups = border._declAnims or {}
+    -- key, edge length, seed offset, travel, and how the clip frame sits on the border.
+    local edges = {
+        { key = "bottom", len = width,  seed = 0,                    dx = -P, dy = 0,
+          horiz = true,  point = "BOTTOMLEFT",  ox = inset,  oy = inset },
+        { key = "left",   len = height, seed = width,                dx = 0,  dy = P,
+          horiz = false, point = "TOPLEFT",     ox = inset,  oy = -inset },
+        { key = "top",    len = width,  seed = width + height,       dx = P,  dy = 0,
+          horiz = true,  point = "TOPLEFT",     ox = inset,  oy = -inset },
+        { key = "right",  len = height, seed = 2 * width + height,   dx = 0,  dy = -P,
+          horiz = false, point = "TOPRIGHT",    ox = -inset, oy = -inset },
+    }
+    for _, ed in ipairs(edges) do
+        local e = ensureMarchEdge(store, ed.key, border)
+        e.clip:ClearAllPoints()
+        e.clip:SetPoint(ed.point, border, ed.point, ed.ox, ed.oy)
+        e.clip:SetSize(ed.horiz and ed.len or th, ed.horiz and th or ed.len)
+        local startPos = -(ed.seed % P)
+        local count = math.ceil(ed.len / P) + 2
+        for i = 1, count do
+            local dashStart = startPos + (i - 1) * P
+            local q = marchQuad(e, i)
+            q:SetColorTexture(r, g, b, a)
+            q:ClearAllPoints()
+            if ed.horiz then
+                q:SetSize(DF_DASH_LEN, th)
+                q:SetPoint("BOTTOMLEFT", e.mover, "BOTTOMLEFT", dashStart, 0)
+            else
+                q:SetSize(th, DF_DASH_LEN)
+                -- Vertical edges measure DOWNWARD from the top, matching drawDashEdgeV.
+                q:SetPoint("TOPLEFT", e.mover, "TOPLEFT", 0, -dashStart)
+            end
+        end
+        for i = count + 1, #e.quads do e.quads[i]:Hide() end
+        playMarch(e, ed.dx, ed.dy, dur, groups)
+    end
+    border._declAnims = groups
+    return true
+end
+
 -- ===== DF_PIXEL (chasing pixels — discrete bars) =====
 -- N plain rectangles chase around the perimeter with even gaps, each oriented
 -- along the edge it's on (a horizontal bar on top/bottom, a vertical bar on
@@ -1588,6 +1787,12 @@ local PIXEL_TEX = [[Interface\BUTTONS\WHITE8X8]]
 local PIXEL_BASE_PERIOD = 4
 
 local function hidePixelParticles(border)
+    -- Declarative edges first — see hideDashPool.
+    if border._pixelDecl then
+        for _, e in pairs(border._pixelDecl) do
+            if e.clip then e.clip:Hide() end
+        end
+    end
     if not border.pixelTex then return end
     for _, t in ipairs(border.pixelTex) do t:Hide() end
 end
@@ -1667,6 +1872,83 @@ local function pixelTick(border, anim, dt)
             end
         end
     end
+end
+
+-- DF_PIXEL, DECLARATIVE.
+--
+-- ☠ THIS IS NOT THE ORBIT WITH DIFFERENT ART, and that is the whole difficulty. A
+-- chasing pixel is a BAR that changes orientation at every corner — horizontal along
+-- the top and bottom, vertical up the sides — and a Translation cannot resize its
+-- target mid-flight. So the perimeter walk that carries DF Chase cannot carry this.
+--
+-- Instead each edge owns bars of its own fixed orientation, marching along it and
+-- clipped to it: a bar leaving one edge is clipped away while the next enters at the
+-- far end, which reads the same because every bar is identical. Spacing is seeded from
+-- the CUMULATIVE perimeter position, so bars stay evenly spaced across the corners and
+-- the lap time is unchanged.
+--
+-- ⚠ The one visible difference from the tick: the tick lets a bar overhang a corner
+-- (it is centre-anchored on the edge line), while a clipped bar is cut at the corner
+-- instead. On a bar the length of a pixel that is a couple of frames of travel.
+local function buildPixelAnims(border, anim)
+    local host = border._pixelHost
+    if not host then return false end
+    local w, h = border._knownW, border._knownH
+    if not (w and h) then return false end
+    w = w - 2 * (anim.inset or 0)
+    h = h - 2 * (anim.inset or 0)
+    if w <= 0 or h <= 0 then return false end
+    local N      = border._pixelN or 8
+    local len    = border._pixelLen or 6
+    local th     = border._pixelTh or 2
+    local period = border._pixelPeriod or PIXEL_BASE_PERIOD
+    local perimeter = 2 * (w + h)
+    local space = perimeter / N
+    if space <= 0 or period <= 0 then return false end
+    -- One spacing of travel per loop; a full lap therefore still takes `period`.
+    local dur = period / N
+    border._pixelDecl = border._pixelDecl or {}
+    local store = border._pixelDecl
+    local groups = border._declAnims or {}
+    local r, g, b, a = readColor(anim.color or ANIM_GOLD)
+    -- edgeStart = where this edge begins along the perimeter walk, so the bar spacing
+    -- carries across corners exactly as pixelTick's single modulo does.
+    local edges = {
+        { key = "left",   start = 0,         len = h, vert = true,  from = "BOTTOM", dx = 0,      dy = space,  sx = th,  sy = len, cp = "LEFT"   },
+        { key = "top",    start = h,         len = w, vert = false, from = "LEFT",   dx = space,  dy = 0,      sx = len, sy = th,  cp = "TOP"    },
+        { key = "right",  start = h + w,     len = h, vert = true,  from = "TOP",    dx = 0,      dy = -space, sx = th,  sy = len, cp = "RIGHT"  },
+        { key = "bottom", start = 2 * h + w, len = w, vert = false, from = "RIGHT",  dx = -space, dy = 0,      sx = len, sy = th,  cp = "BOTTOM" },
+    }
+    for _, ed in ipairs(edges) do
+        local e = ensureMarchEdge(store, ed.key, host)
+        e.clip:ClearAllPoints()
+        -- The clip straddles the edge LINE (bars are centre-anchored on it), and is
+        -- exactly one bar thick, so a bar on the line fits without being trimmed.
+        e.clip:SetSize(ed.vert and th or ed.len, ed.vert and ed.len or th)
+        e.clip:SetPoint("CENTER", host, ed.cp, 0, 0)
+        -- First bar at or before the edge start, then every `space` along it.
+        local first = ((-ed.start) % space) - space
+        local count = math.ceil(ed.len / space) + 2
+        for i = 1, count do
+            local at = first + (i - 1) * space
+            local q = marchQuad(e, i)
+            q:SetTexture(PIXEL_TEX)
+            q:SetVertexColor(r, g, b, a)
+            q:SetSize(ed.sx, ed.sy)
+            q:ClearAllPoints()
+            if ed.vert then
+                -- "left" measures UP from the bottom, "right" measures DOWN from the top.
+                q:SetPoint("CENTER", e.mover, ed.from, 0, (ed.from == "BOTTOM") and at or -at)
+            else
+                -- "top" measures RIGHT from the left, "bottom" measures LEFT from the right.
+                q:SetPoint("CENTER", e.mover, ed.from, (ed.from == "LEFT") and at or -at, 0)
+            end
+        end
+        for i = count + 1, #e.quads do e.quads[i]:Hide() end
+        playMarch(e, ed.dx, ed.dy, dur, groups)
+    end
+    border._declAnims = groups
+    return true
 end
 
 -- ===== DF_PROC (proc flare — DF-owned ProcGlow stand-in) =====
@@ -1820,6 +2102,62 @@ local function procTick(border, anim, dt)
     border._procStartElapsed = PROC_START_DURATION
     if s then s:SetAlpha(0) end
     t:SetAlpha(1)
+end
+
+-- DF_PROC, DECLARATIVE. The comment on stepProcFlipbook says the native FlipBook
+-- "won't tick inside a container-button subtree" — that was the same wrong reading that
+-- retired animation everywhere, and this is its replacement. A FlipBook animation is
+-- declarative, so it runs there; only the hand-stepping did not.
+--
+-- ★ SetAtlas, NOT SetTexture(info.file). A FlipBook with frame width/height 0 derives
+-- its grid from the region's own texture rect, which is what confines the walk to the
+-- atlas sub-rect instead of the whole sheet. This is LibCustomGlow's recipe on these
+-- exact Blizzard atlases, and it is why the manual texcoord maths is not needed here.
+--
+-- The intro burst is a second, NON-looping group: flipbook once, then alpha to 0, with
+-- SetToFinalAlpha so it stays gone. The loop's own fade-in is delayed by the intro
+-- length, which reproduces the tick's hand-off without a timeline in Lua.
+local function buildProcAnims(border, anim)
+    local t, s, host = border.procTex, border.procStartTex, border._procHost
+    if not (t and host) then return false end
+    local w = border._knownW
+    if not w then return false end
+    w = w - 2 * (anim.inset or 0)
+    if w <= 0 then return false end
+    if not border._procAtlas then return false end
+    -- Geometry is applied once here instead of per tick: every number is plain config.
+    t:SetAtlas(PROC_ATLAS)
+    local off = floor(w * PROC_LOOP_SPILL + 0.5)
+    t:ClearAllPoints()
+    t:SetPoint("TOPLEFT",     host, "TOPLEFT",     -off,  off)
+    t:SetPoint("BOTTOMRIGHT", host, "BOTTOMRIGHT",  off, -off)
+    local groups = border._declAnims or {}
+    local showIntro = (not anim.procStart) and s and border._procStartAtlas
+    if showIntro then
+        s:SetAtlas(PROC_START_ATLAS)
+        s:SetSize(w * PROC_BURST_SCALE, w * PROC_BURST_SCALE)
+        s:SetAlpha(1)
+        local ag = s:CreateAnimationGroup()
+        ag:SetToFinalAlpha(true)
+        local fb = ag:CreateAnimation("FlipBook")
+        fb:SetDuration(PROC_START_DURATION); fb:SetOrder(1)
+        fb:SetFlipBookRows(PROC_ROWS); fb:SetFlipBookColumns(PROC_COLS)
+        fb:SetFlipBookFrames(PROC_FRAMES)
+        fb:SetFlipBookFrameWidth(0); fb:SetFlipBookFrameHeight(0)
+        local out = ag:CreateAnimation("Alpha")
+        out:SetFromAlpha(1); out:SetToAlpha(0)
+        out:SetDuration(0.001); out:SetOrder(2)
+        ag:Play()
+        groups[#groups + 1] = ag
+        t:SetAlpha(0)
+        playAlphaOnce(t, 0, 1, PROC_START_DURATION, 0.001, groups)
+    else
+        if s then s:SetAlpha(0) end
+        t:SetAlpha(1)
+    end
+    playFlipBook(t, PROC_ROWS, PROC_COLS, PROC_FRAMES, 0, 0, border._procPeriod or 1, groups)
+    border._declAnims = groups
+    return true
 end
 
 -- ===== DF_FLASH (button-glow flash — DF-owned ButtonGlow stand-in) =====
@@ -2008,6 +2346,96 @@ local function flashTick(border, anim, dt)
     end
 end
 
+-- 22 ants frames in a 5-column sheet -> 5 rows. 48px frames in a 256px sheet, which is
+-- the same 48/256 UV step the tick walks by hand.
+local FLASH_ANTS_ROWS = 5
+local FLASH_ANTS_PX   = 48
+
+-- A one-shot alpha rise then fall that ends where it started. Local to DF Flash: it is
+-- the only effect whose intro needs a peak rather than a ramp.
+local function playAlphaOnceInOut(region, peak, rise, fall, groups)
+    local ag = region:CreateAnimationGroup()
+    ag:SetToFinalAlpha(true)
+    local up = ag:CreateAnimation("Alpha")
+    up:SetFromAlpha(0); up:SetToAlpha(peak)
+    up:SetDuration(rise); up:SetOrder(1)
+    local down = ag:CreateAnimation("Alpha")
+    down:SetFromAlpha(peak); down:SetToAlpha(0)
+    down:SetDuration(fall); down:SetOrder(2)
+    ag:Play()
+    groups[#groups + 1] = ag
+    return ag
+end
+
+-- DF_FLASH, DECLARATIVE.
+--
+-- ☠ THE INTRO IS SIMPLIFIED HERE, DELIBERATELY, AND THIS IS THE ONE EFFECT THAT IS NOT
+-- A FAITHFUL PORT. The tick's intro is a SIZE choreography — the outer glow collapses
+-- 2F->F while the inner expands F/2->F under a spark that grows and shrinks. Expressing
+-- that declaratively needs Scale animations, and Scale was built and tried on a
+-- container button child in August and did NOTHING while Alpha worked (pandemic FLASH,
+-- 2026-08-05). Shipping a size timeline that might silently not run would leave the
+-- outer glow parked at 2F and read as broken, so the sizes are set to their STEADY
+-- values at build time and the intro is played in alpha alone: the glows fade up, the
+-- spark peaks and goes, the ants crawl in behind it. The steady state — an outer glow
+-- at F under marching ants — is identical to the tick's, and that is what is on screen
+-- for all but the first fraction of a second.
+-- ⚠ Re-test Scale on a later build; if it works, the size timeline can come back here.
+local function buildFlashAnims(border, anim)
+    local outer, ants, host = border.flashOuter, border.flashAnts, border._flashHost
+    if not (outer and ants and host) then return false end
+    local w = border._knownW
+    if not w then return false end
+    w = w - 2 * (anim.inset or 0)
+    if w <= 0 then return false end
+    local F = w * FLASH_FRAME_SCALE
+    border._flashF = F
+    border._flashGeomW = w
+    border._flashSettled = true
+    local maxA = border._flashMaxA or 1
+    local spark, inner = border.flashSpark, border.flashInner
+    local innerOver, outerOver = border.flashInnerOver, border.flashOuterOver
+    -- Steady sizes, set once.
+    outer:SetSize(F, F)
+    if outerOver then outerOver:ClearAllPoints(); outerOver:SetAllPoints(outer) end
+    if inner then inner:SetSize(F, F) end
+    if innerOver then innerOver:ClearAllPoints(); innerOver:SetAllPoints(inner) end
+    if spark then spark:SetSize(F * 1.5, F * 1.5) end
+    ants:SetSize(F * 0.85, F * 0.85)
+    local groups = border._declAnims or {}
+    playFlipBook(ants, FLASH_ANTS_ROWS, FLASH_ANTS_COLS, FLASH_ANTS_FRAMES,
+                 FLASH_ANTS_PX, FLASH_ANTS_PX, border._flashPeriod or 0.5, groups)
+    local showIntro = not anim.procStart
+    if showIntro then
+        local d = FLASH_INTRO_DUR
+        -- Same proportions as the tick's timeline: glows land at 60%, the spark peaks
+        -- at 40% and is gone by 80%, the ants take over across the last 40%.
+        outer:SetAlpha(0)
+        playAlphaOnce(outer, 0, maxA, 0, d * 0.6, groups)
+        if outerOver then outerOver:SetAlpha(0) end
+        if inner then
+            inner:SetAlpha(0)
+            playAlphaOnceInOut(inner, maxA, d * 0.6, d * 0.4, groups)
+        end
+        if innerOver then innerOver:SetAlpha(0) end
+        if spark then
+            spark:SetAlpha(0)
+            playAlphaOnceInOut(spark, maxA, d * 0.4, d * 0.4, groups)
+        end
+        ants:SetAlpha(0)
+        playAlphaOnce(ants, 0, maxA, d * 0.6, d * 0.4, groups)
+    else
+        outer:SetAlpha(maxA)
+        ants:SetAlpha(maxA)
+        if outerOver then outerOver:SetAlpha(0) end
+        if inner then inner:SetAlpha(0) end
+        if innerOver then innerOver:SetAlpha(0) end
+        if spark then spark:SetAlpha(0) end
+    end
+    border._declAnims = groups
+    return true
+end
+
 -- ===== CUSTOM ONUPDATE TICKS =====
 -- Each tick function receives (border, anim, elapsed) and modulates the 4
 -- edge SetAlpha values. Period defaults to anim.frequency-derived; a
@@ -2036,6 +2464,57 @@ customTicks.BLINK = function(border, anim, elapsed)
     if o.right  then o.right:SetAlpha(on)  end
     if o.bottom then o.bottom:SetAlpha(on) end
     if o.left   then o.left:SetAlpha(on)   end
+end
+
+-- BLINK, DECLARATIVE. Four square waves, one per overlay edge. They are separate groups
+-- rather than one, because an animation drives the object its group was created on and
+-- these are four independent textures; started in the same frame with identical
+-- durations, they stay in step C-side.
+local function buildBlinkAnims(border, anim)
+    local o = border.animOverlay
+    if not o then return false end
+    local period = tickPeriod(anim, 1)
+    if not period or period <= 0 then return false end
+    local groups = border._declAnims or {}
+    local half = period * 0.5
+    local n = 0
+    for _, e in ipairs({ o.top, o.right, o.bottom, o.left }) do
+        if e then playStrobe(e, 1, 0, half, groups); n = n + 1 end
+    end
+    if n == 0 then return false end
+    border._declAnims = groups
+    return true
+end
+
+-- DF_PULSATE, DECLARATIVE.
+--
+-- ☠ IT ANIMATES THE BORDER'S CONTENT, NOT THE BORDER FRAME — and that difference is
+-- load-bearing, not tidiness. The tick drives the WRAPPER's alpha, which is also the
+-- carrier for the out-of-range fade, so it has to fold the fade in itself on every
+-- frame (SetAlphaFromBoolean against a possibly-secret inRange). A declarative group
+-- has no way to fold in a value that changes at runtime: an Alpha animation on the
+-- wrapper would simply overwrite the range fade, and an out-of-range frame would pulse
+-- back to full. Animating the edges and pieces instead leaves the wrapper's alpha free
+-- for the range system, and the two multiply — so the pulse and the fade compose
+-- instead of fighting, which is strictly better than what the tick manages.
+local function buildPulsateAnims(border, anim)
+    local rawFreq = (anim.frequency and anim.frequency > 0) and anim.frequency or 1
+    -- period = 2/freq, then half of it per direction — the tick's mapping exactly.
+    local half = (2 / rawFreq) * 0.5
+    local groups = border._declAnims or {}
+    local n = 0
+    local function add(region)
+        if region then playFade(region, 0.05, 1, half, groups); n = n + 1 end
+    end
+    add(border.top); add(border.bottom); add(border.left); add(border.right)
+    -- TEXTURE style paints 8 pieces (or a backdrop child) instead of the four edges.
+    if border.texPieces then
+        for _, p in pairs(border.texPieces) do add(p) end
+    end
+    if border.bd then add(border.bd) end
+    if n == 0 then return false end
+    border._declAnims = groups
+    return true
 end
 
 -- ===== STATIC SHAPE MODES =====
@@ -2134,6 +2613,9 @@ function Border:StopAnimation(border)
         return
     end
     unregisterAnimTick(border)
+    -- Declarative groups next: they are the other half of "this border is animating",
+    -- and unlike the driver they keep running on their own until stopped.
+    stopDeclAnims(border)
     -- Hide all overlay sets from prior animation passes. The cornerExtras
     -- field is from a previous-rev CORNERS_ONLY implementation; we keep
     -- the Hide-loop for backward compat on profiles where the field was
@@ -2242,12 +2724,12 @@ function Border:StartAnimation(border, spec)
     -- animation frozen until a real spec change forces a restart (the "move the
     -- frequency slider off 1 and back" symptom). When the driver is dead, fall
     -- through and restart instead of no-opping.
-    -- ⚠ A DECLARATIVE orbit counts as live too. It has no animRegistry entry by design
-    -- (nothing ticks it), so without _orbitAnims here the "driver is dead, restart" arm
+    -- ⚠ A DECLARATIVE effect counts as live too. It has no animRegistry entry by design
+    -- (nothing ticks it), so without _declAnims here the "driver is dead, restart" arm
     -- would fire on EVERY re-apply and rebuild its animation groups from scratch — on a
     -- container border that is also a tainted write into the button subtree.
     if border._animHash == newHash then
-        if not DRIVER_ANIMS[border.activeAnimation] or animRegistry[border] or border._orbitAnims then
+        if not DRIVER_ANIMS[border.activeAnimation] or animRegistry[border] or border._declAnims then
             return
         end
     end
@@ -2263,8 +2745,15 @@ function Border:StartAnimation(border, spec)
     --     the period changes how fast the phase advances but never makes the
     --     phase value jump — the fade is never clipped or restarted mid-cycle.
     if anim.type == "DF_PULSATE" and border.activeAnimation == "DF_PULSATE" then
-        local rawFreq = (anim.frequency and anim.frequency > 0) and anim.frequency or 1
-        border._dfPulsatePeriod = 2 / rawFreq
+        -- ⚠ A DECLARATIVE pulse cannot be retuned in place: its groups are frozen at
+        -- creation and reaching back in would be a tainted write to a button child. A
+        -- genuine speed change arrives as a container Rebuild instead (the animation
+        -- keys ride the border's struct signature), so the right move here is to leave
+        -- the running pulse alone rather than tear it down and fail to rebuild it.
+        if not (border._secretRect and border._declAnims) then
+            local rawFreq = (anim.frequency and anim.frequency > 0) and anim.frequency or 1
+            border._dfPulsatePeriod = 2 / rawFreq
+        end
         border._animHash = newHash
         return
     end
@@ -2284,6 +2773,11 @@ function Border:StartAnimation(border, spec)
     local tick = customTicks[anim.type]
     if tick then
         setupAnimOverlay(border, anim)
+        -- BLINK is the only customTick effect, and it has a declarative twin.
+        if border._secretRect and anim.type == "BLINK" and buildBlinkAnims(border, anim) then
+            border.activeAnimation = anim.type
+            return
+        end
         registerAnimTick(border, function(b, el)
             tick(b, anim, el)
         end)
@@ -2326,6 +2820,15 @@ function Border:StartAnimation(border, spec)
         border._dfDashR, border._dfDashG, border._dfDashB, border._dfDashA = r, g, b, a
         local rawFreq = anim.frequency or 0
         local marchSpeed = (rawFreq and rawFreq > 0) and (rawFreq * DF_DASH_SPEED) or 0
+        -- Container-hosted and actually marching: clip-and-translate instead of
+        -- redrawing every dash each frame. A STATIC dashed border needs no declarative
+        -- path — it is drawn once below and never written again.
+        if border._secretRect and marchSpeed > 0
+            and buildDashAnims(border, anim, border._dfDashTh, border._dfDashInset,
+                               r, g, b, a, marchSpeed) then
+            border.activeAnimation = anim.type
+            return
+        end
         if marchSpeed > 0 then
             -- Marching: OnUpdate advances the offset, reading colour/size from the
             -- fields so a live recolour is picked up next tick. elapsed persists
@@ -2347,6 +2850,16 @@ function Border:StartAnimation(border, spec)
     -- DF Dash). Taint-safe perimeter walk on the shared driver.
     if anim.type == "DF_PIXEL" then
         setupPixelParticles(border, anim)
+        if border._secretRect and buildPixelAnims(border, anim) then
+            -- setupPixelParticles above built and SHOWED the perimeter-walk pool. The
+            -- declarative build owns its own per-edge quads instead, so park the pool or
+            -- its bars sit on top of the moving ones, frozen at their seed positions.
+            if border.pixelTex then
+                for _, t in ipairs(border.pixelTex) do t:Hide() end
+            end
+            border.activeAnimation = anim.type
+            return
+        end
         registerAnimTick(border, function(b, el, dt)
             pixelTick(b, anim, dt)
         end)
@@ -2358,6 +2871,10 @@ function Border:StartAnimation(border, spec)
     -- flipbook on the shared driver, taint-safe on aura buttons.
     if anim.type == "DF_PROC" then
         setupProcGlow(border, anim)
+        if border._secretRect and buildProcAnims(border, anim) then
+            border.activeAnimation = anim.type
+            return
+        end
         registerAnimTick(border, function(b, el, dt)
             procTick(b, anim, dt)
         end)
@@ -2369,6 +2886,10 @@ function Border:StartAnimation(border, spec)
     -- halo that flashes on the shared driver, taint-safe on aura buttons.
     if anim.type == "DF_FLASH" then
         setupFlashGlow(border, anim)
+        if border._secretRect and buildFlashAnims(border, anim) then
+            border.activeAnimation = anim.type
+            return
+        end
         registerAnimTick(border, function(b, el, dt)
             flashTick(b, anim, dt)
         end)
@@ -2402,6 +2923,10 @@ function Border:StartAnimation(border, spec)
         -- path at the top of StartAnimation can change the pulse speed on the
         -- already-running driver without re-SetScript'ing.
         border._dfPulsatePeriod = 2 / rawFreq
+        if border._secretRect and buildPulsateAnims(border, anim) then
+            border.activeAnimation = anim.type
+            return
+        end
         -- Advance a PHASE accumulator in [0,1) by dt/period each frame rather
         -- than deriving phase from absolute elapsed.  Two consequences:
         --   * Changing the period (frequency) only changes how fast the phase

--- a/DandersFrames_Options/AuraDesigner/UI/Cards.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Cards.lua
@@ -2949,14 +2949,19 @@ local function AddGroupAppearanceSection(body, group, bodyWidth, by, cardKey)
     end)
 
     -- ── BORDER ── (the placed icon's control set; gradient degrades to solid on
-    -- container slots — same known casualty as placed indicators; LCG glow types
-    -- are excluded from the animation dropdown, mirror the placed border)
+    -- container slots — same known casualty as placed indicators. Animation
+    -- restored 2026-08-29 with the button-mode reopening: the group's style
+    -- table carries the BorderAnimation* keys, buildGroupBorderSpec feeds them
+    -- through the same builder as the placed indicators, and a key edit
+    -- rebuilds the group container — groupStyleStructSig folds
+    -- rawBorderAnimStructTok.)
     AddSection(L["Border"], "border", function(g)
         GUI:CreateBorderControls(g, proxy, "", {
             parent  = body,
             include = {
                 inset = true, offset = true, blendMode = true,
                 gradient = true, shadow = true, alpha = true,
+                animate = true,
             },
             fullUpdate    = refresh,
             lightUpdate   = refresh,

--- a/DandersFrames_Options/AuraDesigner/UI/Cards.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Cards.lua
@@ -2963,6 +2963,7 @@ local function AddGroupAppearanceSection(body, group, bodyWidth, by, cardKey)
                 gradient = true, shadow = true, alpha = true,
                 animate = true,
             },
+            animIntroInert = true,   -- pooled buttons never see the intro burst
             fullUpdate    = refresh,
             lightUpdate   = refresh,
             lightColors   = refresh,

--- a/DandersFrames_Options/AuraDesigner/UI/Groups.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Groups.lua
@@ -2633,9 +2633,13 @@ local function RefreshPreviewEffects()
     -- Every type skips hidden blocks (eye toggle, enabled == false) — same as pickWinner.
     if auraCfg.border and auraCfg.border.enabled ~= false and auraCfg.border.ShowBorder ~= false then
         local spec = DF.Border:BuildSpec(auraCfg.border, "")
-        spec.animation = nil   -- AD border animation retired on 12.1; the preview must match the
-                               -- live render (which strips it at the container chokepoint) so a
-                               -- stuck-on BorderAnimationType from an old profile doesn't animate here.
+        -- ANIMATION: kept, because the live frame-level border animates again (the
+        -- AuraContainer ANIMATION FILTER reopened OVERLAY mode, 2026-08-27) and a preview
+        -- that stripped it would show something the live render does not — the one thing
+        -- previews must never do. The overlay here is an editor-owned frame, not a slot
+        -- child, so it is a plain DF.Border with no restriction to worry about, and the
+        -- reset at the top of this refresh (`Apply { enabled = false }` -> StopAnimation)
+        -- is what stops a previously-animated preview when the effect is turned off.
         if not spec.color then spec.color = { r = 1, g = 1, b = 1, a = 1 } end
         spec.enabled = true
         if auraCfg.border.borderMode == "custom" then

--- a/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
@@ -586,12 +586,16 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
         -- Border (Stage 5.1c — unified controls via CreateBorderControls).
         -- Show / Thickness / Inset are the same widgets as before; the helper
         -- adds Style / Texture / Color / Gradient / Shadow / BlendMode /
-        -- Offset / Alpha on top.  Animation, classColor, roleColor, and the
-        -- colorByTime checkbox are deliberately omitted — animation isn't
-        -- wired through AD's expiring system yet, class/role don't fit aura
+        -- Offset / Alpha on top.  classColor, roleColor, and the colorByTime
+        -- checkbox are deliberately omitted — class/role don't fit aura
         -- indicators (the indicator's job is to show aura state, not unit
         -- identity), and AD's Expiring section already covers "colour by
         -- time remaining" implicitly through its own colour curve.
+        -- Animation RESTORED 2026-08-29 (button-mode reopening): the placed
+        -- indicator's container opts into the declarative DF border animations
+        -- (config.adBorderAnim + the AuraContainer ANIMATION FILTER), and an
+        -- animation-key edit rebuilds the container (rawBorderAnimStructTok —
+        -- the effect is creation-frozen on a restricted button).
         -- Text-only mode hides the icon texture, so the whole Border group is
         -- hidden (the runtime force-disables the border there too).
         if not proxy.hideIcon then
@@ -601,6 +605,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
+                    animate = true,
                 },
                 -- IMPORTANT: AD's per-aura proxy only triggers
                 -- RefreshLiveFramesThrottled + S.RefreshPreviewLightweight
@@ -758,7 +763,8 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
         end)
         -- Border (Stage 5.2 — unified controls via CreateBorderControls).
         -- Same full toolkit as the icon's base border: Style / Texture / Colour
-        -- / Gradient / Shadow / Blend / Offset / Alpha + Animation.  The
+        -- / Gradient / Shadow / Blend / Offset / Alpha + Animation (restored
+        -- 2026-08-29 with the button-mode reopening — see the icon card).  The
         -- square's expiring system tints the FILL (not the border), so the
         -- icon's expiring-border overrides are intentionally NOT added here.
         AddGroup(L["Border"], function(g)
@@ -767,6 +773,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
+                    animate = true,
                 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
@@ -925,16 +932,18 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
         end)
         -- Border (Stage 5.3 — unified controls via CreateBorderControls).
         -- Full toolkit (Style / Texture / Colour / Gradient / Shadow / Blend /
-        -- Inset / Alpha + Animation).  No offset (the bar has its own X/Y) and
-        -- no class/role (it's an aura bar, not unit identity).  The bar's
-        -- expiring tints the FILL via its colour curve, so the icon/square
-        -- expiring-border overrides are intentionally not added here.
+        -- Inset / Alpha + Animation, restored 2026-08-29 — see the icon card).
+        -- No offset (the bar has its own X/Y) and no class/role (it's an aura
+        -- bar, not unit identity).  The bar's expiring tints the FILL via its
+        -- colour curve, so the icon/square expiring-border overrides are
+        -- intentionally not added here.
         AddGroup(L["Border"], function(g)
             GUI:CreateBorderControls(g, proxy, "", {
                 parent  = parent,
                 include = {
                     inset = true, blendMode = true, gradient = true,
                     shadow = true, alpha = true,
+                    animate = true,
                 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,

--- a/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
@@ -1068,24 +1068,15 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     -- animation gone those profiles resolved to a border that drew nothing.
                     animate = true,
                 },
-                -- ☠ ONLY THE PORTED EFFECTS ARE OFFERED HERE. This border lives on a
-                -- container button subtree, where the shared OnUpdate driver is refused
-                -- once auras are secret — so an effect that still rides it would look
-                -- fine at the target dummy and freeze the moment you pulled, which is
-                -- the exact behaviour that got animation retired in the first place.
-                -- DF Chase runs as declarative Translation groups (Border.lua,
-                -- "DF_ORBIT, DECLARATIVE") and is confirmed animating in combat.
-                -- ★ DELETE A LINE FROM THIS SET AS EACH EFFECT IS PORTED. Rough order of
-                -- difficulty: BLINK (a hard on/off alpha pair) and DF_PROC (its 6x5 atlas
-                -- maps onto a native FlipBook) are close to direct; DF_PULSATE drives the
-                -- border WRAPPER's alpha, which also carries the out-of-range fade, so it
-                -- needs its own host; DF_DASH wants masked strips translating one pattern
-                -- cycle; DF_PIXEL walks BARS that change orientation at every corner and a
-                -- Translation cannot resize mid-flight, so it needs a real rethink.
-                animExcludeTypes = {
-                    DF_PULSATE = true, DF_DASH = true, BLINK = true,
-                    DF_PROC = true, DF_FLASH = true, DF_PIXEL = true,
-                },
+                -- ★ THE WHOLE SET IS OFFERED AGAIN. Every effect now has a declarative
+                -- twin that runs on a container button subtree, where the shared OnUpdate
+                -- driver is refused once auras are secret — see "DECLARATIVE EFFECTS" in
+                -- Frames/Border.lua. There was an animExcludeTypes filter here while only
+                -- DF Chase was ported; it is gone rather than emptied, because an empty
+                -- exclude set reads as "someone meant to restrict this and forgot".
+                -- ⚠ If a NEW effect type is ever added, give it a declarative twin or put
+                -- the filter back for it — on this surface an OnUpdate-only effect looks
+                -- correct at a target dummy and freezes on the pull.
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
                 lightColors   = RPL,

--- a/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
@@ -607,6 +607,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     gradient = true, shadow = true, alpha = true,
                     animate = true,
                 },
+                animIntroInert = true,   -- pooled buttons never see the intro burst
                 -- IMPORTANT: AD's per-aura proxy only triggers
                 -- RefreshLiveFramesThrottled + S.RefreshPreviewLightweight
                 -- on direct key assignment (proxy.X = v) via __newindex.
@@ -775,6 +776,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     gradient = true, shadow = true, alpha = true,
                     animate = true,
                 },
+                animIntroInert = true,   -- pooled buttons never see the intro burst
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
                 lightColors   = RPL,
@@ -945,6 +947,7 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     shadow = true, alpha = true,
                     animate = true,
                 },
+                animIntroInert = true,   -- pooled buttons never see the intro burst
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
                 lightColors   = RPL,

--- a/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
@@ -1056,6 +1056,17 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                 include = {
                     inset = true, offset = true, blendMode = true,
                     gradient = true, shadow = true, alpha = true,
+                    -- RESTORED 2026-08-27 (removed in the 12.1 retirement, 961d1e13).
+                    -- This border is the whole-frame presence ring, drawn on an
+                    -- OVERLAY-mode container — the one surface the AuraContainer
+                    -- ANIMATION FILTER reopens, because it is a single ring per frame.
+                    -- Every type the dropdown offers is in SAFE_OVERLAY_ANIM, so no
+                    -- animExcludeTypes filter is needed here.
+                    -- ⚠ The legacy style migration DEPENDS on this control existing:
+                    -- the old Dashed/Animated styles map onto Thickness 0 + DF Dash, and
+                    -- Corners onto Thickness 0 + Corners Only (see the note above) — with
+                    -- animation gone those profiles resolved to a border that drew nothing.
+                    animate = true,
                 },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,

--- a/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
+++ b/DandersFrames_Options/AuraDesigner/UI/Indicators.lua
@@ -1068,6 +1068,24 @@ local function BuildTypeContent(parent, typeKey, auraName, width, optProxy, yOff
                     -- animation gone those profiles resolved to a border that drew nothing.
                     animate = true,
                 },
+                -- ☠ ONLY THE PORTED EFFECTS ARE OFFERED HERE. This border lives on a
+                -- container button subtree, where the shared OnUpdate driver is refused
+                -- once auras are secret — so an effect that still rides it would look
+                -- fine at the target dummy and freeze the moment you pulled, which is
+                -- the exact behaviour that got animation retired in the first place.
+                -- DF Chase runs as declarative Translation groups (Border.lua,
+                -- "DF_ORBIT, DECLARATIVE") and is confirmed animating in combat.
+                -- ★ DELETE A LINE FROM THIS SET AS EACH EFFECT IS PORTED. Rough order of
+                -- difficulty: BLINK (a hard on/off alpha pair) and DF_PROC (its 6x5 atlas
+                -- maps onto a native FlipBook) are close to direct; DF_PULSATE drives the
+                -- border WRAPPER's alpha, which also carries the out-of-range fade, so it
+                -- needs its own host; DF_DASH wants masked strips translating one pattern
+                -- cycle; DF_PIXEL walks BARS that change orientation at every corner and a
+                -- Translation cannot resize mid-flight, so it needs a real rethink.
+                animExcludeTypes = {
+                    DF_PULSATE = true, DF_DASH = true, BLINK = true,
+                    DF_PROC = true, DF_FLASH = true, DF_PIXEL = true,
+                },
                 fullUpdate    = RPL,
                 lightUpdate   = RPL,
                 lightColors   = RPL,

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -2735,8 +2735,15 @@ function GUI:CreateAnimationControls(group, dbTable, animPrefix, opts)
     -- intro off for row-mode buttons (AuraContainer's ANIMATION FILTER), so this
     -- checkbox is permanently greyed there and the tooltip explains why instead
     -- of describing a burst the user will never see.
+    -- ☠ GREY DIRECTLY at build, not only via disableOn: the AD cards never run
+    -- the RefreshChildStates pass that applies disableOn predicates (the group
+    -- card's refreshStates comment documents this on purpose), so a
+    -- predicate-only grey renders enabled there — field-caught on the AD icon
+    -- card, 2026-08-29. disableOn stays as well, so a context that DOES apply
+    -- predicates cannot re-enable it.
     if opts.introInert then
         w.animationHideIntro.disableOn = function() return true end
+        w.animationHideIntro:SetEnabled(false)
         w.animationHideIntro.tooltip = L["Aura buttons never play the intro burst: the game engine shows and hides the pooled buttons itself, and the burst can only play when the buttons are first built - not when an aura appears. Buttons go straight to the settled loop, so there is nothing to switch off here. The frame-level border keeps its intro."]
     end
 

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -2728,6 +2728,17 @@ function GUI:CreateAnimationControls(group, dbTable, animPrefix, opts)
         dbTable, aKey("ProcStart"), fullUpdate), 30)
     w.animationHideIntro.hideOn = hideUnless({ DF_FLASH = 1, DF_PROC = 1 })
     w.animationHideIntro.tooltip = L["These effects open with a one-off burst before settling into their loop. Turn this on to skip the burst and go straight to the loop."]
+    -- introInert (aura-button border cards): the intro cannot fire on a pooled
+    -- container button — animation timelines advance while the button is hidden
+    -- and no OnShow script runs in the restricted subtree, so a build-time
+    -- one-shot is spent before the first aura ever shows. The runtime forces the
+    -- intro off for row-mode buttons (AuraContainer's ANIMATION FILTER), so this
+    -- checkbox is permanently greyed there and the tooltip explains why instead
+    -- of describing a burst the user will never see.
+    if opts.introInert then
+        w.animationHideIntro.disableOn = function() return true end
+        w.animationHideIntro.tooltip = L["Aura buttons never play the intro burst: the game engine shows and hides the pooled buttons itself, and the burst can only play when the buttons are first built - not when an aura appears. Buttons go straight to the settled loop, so there is nothing to switch off here. The frame-level border keeps its intro."]
+    end
 
     w.animationCornerLength = group:AddWidget(GUI:CreateSlider(parent, L["Corner Length"],
         2, 40, 1, dbTable, aKey("CornerLength"),
@@ -3026,6 +3037,9 @@ function GUI:CreateBorderControls(group, dbTable, prefix, opts)
             -- site (e.g. the Aura Designer border restricts to overlay-recoverable
             -- animation types). nil for every other caller → full type list.
             excludeTypes = opts.animExcludeTypes,
+            -- Aura-button border cards grey the intro checkbox — see introInert
+            -- in CreateAnimationControls. nil everywhere else.
+            introInert   = opts.animIntroInert,
             hideExtra    = hideOff,
             onTypeChange = function()
                 if refreshStates then refreshStates() end

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -2744,7 +2744,7 @@ function GUI:CreateAnimationControls(group, dbTable, animPrefix, opts)
     if opts.introInert then
         w.animationHideIntro.disableOn = function() return true end
         w.animationHideIntro:SetEnabled(false)
-        w.animationHideIntro.tooltip = L["Aura buttons never play the intro burst: the game engine shows and hides the pooled buttons itself, and the burst can only play when the buttons are first built - not when an aura appears. Buttons go straight to the settled loop, so there is nothing to switch off here. The frame-level border keeps its intro."]
+        w.animationHideIntro.tooltip = L["Aura icons can't play the intro flash, so the effect always starts on its loop. Only the frame-level border can show the intro."]
     end
 
     w.animationCornerLength = group:AddWidget(GUI:CreateSlider(parent, L["Corner Length"],

--- a/DandersFrames_Options/GUI/SettingsWidgets.lua
+++ b/DandersFrames_Options/GUI/SettingsWidgets.lua
@@ -2585,8 +2585,14 @@ function GUI:CreateAnimationControls(group, dbTable, animPrefix, opts)
     -- Inset / Offset apply to every non-NONE effect EXCEPT DF_PULSATE (which
     -- modulates the border's own edges and has no separate animRect).
     local hasPositioning = { CORNERS_ONLY=1, DF_DASH=1, BLINK=1, DF_ORBIT=1, DF_PROC=1, DF_FLASH=1, DF_PIXEL=1 }
-    -- Scale slider = sparkle size (DF Chase).
-    local hasScale     = { DF_ORBIT=1 }
+    -- Scale slider = how big the effect draws. Sparkle size on DF Chase; on DF Proc and
+    -- DF Flash it multiplies how far the glow reaches past the border. That reach cannot
+    -- be a constant: both are a square glow texture stretched over the host, its bright
+    -- band is a soft gradient baked into the art (no line to pin), and frames come in
+    -- every shape — the value that hugs a 125x60 frame is wrong on a tall one. The
+    -- per-axis geometry puts the band's midline on the frame edge; Scale is the one knob
+    -- that moves the band in or out from there.
+    local hasScale     = { DF_ORBIT=1, DF_PROC=1, DF_FLASH=1 }
     -- Length slider = bar length (DF Pixel's chasing bars).
     local hasLength    = { DF_PIXEL=1 }
     local cornersOnly  = { CORNERS_ONLY=1 }
@@ -2699,6 +2705,7 @@ function GUI:CreateAnimationControls(group, dbTable, animPrefix, opts)
         0.5, 3, 0.05, dbTable, aKey("Scale"),
         fullUpdate, lightUpdate, true), 55)
     w.animationScale.hideOn = hideUnless(hasScale)
+    w.animationScale.tooltip = L["How large the effect draws. On DF Chase, the size of each sparkle; on DF Proc and DF Flash, how far the glow reaches beyond the border."]
 
     w.animationInset = group:AddWidget(GUI:CreateSlider(parent, L["Animation Inset"],
         -50, 50, 1, dbTable, aKey("Inset"),


### PR DESCRIPTION
Against **stable** (the live line).

## What was lost, and the way back

The 12.1 secrecy work retired all eight DF border effects: they rode a shared per-frame OnUpdate driver writing into the aura-button subtree every tick, and that class of write is refused once auras are secret. The retirement was correct about the driver — and wrong about animation as such. A **declarative AnimationGroup, created and started inside the button's secure init and never touched again, runs engine-side straight through aura secrecy — in combat included.** That is the entire trick; the rest of this PR is porting every effect onto it.

## What this does

**All seven border effects return, on every aura surface.** First the frame-level border (an overlay-mode container slot), then the aura icons themselves: placed icon and square indicators, aura bars, and filter / debuff / layout group icons. Effects loop invisibly on the pooled buttons from creation, so when the engine shows a button for an aura, the animation is already running — presence-driven, with zero addon reads of aura state.

**Per-shape glow geometry + an Animation Scale slider.** The glow-band effects (DF Proc / DF Flash) take their shape from both frame axes rather than width alone, and Scale is the one knob that moves the band in or out — the value that hugs one frame shape is wrong on another, so it could never be a constant.

**The intro flash rule.** A pooled button can never play the intro burst: animation timelines advance while the button is hidden and no OnShow script runs in the restricted subtree, so a build-time one-shot is spent before the first aura shows. Rather than let it fire as noise across a row of icons on every container rebuild, the runtime forces it off for buttons and the GUI greys the Hide Intro Flash checkbox with a plain-language tooltip. The frame-level border keeps its intro and its live checkbox.

**Animation keys are structural.** The groups are creation-frozen on a restricted button, so every animation key change hands over fresh buttons via Rebuild — each family's structural signature folds a raw-config token that is **empty when no animation is configured**, so existing profiles sig byte-identically and nothing rebuilds on upgrade.

**A type allowlist guards imports.** Only DF-owned effect types animate; a stale or imported profile naming anything else renders a static border rather than erroring.

## Confirmed in game (Krathe)

Frame-border effects running in combat; all button surfaces (placed icons, squares, bars, groups) animating; animation edits applying live through the rebuild path; the greyed intro checkbox with its tooltip.

## Verification

`luac -p` clean on every changed file, `_ENV` global reads diffed against base (no drift), CRLF intact. Shipped files are functionally byte-identical to the tested tree; the only content held back is locally-kept debug tooling and the process comments that reference it.
